### PR TITLE
Add session state legend to help overlay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2048,6 +2048,30 @@ impl App {
                 lines.push(Line::from(spans));
             }
         }
+        // Session state legend
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Session states",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )));
+        let session_states: &[(&str, Color, &str)] = &[
+            ("●", self.theme.session_active, "Active — agent is running"),
+            ("◐", self.theme.session_detached, "Detached — agent process disconnected"),
+            ("○", self.theme.session_exited, "Exited — agent has finished"),
+        ];
+        for (dot, color, desc) in session_states {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(*dot, Style::default().fg(*color)),
+                Span::raw("  "),
+                Span::styled(
+                    desc.to_string(),
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ),
+            ]));
+        }
         Paragraph::new(lines)
             .block(self.themed_overlay_block("Help"))
             .wrap(Wrap { trim: false })


### PR DESCRIPTION
## Summary
- Adds a "Session states" section to the help overlay (`?`) that explains the three circle indicators used in the Projects panel: active (●), detached (◐), and exited (○), each shown with its actual color and a short description.

## Test plan
- [ ] Open the app and press `?` to open the help overlay
- [ ] Verify the new "Session states" section appears at the bottom with the three colored circle indicators and their descriptions