### PR TITLE
Shrink default side pane widths for more center space

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -120,8 +120,8 @@ impl Default for LoggingConfig {
 impl Default for UiConfig {
     fn default() -> Self {
         Self {
-            left_width_pct: 20,
-            right_width_pct: 23,
+            left_width_pct: 17,
+            right_width_pct: 19,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reduces default left pane width from 20% to 17% and right pane width from 23% to 19%
- Gives roughly 15-17% more horizontal space to the center content area
- User-configured values in `config.toml` are unaffected