### PR TITLE
Fix provider swap not taking effect on exited sessions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1150,6 +1150,14 @@ impl App {
             project_config.default_provider = Some(next.as_str().to_string());
         }
         save_config(&self.paths.config_path, &self.config)?;
+        for session in self
+            .sessions
+            .iter_mut()
+            .filter(|s| s.project_id == project.id)
+        {
+            session.provider = next.clone();
+            self.session_store.upsert_session(session)?;
+        }
         self.set_info(format!(
             "Default provider for {} is now {}",
             project.name,


### PR DESCRIPTION
## Summary

- When cycling a project's provider with `d`, only the project-level config was updated — existing sessions kept their original provider value
- Relaunching an exited session with `r` would still use the stale provider from when the session was first created
- Now `cycle_selected_project_provider()` also updates and persists all sessions belonging to the project

## Test plan

- [ ] Create an agent with one provider (e.g. Codex), let it exit
- [ ] Hover over it in the projects panel and press `d` to swap provider
- [ ] Press `r` to relaunch — verify it launches with the new provider