### PR TITLE
Auto-refresh changed files with syntax-highlighted diffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,17 @@ The current app provides:
   - PTY process early exit
 - If the UI appears frozen, verify the operation is on a worker path rather than the main event loop.
 
+## Git Command Safety
+
+When shelling out to git, **always ensure the command output is immune to user-specific git configuration**. User settings like `color.diff`, `diff.noprefix`, `status.branch`, `status.renames`, `core.quotePath`, and others can alter output in ways that break parsing.
+
+- **Prefer plumbing commands** (`cat-file`, `rev-parse`, `for-each-ref`) over porcelain when you need machine-readable output. Plumbing commands are guaranteed stable.
+- **Use `--porcelain`** for `git status`. Never use `--short` — it is affected by user config (`status.branch`, `status.relativePaths`, etc.).
+- **Use `--numstat`** for line-level diff statistics. It outputs tab-separated values unaffected by config.
+- **Override config with `-c`** when a porcelain/plumbing alternative doesn't exist (e.g., `git -c color.diff=false diff`).
+- **Imperative commands** that aren't parsed (`worktree add`, `branch -D`, `pull`) are fine as-is.
+- **Avoid shelling out to `git diff` for display** — the project computes diffs in-process using the `similar` crate and applies syntax highlighting with `syntect`. Use `git::file_at_head()` to get the base version and read the working copy from disk.
+
 ## Recommendations For Editing
 
 - Keep changes small and composable in `src/app.rs`; it is large enough that unrelated edits can conflict.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +343,8 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "similar",
+ "syntect",
  "tempfile",
  "toml",
  "uuid",
@@ -422,7 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
 
@@ -441,6 +452,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -853,6 +870,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1095,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1161,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1252,6 +1306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1363,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,7 +1399,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1329,6 +1416,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1488,6 +1586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1719,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ uuid = { version = "1.17.0", features = ["v4"] }
 portable-pty = "0.9"
 vt100 = "0.15"
 petname = { version = "2.0.2", default-features = false, features = ["default-rng", "default-words"] }
