### PR TITLE
Improve statusline messages with verbose, quoted context

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -427,7 +427,7 @@ impl App {
                     self.input_target = InputTarget::Agent;
                     self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                 } else {
-                    self.set_error("No active agent. Press r to restart or n to create.");
+                    self.set_error("No active agent. Press \"r\" to restart or \"n\" to create a new one.");
                 }
             }
             _ => {}
@@ -447,7 +447,7 @@ impl App {
                     self.input_target = InputTarget::Agent;
                     self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                 } else {
-                    self.set_error("No active agent. Press r to restart or n to create.");
+                    self.set_error("No active agent. Press \"r\" to restart or \"n\" to create a new one.");
                 }
             }
             KeyCode::Char('r') => {
@@ -959,7 +959,7 @@ impl App {
         logger::info(&format!("attempting to add project {}", path.display()));
         if !path.exists() || !git::is_git_repo(&path) {
             logger::error(&format!("add project rejected for {}", path.display()));
-            self.set_error(format!("{} is not a git repository.", path.display()));
+            self.set_error(format!("\"{}\" is not a git repository.", path.display()));
             return Ok(());
         }
         if self
@@ -967,7 +967,7 @@ impl App {
             .iter()
             .any(|project| Path::new(&project.path) == path.as_path())
         {
-            self.set_error(format!("{} is already registered.", path.display()));
+            self.set_error(format!("\"{}\" is already registered as a project.", path.display()));
             return Ok(());
         }
         let branch = git::current_branch(&path)?;
@@ -999,7 +999,7 @@ impl App {
             current_branch: branch,
         });
         logger::info(&format!("registered project {}", path.display()));
-        self.set_info(format!("Added project {display_name}"));
+        self.set_info(format!("Added project \"{}\" to workspace", display_name));
         Ok(())
     }
 
@@ -1014,7 +1014,10 @@ impl App {
         };
         logger::info(&format!("creating agent for project {}", project.path));
         self.create_agent_in_flight = true;
-        self.set_busy(format!("Creating worktree for {}...", project.name));
+        self.set_busy(format!(
+            "Creating worktree for project \"{}\"...",
+            project.name
+        ));
         let paths = self.paths.clone();
         let config = self.config.clone();
         let worker_tx = self.worker_tx.clone();
@@ -1065,7 +1068,11 @@ impl App {
             existing.current_branch =
                 git::current_branch(path).unwrap_or_else(|_| existing.current_branch.clone());
         }
-        self.set_info(format!("Refreshed {}: {}", project.name, output.trim()));
+        self.set_info(format!(
+            "Refreshed project \"{}\": {}",
+            project.name,
+            output.trim()
+        ));
         Ok(())
     }
 
@@ -1113,7 +1120,12 @@ impl App {
         self.session_store.delete_session(&session.id)?;
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
-        self.set_info(format!("Deleted {}", session.branch_name));
+        self.set_info(format!(
+            "Deleted {} agent from project \"{}\" with branch \"{}\"",
+            session.provider.as_str(),
+            project.name,
+            session.branch_name
+        ));
         Ok(())
     }
 
@@ -1151,7 +1163,7 @@ impl App {
             self.session_store.upsert_session(session)?;
         }
         self.set_info(format!(
-            "Default provider for {} is now {}",
+            "Default provider for project \"{}\" changed to \"{}\"",
             project.name,
             next.as_str()
         ));
