### PR TITLE
Improve command palette search and remove colon shortcut

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +66,18 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cassowary"
@@ -87,6 +125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +161,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossterm"
@@ -157,6 +213,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -215,6 +277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +300,7 @@ name = "dux"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "chrono",
  "crossterm 0.29.0",
  "home",
@@ -263,6 +336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,16 +360,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
 
 [[package]]
 name = "getrandom"
@@ -303,6 +431,17 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -381,6 +520,20 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
 
 [[package]]
 name = "indexmap"
@@ -513,6 +666,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,12 +688,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -569,10 +815,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "prettyplease"
@@ -592,6 +857,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -802,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +1146,20 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1066,6 +1363,12 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -1328,7 +1631,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7a1c0af6e5d8d1363f4994b7a091ccf963d8b694f7da5b0b9cceb82da2c0a6"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
+arboard = "3.4.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 crossterm = "0.29.0"
 home = "0.5.11"

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,6 @@ enum PromptState {
     Command {
         input: String,
         selected: usize,
-        direct: bool,
         searching: bool,
     },
     BrowseProjects {
@@ -337,20 +336,9 @@ impl App {
             self.prompt = PromptState::Command {
                 input: String::new(),
                 selected: 0,
-                direct: false,
                 searching: false,
             };
             self.set_info("Command palette opened.");
-            return Ok(false);
-        }
-        if key.code == KeyCode::Char(':') {
-            self.prompt = PromptState::Command {
-                input: String::new(),
-                selected: 0,
-                direct: true,
-                searching: false,
-            };
-            self.set_info("Command mode opened.");
             return Ok(false);
         }
         if key.code == KeyCode::Tab {
@@ -502,7 +490,6 @@ impl App {
         if let PromptState::Command {
             input,
             selected,
-            direct: _,
             searching,
         } = &mut self.prompt
         {
@@ -1459,7 +1446,6 @@ impl App {
                 ("a", "Agent"),
                 ("p", "Add"),
                 ("^P", "Palette"),
-                (":", "Cmd"),
                 ("d", "Provider"),
                 ("u", "Pull"),
                 ("[", "Sidebar"),
@@ -1469,7 +1455,6 @@ impl App {
             FocusPane::Center => &[
                 ("i", "Prompt"),
                 ("^P", "Palette"),
-                (":", "Cmd"),
                 ("Esc", "Close diff"),
                 ("Tab", "Next"),
                 ("[", "Sidebar"),
@@ -1480,7 +1465,6 @@ impl App {
                 ("j/k", "Move"),
                 ("Enter", "Diff"),
                 ("^P", "Palette"),
-                (":", "Cmd"),
                 ("Tab", "Next"),
                 ("[", "Sidebar"),
                 ("?", "Help"),
@@ -1547,7 +1531,6 @@ impl App {
                 &[
                     ("Tab", "Focus next pane"),
                     ("Ctrl-p", "Open command palette"),
-                    (":", "Open command mode"),
                     ("Ctrl-w", "Resize mode (h/l side, j/k split)"),
                     ("?", "Toggle help"),
                     ("q", "Quit"),
@@ -1612,7 +1595,6 @@ impl App {
             PromptState::Command {
                 input,
                 selected,
-                direct,
                 searching,
             } => {
                 self.render_dim_overlay(frame);
@@ -1625,7 +1607,7 @@ impl App {
                     commands
                         .iter()
                         .map(|command| {
-                            let mut spans = vec![
+                            let mut left_spans = vec![
                                 Span::styled(
                                     command.name.to_string(),
                                     Style::default()
@@ -1638,10 +1620,15 @@ impl App {
                                 ),
                             ];
                             if let Some(shortcut) = command.shortcut {
-                                spans.push(Span::raw("  "));
-                                spans.extend(self.theme.key_badge(shortcut, Color::Reset));
+                                let left_len: usize = left_spans.iter().map(|s| s.width()).sum();
+                                // +3 for badge brackets <k>, +2 for borders, +1 for right padding
+                                let badge_len = shortcut.len() + 3;
+                                let avail = popup.width as usize;
+                                let pad = avail.saturating_sub(left_len + badge_len + 3);
+                                left_spans.push(Span::raw(" ".repeat(pad.max(2))));
+                                left_spans.extend(self.theme.key_badge(shortcut, Color::Reset));
                             }
-                            ListItem::new(Line::from(spans))
+                            ListItem::new(Line::from(left_spans))
                         })
                         .collect::<Vec<_>>()
                 };
@@ -1653,8 +1640,6 @@ impl App {
                     .areas(popup);
                 let title = if *searching {
                     "Command Palette (searching)"
-                } else if *direct {
-                    "Command"
                 } else {
                     "Command Palette"
                 };
@@ -1676,8 +1661,6 @@ impl App {
                 }
                 let prompt_prefix = if *searching {
                     "/ "
-                } else if *direct {
-                    ":"
                 } else {
                     "> "
                 };
@@ -1921,7 +1904,7 @@ impl App {
     }
 
     fn execute_command(&mut self, command: String) -> Result<()> {
-        let command = command.trim().trim_start_matches(':');
+        let command = command.trim();
         match command {
             "new-agent" => self.create_agent_for_selected_project(),
             "provider" => self.cycle_selected_project_provider(),
@@ -2304,13 +2287,19 @@ fn browser_entries(dir: &Path) -> Vec<BrowserEntry> {
 }
 
 fn filtered_commands(input: &str) -> Vec<&'static CommandDef> {
-    let needle = input.trim().trim_start_matches(':').to_lowercase();
-    COMMANDS
-        .iter()
-        .filter(|command| {
-            needle.is_empty()
-                || command.name.contains(&needle)
-                || command.description.to_lowercase().contains(&needle)
-        })
-        .collect()
+    let needle = input.trim().to_lowercase();
+    if needle.is_empty() {
+        return COMMANDS.iter().collect();
+    }
+    let mut name_matches: Vec<&'static CommandDef> = Vec::new();
+    let mut desc_matches: Vec<&'static CommandDef> = Vec::new();
+    for command in COMMANDS.iter() {
+        if command.name.contains(&needle) {
+            name_matches.push(command);
+        } else if command.description.to_lowercase().contains(&needle) {
+            desc_matches.push(command);
+        }
+    }
+    name_matches.extend(desc_matches);
+    name_matches
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -201,6 +201,11 @@ const COMMANDS: &[CommandDef] = &[
         shortcut: Some("["),
     },
     CommandDef {
+        name: "copy-path",
+        description: "Copy the selected agent's worktree path",
+        shortcut: Some("y"),
+    },
+    CommandDef {
         name: "help",
         description: "Open the help overlay",
         shortcut: Some("?"),
@@ -419,6 +424,7 @@ impl App {
             KeyCode::Char('x') => self.delete_selected_session()?,
             KeyCode::Char('d') => self.cycle_selected_project_provider()?,
             KeyCode::Char('r') => self.reconnect_selected_session()?,
+            KeyCode::Char('y') => self.copy_selected_path()?,
             _ => {}
         }
         Ok(())
@@ -1918,6 +1924,7 @@ impl App {
                 };
                 Ok(())
             }
+            "copy-path" => self.copy_selected_path(),
             "toggle-sidebar" => {
                 self.left_collapsed = !self.left_collapsed;
                 Ok(())
@@ -1963,6 +1970,33 @@ impl App {
         match self.left_items().get(self.selected_left) {
             Some(LeftItem::Session(index)) => self.sessions.get(*index),
             _ => None,
+        }
+    }
+
+    fn copy_selected_path(&mut self) -> Result<()> {
+        let path = match self.left_items().get(self.selected_left) {
+            Some(LeftItem::Session(index)) => {
+                self.sessions.get(*index).map(|s| s.worktree_path.clone())
+            }
+            Some(LeftItem::Project(index)) => {
+                self.projects.get(*index).map(|p| p.path.clone())
+            }
+            None => None,
+        };
+        match path {
+            Some(p) => {
+                let mut clipboard = arboard::Clipboard::new()
+                    .map_err(|e| anyhow::anyhow!("Failed to access clipboard: {e}"))?;
+                clipboard
+                    .set_text(&p)
+                    .map_err(|e| anyhow::anyhow!("Failed to copy to clipboard: {e}"))?;
+                self.set_info(format!("Copied: {p}"));
+                Ok(())
+            }
+            None => {
+                self.set_error("No project or agent selected.");
+                Ok(())
+            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1269,7 +1269,7 @@ impl App {
             let mut state = ListState::default().with_selected(Some(self.selected_left));
             StatefulWidget::render(
                 List::new(items)
-                    .block(self.themed_block("P", focused))
+                    .block(self.themed_block("", focused))
                     .highlight_style(self.theme.selection_style()),
                 area,
                 frame.buffer_mut(),
@@ -1326,10 +1326,7 @@ impl App {
                 }
             })
             .collect::<Vec<_>>();
-        let title = format!(
-            "Projects ({})",
-            self.projects.len()
-        );
+        let title = format!("Projects ({})", self.projects.len());
         let mut state = ListState::default().with_selected(Some(self.selected_left));
         StatefulWidget::render(
             List::new(items)


### PR DESCRIPTION
## Summary
- Command palette search now prioritizes command name matches over description-only matches (e.g. searching "pro" ranks `provider` above `new-agent`)
- Key combo badges in the command list are right-aligned instead of inline
- Removed the redundant colon (`:`) keybinding and "direct command mode" — only `Ctrl-P` opens the palette now
- Cleaned up the `direct` field from `PromptState::Command` and all associated rendering branches

## Test plan
- [ ] Open command palette with `Ctrl-P`, search "pro" — `provider` should appear first
- [ ] Verify key combo badges are right-aligned in the command list
- [ ] Confirm `:` no longer opens command mode
- [ ] Check help overlay and hint bars no longer reference `:`