### PR TITLE
Remap keybindings and make footer hints context-aware

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1150,12 +1150,16 @@ impl App {
     }
 
     fn render(&self, frame: &mut Frame) {
+        let term_w = frame.area().width as usize;
+        let status_text_len = self.status.text().len() + 3; // " ● " prefix
+        let status_lines: u16 = if term_w > 0 && status_text_len > term_w { 2 } else { 1 };
+        let footer_h = 1 + status_lines; // 1 for hints + status lines
         let [header, body, footer] = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(1),
                 Constraint::Min(4),
-                Constraint::Length(3),
+                Constraint::Length(footer_h),
             ])
             .areas(frame.area());
         self.render_header(frame, header);
@@ -1491,9 +1495,30 @@ impl App {
                 ("q", "Quit"),
             ],
         };
+        let [hints_area, status_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .areas(area);
+        let max_w = hints_area.width as usize;
+        let ellipsis = "…";
+        let ellipsis_w = 1;
+
         let mut hint_spans: Vec<Span> = Vec::new();
         let bar_bg = self.theme.hint_bar_bg;
+        let mut used = 0usize;
         for (i, (key, desc)) in hints.iter().enumerate() {
+            // width of this hint: separator + <key> + space + desc
+            let sep = if i > 0 { 1 } else { 0 };
+            let hint_w = sep + key.len() + 2 + 1 + desc.len();
+            if used + hint_w > max_w {
+                if used + ellipsis_w <= max_w {
+                    hint_spans.push(Span::styled(
+                        ellipsis,
+                        Style::default().fg(self.theme.hint_desc_fg).bg(bar_bg),
+                    ));
+                }
+                break;
+            }
             if i > 0 {
                 hint_spans.push(Span::styled(" ", Style::default().bg(bar_bg)));
             }
@@ -1502,12 +1527,9 @@ impl App {
                 format!(" {desc}"),
                 Style::default().fg(self.theme.hint_desc_fg).bg(bar_bg),
             ));
+            used += hint_w;
         }
 
-        let [hints_area, status_area] = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(1), Constraint::Length(2)])
-            .areas(area);
         Paragraph::new(Line::from(hint_spans))
             .style(Style::default().bg(self.theme.hint_bar_bg))
             .render(hints_area, frame.buffer_mut());
@@ -1525,13 +1547,22 @@ impl App {
             StatusTone::Busy => self.theme.status_busy_bg,
             StatusTone::Error => self.theme.status_error_bg,
         };
+        let prefix = format!(" {dot} ");
+        let prefix_w = prefix.len();
+        let max_status_chars = (status_area.width as usize) * (status_area.height as usize);
+        let available = max_status_chars.saturating_sub(prefix_w);
+        let truncated = if status_text.len() > available && available > 1 {
+            format!("{}…", &status_text[..available - 1])
+        } else {
+            status_text
+        };
         let status_line = Line::from(vec![
             Span::styled(
-                format!(" {dot} "),
+                prefix,
                 Style::default().fg(dot_color).bg(status_bg),
             ),
             Span::styled(
-                status_text,
+                truncated,
                 Style::default().fg(msg_color).bg(status_bg),
             ),
         ]);