@@ -1193,22 +1205,31 @@ impl App {
         save_config(&self.paths.config_path, &self.config)?;
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
-        self.set_info(format!("Deleted project {}", project.name));
+        self.set_info(format!(
+            "Deleted project \"{}\" and all its agents",
+            project.name
+        ));
         Ok(())
     }
 
     fn reconnect_selected_session(&mut self) -> Result<()> {
         let Some(session) = self.selected_session().cloned() else {
-            self.set_error("Select a stopped agent first.");
+            self.set_error("Select a stopped agent first to reconnect.");
             return Ok(());
         };
         logger::info(&format!("reconnecting session {}", session.id));
         if self.providers.contains_key(&session.id) {
-            self.set_info("Session is already connected.");
+            self.set_info(format!(
+                "Agent \"{}\" is already connected.",
+                session.branch_name
+            ));
             return Ok(());
         }
         if !Path::new(&session.worktree_path).exists() {
-            self.set_error("Worktree no longer exists. Delete and re-create the agent.");
+            self.set_error(format!(
+                "Worktree for agent \"{}\" no longer exists. Delete and re-create the agent.",
+                session.branch_name
+            ));
             return Ok(());
         }
         match self.spawn_pty_for_session(&session) {
@@ -1218,10 +1239,19 @@ impl App {
                 self.focus = FocusPane::Center;
                 self.center_mode = CenterMode::Agent;
                 self.input_target = InputTarget::Agent;
-                self.set_info(format!("Relaunched {}", session.branch_name));
+                let proj_name = self.project_name_for_session(&session);
+                self.set_info(format!(
+                    "Relaunched {} agent \"{}\" in project \"{}\"",
+                    session.provider.as_str(),
+                    session.branch_name,
+                    proj_name
+                ));
             }
             Err(err) => {
-                self.set_error(format!("Reconnect failed: {err}"));
+                self.set_error(format!(
+                    "Reconnect failed for agent \"{}\": {err}",
+                    session.branch_name
+                ));
             }
         }
         Ok(())
@@ -1267,7 +1297,13 @@ impl App {
                     self.focus = FocusPane::Center;
                     self.center_mode = CenterMode::Agent;
                     self.input_target = InputTarget::Agent;
-                    self.set_info(format!("Created {}", session.branch_name));
+                    let proj_name = self.project_name_for_session(&session);
+                    self.set_info(format!(
+                        "Created {} agent \"{}\" in project \"{}\"",
+                        session.provider.as_str(),
+                        session.branch_name,
+                        proj_name
+                    ));
                 }
                 WorkerEvent::CreateAgentFailed(message) => {
                     self.create_agent_in_flight = false;
@@ -1292,7 +1328,7 @@ impl App {
                 if exited.contains(&current.id) {
                     self.input_target = InputTarget::None;
                     self.focus = FocusPane::Left;
-                    self.set_info("Agent CLI exited. Press r to relaunch.");
+                    self.set_info("Agent CLI process has exited. Press \"r\" to relaunch.");
                 }
             }
         }
@@ -2603,7 +2639,7 @@ impl App {
             }
             "" => Ok(()),
             other => {
-                self.set_error(format!("Unknown command: {other}"));
+                self.set_error(format!("Unknown command: \"{other}\""));
                 Ok(())
             }
         }
@@ -2641,6 +2677,14 @@ impl App {
         }
     }
 
+    fn project_name_for_session(&self, session: &AgentSession) -> String {
+        self.projects
+            .iter()
+            .find(|p| p.id == session.project_id)
+            .map(|p| p.name.clone())
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
     fn copy_selected_path(&mut self) -> Result<()> {
         let path = match self.left_items().get(self.selected_left) {
             Some(LeftItem::Session(index)) => {
@@ -2656,11 +2700,11 @@ impl App {
                 clipboard
                     .set_text(&p)
                     .map_err(|e| anyhow::anyhow!("Failed to copy to clipboard: {e}"))?;
-                self.set_info(format!("Copied: {p}"));
+                self.set_info(format!("Copied path to clipboard: \"{p}\""));
                 Ok(())
             }
             None => {
-                self.set_error("No project or agent selected.");
+                self.set_error("No project or agent selected. Select one from the sidebar first.");
                 Ok(())
             }
         }
@@ -2730,7 +2774,7 @@ fn run_create_agent_job(
     term_size: (u16, u16),
 ) {
     let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-        "Creating worktree for {}...",
+        "Creating worktree for project \"{}\"...",
         project.name
     )));
     let repo_path = PathBuf::from(&project.path);


### PR DESCRIPTION
## Summary
- Makes all statusline messages more descriptive by including agent type (claude/codex), project name, and branch name where relevant
- Quotes all variable values (paths, names, commands) with double quotes for visual clarity
- Adds a `project_name_for_session` helper to resolve project names from session context
- Improves error messages with additional guidance (e.g. "Select one from the sidebar first")

## Test plan
- [ ] Create a new agent and verify the status shows provider, branch, and project name
- [ ] Delete an agent and verify the verbose delete message
- [ ] Cycle provider on a project and check the status message
- [ ] Trigger error states (no agent selected, missing worktree) and verify quoted output