### PR TITLE
Remove solid block indicator from focused panel titles

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2090,12 +2090,8 @@ impl App {
     }
 
     fn themed_block<'a>(&self, title: &'a str, focused: bool) -> Block<'a> {
-        let focus_indicator = if focused { " █" } else { "" };
         Block::default()
-            .title(Line::from(vec![
-                Span::styled(title, self.theme.title_style(focused)),
-                Span::styled(focus_indicator, Style::default().fg(self.theme.border_focused)),
-            ]))
+            .title(Line::from(Span::styled(title, self.theme.title_style(focused))))
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
             .border_style(self.theme.border_style(focused))


### PR DESCRIPTION
## Summary
- Removes the "█" solid block caret that appeared next to focused panel titles
- The border color change already indicates which panel is selected, making the caret redundant

## Test plan
- [ ] Run the app and navigate between panels to confirm only the border color changes on focus
- [ ] Verify no visual regression in panel title rendering