--- a/src/app.rs
+++ b/src/app.rs
@@ -158,7 +158,7 @@ const COMMANDS: &[CommandDef] = &[
     CommandDef {
         name: "new-agent",
         description: "Create a new agent for the selected project",
-        shortcut: Some("a"),
+        shortcut: Some("n"),
     },
     CommandDef {
         name: "provider",
@@ -188,7 +188,7 @@ const COMMANDS: &[CommandDef] = &[
     CommandDef {
         name: "add-project",
         description: "Open the project browser",
-        shortcut: Some("p"),
+        shortcut: Some("a"),
     },
     CommandDef {
         name: "add-project-manual",
@@ -409,17 +409,17 @@ impl App {
                 self.focus = FocusPane::Center;
                 self.reload_changed_files();
             }
-            KeyCode::Char('p') => {
+            KeyCode::Char('a') => {
                 self.open_project_browser()?;
             }
-            KeyCode::Char('P') => {
+            KeyCode::Char('A') => {
                 self.prompt = PromptState::AddProject {
                     path: String::new(),
                     name: String::new(),
                     field: PromptField::Path,
                 };
             }
-            KeyCode::Char('a') => self.create_agent_for_selected_project()?,
+            KeyCode::Char('n') => self.create_agent_for_selected_project()?,
             KeyCode::Char('u') => self.refresh_selected_project()?,
             KeyCode::Char('x') => self.delete_selected_session()?,
             KeyCode::Char('d') => self.cycle_selected_project_provider()?,
@@ -1443,33 +1443,50 @@ impl App {
     }
 
     fn render_footer(&self, frame: &mut Frame, area: Rect) {
+        let is_on_project = matches!(
+            self.left_items().get(self.selected_left),
+            Some(LeftItem::Project(_))
+        );
+        let left_project_hints: &[(&str, &str)] = &[
+            ("j/k", "Move"),
+            ("n", "New agent"),
+            ("a", "Add project"),
+            ("d", "Provider"),
+            ("u", "Pull"),
+            ("^P", "Palette"),
+            ("?", "Help"),
+            ("q", "Quit"),
+        ];
+        let left_session_hints: &[(&str, &str)] = &[
+            ("j/k", "Move"),
+            ("Enter", "Focus"),
+            ("r", "Reconnect"),
+            ("x", "Delete"),
+            ("^P", "Palette"),
+            ("?", "Help"),
+            ("q", "Quit"),
+        ];
         let hints: &[(&str, &str)] = match self.focus {
-            FocusPane::Left => &[
-                ("j/k", "Move"),
-                ("a", "Agent"),
-                ("p", "Add"),
-                ("^P", "Palette"),
-                ("d", "Provider"),
-                ("u", "Pull"),
-                ("[", "Sidebar"),
-                ("?", "Help"),
-                ("q", "Quit"),
-            ],
+            FocusPane::Left => {
+                if is_on_project {
+                    left_project_hints
+                } else {
+                    left_session_hints
+                }
+            }
             FocusPane::Center => &[
                 ("i", "Prompt"),
-                ("^P", "Palette"),
                 ("Esc", "Close diff"),
                 ("Tab", "Next"),
-                ("[", "Sidebar"),
+                ("^P", "Palette"),
                 ("?", "Help"),
                 ("q", "Quit"),
             ],
             FocusPane::Files => &[
                 ("j/k", "Move"),
                 ("Enter", "Diff"),
-                ("^P", "Palette"),
                 ("Tab", "Next"),
-                ("[", "Sidebar"),
+                ("^P", "Palette"),
                 ("?", "Help"),
                 ("q", "Quit"),
             ],
@@ -1533,27 +1550,28 @@ impl App {
                 "Global",
                 &[
                     ("Tab", "Focus next pane"),
-                    ("Ctrl-p", "Open command palette"),
-                    ("Ctrl-w", "Resize mode (h/l side, j/k split)"),
+                    ("^P", "Open command palette"),
+                    ("^W", "Resize mode (h/l side, j/k split)"),
+                    ("[", "Toggle sidebar"),
                     ("?", "Toggle help"),
                     ("q", "Quit"),
                 ],
             ),
             (
-                "Left pane",
+                "Projects pane",
                 &[
                     ("j/k", "Move through projects and sessions"),
-                    ("p", "Open project browser"),
-                    ("P", "Open manual path entry"),
-                    ("a", "Create worktree-backed agent session"),
+                    ("a", "Open project browser"),
+                    ("A", "Manual path entry"),
+                    ("n", "New agent session (creates worktree)"),
                     ("d", "Cycle default provider"),
                     ("u", "Refresh checkout (git pull --ff-only)"),
-                    ("r", "Reconnect detached ACP session"),
+                    ("r", "Reconnect detached session"),
                     ("x", "Delete selected session/worktree"),
                 ],
             ),
             (
-                "Center pane",
+                "Agent pane",
                 &[
                     ("i", "Start a prompt turn for the agent"),
                     ("Esc", "Close diff view"),
@@ -1562,6 +1580,12 @@ impl App {
             (
                 "Files pane",
                 &[("Enter", "Open selected file diff")],
+            ),
+            (
+                "Key notation",
+                &[
+                    ("^X", "Hold Ctrl and press X (e.g. ^P = Ctrl+P)"),
+                ],
             ),
         ];
         let mut lines: Vec<Line> = Vec::new();


### PR DESCRIPTION
## Summary
- Remaps `a` to add project (was `p`), `A` for manual path entry (was `P`), and `n` for new agent (was `a`) so that `a` intuitively means "add".
- Footer hint bar now changes based on whether a project or session is selected in the left pane, showing only relevant actions for each.
- Center and Files pane hints trimmed to the most important keys.
- Help screen uses consistent `^` notation for Ctrl keys, renames panes to "Projects" / "Agent", and adds a "Key notation" legend explaining modifier symbols.

## Test plan
- [ ] Verify `a` opens the project browser, `A` opens manual path entry, `n` creates a new agent
- [ ] Navigate between project and session rows in the left pane and confirm footer hints update accordingly
- [ ] Open help (`?`) and verify all listed bindings are accurate and the key notation section renders