+similar = "2"
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -56,6 +57,7 @@ pub struct App {
     last_pty_size: (u16, u16),
     theme: Theme,
     tick_count: u64,
+    watched_worktree: Arc<Mutex<Option<PathBuf>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -86,7 +88,7 @@ impl FocusPane {
 #[derive(Clone, Debug)]
 enum CenterMode {
     Agent,
-    Diff(String),
+    Diff(Vec<Line<'static>>),
 }
 
 #[derive(Clone, Debug)]
@@ -155,6 +157,7 @@ enum WorkerEvent {
         pty_size: (u16, u16), // (rows, cols) the PTY was spawned with
     },
     CreateAgentFailed(String),
+    ChangedFilesReady(Vec<ChangedFile>),
 }
 
 #[derive(Clone, Copy)]
@@ -232,6 +235,7 @@ impl App {
         let projects = load_projects(&config);
         let sessions = session_store.load_sessions()?;
         let (worker_tx, worker_rx) = mpsc::channel();
+        let watched_worktree: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
         let mut app = Self {
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
@@ -258,6 +262,7 @@ impl App {
             last_pty_size: (0, 0),
             theme: Theme::default_dark(),
             tick_count: 0,
+            watched_worktree: Arc::clone(&watched_worktree),
         };
         app.restore_sessions();
         app.reload_changed_files();
@@ -265,6 +270,7 @@ impl App {
     }
 
     pub fn run(&mut self) -> Result<()> {
+        self.spawn_changed_files_poller();
         let mut terminal = ratatui::init();
         loop {
             self.drain_events();
@@ -1235,8 +1241,12 @@ impl App {
         let Some(file) = self.changed_files.get(self.selected_file) else {
             return Ok(());
         };
-        let diff = git::diff_for_file(Path::new(&session.worktree_path), &file.path)?;
-        self.center_mode = CenterMode::Diff(diff);
+        let output = crate::diff::diff_file(
+            Path::new(&session.worktree_path),
+            &file.path,
+            &self.theme,
+        )?;
+        self.center_mode = CenterMode::Diff(output.lines);
         self.focus = FocusPane::Center;
         Ok(())
     }
@@ -1272,6 +1282,12 @@ impl App {
                 WorkerEvent::CreateAgentFailed(message) => {
                     self.create_agent_in_flight = false;
                     self.set_error(message);
+                }
+                WorkerEvent::ChangedFilesReady(files) => {
+                    self.changed_files = files;
+                    if self.selected_file >= self.changed_files.len() {
+                        self.selected_file = self.changed_files.len().saturating_sub(1);
+                    }
                 }
             }
         }
@@ -1484,41 +1500,8 @@ impl App {
         };
         let focused = self.focus == FocusPane::Center;
         match &self.center_mode {
-            CenterMode::Diff(diff) => {
-                let styled_lines: Vec<Line> = if diff.trim().is_empty() {
-                    vec![Line::from("No diff for this file.")]
-                } else {
-                    diff.lines()
-                        .map(|line| {
-                            if line.starts_with("+++") || line.starts_with("---") {
-                                Line::from(Span::styled(
-                                    line.to_string(),
-                                    Style::default()
-                                        .fg(self.theme.diff_file_header)
-                                        .add_modifier(Modifier::BOLD),
-                                ))
-                            } else if line.starts_with("@@") {
-                                Line::from(Span::styled(
-                                    line.to_string(),
-                                    Style::default().fg(self.theme.diff_hunk),
-                                ))
-                            } else if line.starts_with('+') {
-                                Line::from(Span::styled(
-                                    line.to_string(),
-                                    Style::default().fg(self.theme.diff_add),
-                                ))
-                            } else if line.starts_with('-') {
-                                Line::from(Span::styled(
-                                    line.to_string(),
-                                    Style::default().fg(self.theme.diff_remove),
-                                ))
-                            } else {
-                                Line::from(line.to_string())
-                            }
-                        })
-                        .collect()
-                };
-                Paragraph::new(styled_lines)
+            CenterMode::Diff(diff_lines) => {
+                Paragraph::new(diff_lines.clone())
                     .block(self.themed_block(title, focused))
                     .wrap(Wrap { trim: false })
                     .render(area, frame.buffer_mut());
@@ -1744,24 +1727,46 @@ impl App {
     }
 
     fn render_files(&self, frame: &mut Frame, area: Rect) {
-        let width = area.width.saturating_sub(6) as usize;
+        let inner_width = area.width.saturating_sub(2) as usize; // minus borders
         let items = self
             .changed_files
             .iter()
             .enumerate()
             .map(|(index, file)| {
+                // Build the right-aligned stats string, e.g. "+12 -3".
+                let stats = format_line_stats(file.additions, file.deletions);
+                let stats_width = stats.iter().map(|s| s.width()).sum::<usize>();
+
+                // Status prefix takes 3 chars ("M  ").
+                let prefix_width = 3;
+                // Leave 1 char gap between path and stats.
+                let path_budget = inner_width
+                    .saturating_sub(prefix_width)
+                    .saturating_sub(stats_width)
+                    .saturating_sub(1);
+
                 let path = if index == self.selected_file {
                     file.path.clone()
                 } else {
-                    git::ellipsize_middle(&file.path, width.max(10))
+                    git::ellipsize_middle(&file.path, path_budget.max(10))
                 };
-                ListItem::new(Line::from(vec![
+
+                let path_display_width = path.chars().count();
+                let padding = inner_width
+                    .saturating_sub(prefix_width)
+                    .saturating_sub(path_display_width)
+                    .saturating_sub(stats_width);
+
+                let mut spans = vec![
                     Span::styled(
                         format!("{:>2} ", file.status),
                         Style::default().fg(self.theme.file_status_fg),
                     ),
                     Span::raw(path),
-                ]))
+                    Span::raw(" ".repeat(padding)),
+                ];
+                spans.extend(stats);
+                ListItem::new(Line::from(spans))
             })
             .collect::<Vec<_>>();
         let focused = self.focus == FocusPane::Files;
@@ -2667,13 +2672,35 @@ impl App {
     }
 
     fn reload_changed_files(&mut self) {
-        self.changed_files = self
+        let worktree = self
             .selected_session()
-            .and_then(|session| git::changed_files(Path::new(&session.worktree_path)).ok())
+            .map(|s| PathBuf::from(&s.worktree_path));
+        // Keep the background poller in sync with the currently selected session.
+        if let Ok(mut guard) = self.watched_worktree.lock() {
+            *guard = worktree.clone();
+        }
+        self.changed_files = worktree
+            .and_then(|p| git::changed_files(&p).ok())
             .unwrap_or_default();
         if self.selected_file >= self.changed_files.len() {
             self.selected_file = self.changed_files.len().saturating_sub(1);
         }
+    }
+
+    fn spawn_changed_files_poller(&self) {
+        let tx = self.worker_tx.clone();
+        let watched = Arc::clone(&self.watched_worktree);
+        thread::spawn(move || loop {
+            thread::sleep(Duration::from_secs(2));
+            let path = watched.lock().ok().and_then(|guard| guard.clone());
+            if let Some(worktree_path) = path {
+                if let Ok(files) = git::changed_files(&worktree_path) {
+                    if tx.send(WorkerEvent::ChangedFilesReady(files)).is_err() {
+                        break; // receiver dropped, app is shutting down
+                    }
+                }
+            }
+        });
     }
 
     fn mark_session_status(&mut self, session_id: &str, status: SessionStatus) {
@@ -2806,6 +2833,31 @@ fn run_create_agent_job(
     };
     logger::info(&format!("PTY session started for {}", session.id));
     let _ = worker_tx.send(WorkerEvent::CreateAgentReady { session, client, pty_size: (rows, cols) });
+}
+
+/// Format additions/deletions as right-aligned colored spans.
+/// Returns an empty vec when both counts are zero.
+fn format_line_stats(additions: usize, deletions: usize) -> Vec<Span<'static>> {
+    if additions == 0 && deletions == 0 {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    if additions > 0 {
+        spans.push(Span::styled(
+            format!("+{additions}"),
+            Style::default().fg(Color::Green),
+        ));
+    }
+    if additions > 0 && deletions > 0 {
+        spans.push(Span::raw(" "));
+    }
+    if deletions > 0 {
+        spans.push(Span::styled(
+            format!("-{deletions}"),
+            Style::default().fg(Color::Red),
+        ));
+    }
+    spans
 }
 
 fn load_projects(config: &Config) -> Vec<Project> {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use ratatui::prelude::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use similar::{ChangeTag, TextDiff};
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{
+    Color as SynColor, FontStyle, Style as SynStyle, ThemeSet,
+};
+use syntect::parsing::SyntaxSet;
+
+use crate::theme::Theme as AppTheme;
+
+/// Pre-rendered diff ready for display.
+pub struct DiffOutput {
+    pub lines: Vec<Line<'static>>,
+}
+
+/// Compute a syntax-highlighted, unified diff for a single file.
+///
+/// `worktree_path` is the root of the git worktree and `rel_path` is the
+/// file path relative to it (as reported by `git status --porcelain`).
+pub fn diff_file(
+    worktree_path: &Path,
+    rel_path: &str,
+    theme: &AppTheme,
+) -> Result<DiffOutput> {
+    let old_text = crate::git::file_at_head(worktree_path, rel_path)?
+        .unwrap_or_default();
+    let abs_path = worktree_path.join(rel_path);
+    let new_text = fs::read_to_string(&abs_path).unwrap_or_default();
+
+    if old_text == new_text {
+        return Ok(DiffOutput {
+            lines: vec![Line::from("No changes.")],
+        });
+    }
+
+    let syntax_set = SyntaxSet::load_defaults_newlines();
+    let theme_set = ThemeSet::load_defaults();
+    let syn_theme = &theme_set.themes["base16-ocean.dark"];
+
+    let syntax = syntax_set
+        .find_syntax_by_extension(
+            Path::new(rel_path)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or(""),
+        )
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+
+    let text_diff = TextDiff::from_lines(&old_text, &new_text);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // File header.
+    lines.push(Line::from(Span::styled(
+        format!("--- a/{rel_path}"),
+        Style::default()
+            .fg(theme.diff_file_header)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("+++ b/{rel_path}"),
+        Style::default()
+            .fg(theme.diff_file_header)
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    for hunk in text_diff.unified_diff().context_radius(3).iter_hunks() {
+        // Hunk header (@@ ... @@).
+        lines.push(Line::from(Span::styled(
+            hunk.header().to_string(),
+            Style::default().fg(theme.diff_hunk),
+        )));
+
+        // We maintain two separate highlighters so that removed lines are
+        // highlighted in the context of the old file and added/context lines
+        // in the context of the new file. This avoids broken highlighting
+        // when a change spans a multi-line construct.
+        let mut hl_old = HighlightLines::new(syntax, syn_theme);
+        let mut hl_new = HighlightLines::new(syntax, syn_theme);
+
+        for change in hunk.iter_changes() {
+            let tag = change.tag();
+            let text = change.value();
+
+            let (prefix, base_fg, bg, highlighter) = match tag {
+                ChangeTag::Delete => ("-", theme.diff_remove, Some(Color::Rgb(60, 20, 20)), &mut hl_old),
+                ChangeTag::Insert => ("+", theme.diff_add, Some(Color::Rgb(20, 50, 20)), &mut hl_new),
+                ChangeTag::Equal => (" ", Color::Reset, None, &mut hl_new),
+            };
+
+            // Attempt syntax highlighting; fall back to plain coloring.
+            let content = text.trim_end_matches('\n');
+            let spans = match highlighter.highlight_line(content, &syntax_set) {
+                Ok(ranges) if tag == ChangeTag::Equal => {
+                    // Context lines: full syntax colors, no background tint.
+                    let mut out = vec![Span::styled(
+                        prefix.to_string(),
+                        Style::default().fg(base_fg),
+                    )];
+                    out.extend(ranges.into_iter().map(|(s, t)| {
+                        Span::styled(t.to_string(), syntect_to_ratatui(s))
+                    }));
+                    out
+                }
+                Ok(ranges) => {
+                    // Added/removed lines: syntax colors + tinted background.
+                    let mut out = vec![Span::styled(
+                        prefix.to_string(),
+                        Style::default().fg(base_fg).bg(bg.unwrap_or(Color::Reset)),
+                    )];
+                    out.extend(ranges.into_iter().map(|(s, t)| {
+                        let mut style = syntect_to_ratatui(s);
+                        if let Some(bg_color) = bg {
+                            style = style.bg(bg_color);
+                        }
+                        Span::styled(t.to_string(), style)
+                    }));
+                    out
+                }
+                Err(_) => {
+                    // Fallback: no syntax highlighting.
+                    vec![Span::styled(
+                        format!("{prefix}{content}"),
+                        Style::default().fg(base_fg).bg(bg.unwrap_or(Color::Reset)),
+                    )]
+                }
+            };
+            lines.push(Line::from(spans));
+        }
+    }
+
+    if lines.len() <= 2 {
+        // Only headers, no actual hunks (e.g. binary file or mode change).
+        lines.push(Line::from("No text diff available."));
+    }
+
+    Ok(DiffOutput { lines })
+}
+
+/// Convert a syntect `Style` to a ratatui `Style`.
+fn syntect_to_ratatui(style: SynStyle) -> Style {
+    let fg = syntect_color(style.foreground);
+    let mut ratatui_style = Style::default();
+    if let Some(c) = fg {
+        ratatui_style = ratatui_style.fg(c);
+    }
+    if style.font_style.contains(FontStyle::BOLD) {
+        ratatui_style = ratatui_style.add_modifier(Modifier::BOLD);
+    }
+    if style.font_style.contains(FontStyle::ITALIC) {
+        ratatui_style = ratatui_style.add_modifier(Modifier::ITALIC);
+    }
+    if style.font_style.contains(FontStyle::UNDERLINE) {
+        ratatui_style = ratatui_style.add_modifier(Modifier::UNDERLINED);
+    }
+    ratatui_style
+}
+
+/// Convert a syntect RGBA color to a ratatui `Color`, ignoring fully
+/// transparent colors (which syntect uses to mean "inherit").
+fn syntect_color(c: SynColor) -> Option<Color> {
+    if c.a == 0 {
+        None
+    } else {
+        Some(Color::Rgb(c.r, c.g, c.b))
+    }
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -143,13 +144,11 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path, branch_name: &str
 }
 
 pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {
+    let wt = worktree_path.to_string_lossy();
+
+    // 1. Get file statuses via porcelain (config-immune).
     let output = Command::new("git")
-        .args([
-            "-C",
-            worktree_path.to_string_lossy().as_ref(),
-            "status",
-            "--short",
-        ])
+        .args(["-C", wt.as_ref(), "status", "--porcelain"])
         .output()?;
     if !output.status.success() {
         return Err(anyhow!(
@@ -164,28 +163,61 @@ pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {
         }
         let status = line[..2].trim().to_string();
         let path = line[3..].to_string();
-        files.push(ChangedFile { status, path });
+        files.push(ChangedFile {
+            status,
+            path,
+            additions: 0,
+            deletions: 0,
+        });
     }
+
+    // 2. Get line-level stats via diff --numstat (plumbing-style output).
+    if let Ok(ns) = Command::new("git")
+        .args(["-C", wt.as_ref(), "diff", "--numstat"])
+        .output()
+    {
+        if ns.status.success() {
+            let text = String::from_utf8_lossy(&ns.stdout);
+            let stats: HashMap<String, (usize, usize)> = text
+                .lines()
+                .filter_map(|line| {
+                    let mut parts = line.split('\t');
+                    let add = parts.next()?.parse::<usize>().ok()?;
+                    let del = parts.next()?.parse::<usize>().ok()?;
+                    let path = parts.next()?.to_string();
+                    Some((path, (add, del)))
+                })
+                .collect();
+            for file in &mut files {
+                if let Some(&(a, d)) = stats.get(&file.path) {
+                    file.additions = a;
+                    file.deletions = d;
+                }
+            }
+        }
+    }
+
     Ok(files)
 }
 
-pub fn diff_for_file(worktree_path: &Path, path: &str) -> Result<String> {
+/// Return the contents of a file as it exists at HEAD, or `None` for new
+/// (untracked) files. Uses the plumbing command `cat-file` which is immune
+/// to user configuration.
+pub fn file_at_head(worktree_path: &Path, path: &str) -> Result<Option<String>> {
     let output = Command::new("git")
         .args([
             "-C",
             worktree_path.to_string_lossy().as_ref(),
-            "diff",
-            "--",
-            path,
+            "cat-file",
+            "-p",
+            &format!("HEAD:{path}"),
         ])
         .output()?;
     if !output.status.success() {
-        return Err(anyhow!(
-            "git diff failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+        // File doesn't exist at HEAD (new/untracked file).
+        return Ok(None);
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
 }
 
 pub fn ellipsize_middle(input: &str, max_width: usize) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod config;
+mod diff;
 mod git;
 mod logger;
 mod model;

--- a/src/model.rs
+++ b/src/model.rs
@@ -74,4 +74,6 @@ pub struct AgentSession {
 pub struct ChangedFile {
     pub status: String,
     pub path: String,
+    pub additions: usize,
+    pub deletions: usize,
 }


### PR DESCRIPTION
## Summary

- The changed files panel now auto-refreshes every 2 seconds via a background polling thread, so file edits by agents are detected immediately without user interaction.
- Diffs are computed in-process using `similar` and syntax-highlighted with `syntect`, replacing the previous `git diff` shell-out. This eliminates sensitivity to user gitconfig settings.
- Git commands that parse output now use porcelain/plumbing formats (`--porcelain`, `cat-file`, `--numstat`) to avoid breakage from user configuration.
- The file list shows per-file `+N -M` line counts right-aligned in green/red.
- Added a "Git Command Safety" section to AGENTS.md documenting these conventions.

## Test plan

- [ ] Verify changed files panel updates automatically when an agent edits files
- [ ] Verify diff view shows syntax-highlighted code with green/red background tints
- [ ] Verify file list shows +/- line counts aligned to the right
- [ ] Verify untracked (new) files show no +/- counts
- [ ] Confirm no UI jank from the background polling thread