### PR TITLE
Migrate project IDs to UUIDs, fix TOML escaping, and harden path safety

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,7 +56,8 @@ pub struct App {
     last_pty_size: (u16, u16),
     theme: Theme,
     tick_count: u64,
-    collapsed_projects: HashSet<i64>,
+    collapsed_projects: HashSet<String>,
+    left_items_cache: Vec<LeftItem>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -142,7 +143,7 @@ enum InputTarget {
     Agent,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 enum LeftItem {
     Project(usize),
     Session(usize),
@@ -265,8 +266,10 @@ impl App {
             theme: Theme::default_dark(),
             tick_count: 0,
             collapsed_projects: HashSet::new(),
+            left_items_cache: Vec::new(),
         };
         app.restore_sessions();
+        app.rebuild_left_items();
         app.reload_changed_files();
         Ok(app)
     }
@@ -437,7 +440,9 @@ impl App {
                     self.input_target = InputTarget::Agent;
                     self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                 } else {
-                    self.set_error("No active agent. Press \"r\" to restart or \"n\" to create a new one.");
+                    self.set_error(
+                        "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
+                    );
                 }
             }
             _ => {}
@@ -457,7 +462,9 @@ impl App {
                     self.input_target = InputTarget::Agent;
                     self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                 } else {
-                    self.set_error("No active agent. Press \"r\" to restart or \"n\" to create a new one.");
+                    self.set_error(
+                        "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
+                    );
                 }
             }
             KeyCode::Char('r') => {
@@ -677,8 +684,7 @@ impl App {
                             *selected = 0;
                             filter.clear();
                         } else {
-                            error_msg =
-                                Some(format!("{} is not a directory.", path_input.trim()));
+                            error_msg = Some(format!("{} is not a directory.", path_input.trim()));
                         }
                         *editing_path = false;
                         path_input.clear();
@@ -837,7 +843,11 @@ impl App {
         {
             match key.code {
                 KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::Char('h') | KeyCode::Char('l') => {
+                KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Tab
+                | KeyCode::Char('h')
+                | KeyCode::Char('l') => {
                     *confirm_selected = !*confirm_selected;
                 }
                 KeyCode::Enter => {
@@ -859,7 +869,11 @@ impl App {
         {
             match key.code {
                 KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::Char('h') | KeyCode::Char('l') => {
+                KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Tab
+                | KeyCode::Char('h')
+                | KeyCode::Char('l') => {
                     *confirm_selected = !*confirm_selected;
                 }
                 KeyCode::Enter => {
@@ -965,7 +979,9 @@ impl App {
     }
 
     fn add_project(&mut self, raw_path: String, name: String) -> Result<()> {
-        let path = PathBuf::from(raw_path.trim());
+        let path = PathBuf::from(raw_path.trim())
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(raw_path.trim()));
         logger::info(&format!("attempting to add project {}", path.display()));
         if !path.exists() || !git::is_git_repo(&path) {
             logger::error(&format!("add project rejected for {}", path.display()));
@@ -977,7 +993,10 @@ impl App {
             .iter()
             .any(|project| Path::new(&project.path) == path.as_path())
         {
-            self.set_error(format!("\"{}\" is already registered as a project.", path.display()));
+            self.set_error(format!(
+                "\"{}\" is already registered as a project.",
+                path.display()
+            ));
             return Ok(());
         }
         let branch = git::current_branch(&path)?;
@@ -989,25 +1008,22 @@ impl App {
         } else {
             name.trim().to_string()
         };
+        let project_id = Uuid::new_v4().to_string();
         self.config.projects.push(ProjectConfig {
+            id: project_id.clone(),
             path: path.to_string_lossy().to_string(),
             name: Some(display_name.clone()),
             default_provider: None,
         });
         save_config(&self.paths.config_path, &self.config)?;
         self.projects.push(Project {
-            id: self
-                .projects
-                .iter()
-                .map(|project| project.id)
-                .max()
-                .unwrap_or_default()
-                + 1,
+            id: project_id,
             name: display_name.clone(),
             path: path.to_string_lossy().to_string(),
             default_provider: self.config.default_provider(),
             current_branch: branch,
         });
+        self.rebuild_left_items();
         logger::info(&format!("registered project {}", path.display()));
         self.set_info(format!("Added project \"{}\" to workspace", display_name));
         Ok(())
@@ -1100,12 +1116,7 @@ impl App {
     }
 
     fn do_delete_session(&mut self, session_id: &str) -> Result<()> {
-        let Some(session) = self
-            .sessions
-            .iter()
-            .find(|s| s.id == session_id)
-            .cloned()
-        else {
+        let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
             return Ok(());
         };
         logger::info(&format!(
@@ -1128,6 +1139,7 @@ impl App {
         self.providers.remove(&session.id);
         self.sessions.retain(|candidate| candidate.id != session.id);
         self.session_store.delete_session(&session.id)?;
+        self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
         self.set_info(format!(
@@ -1172,10 +1184,7 @@ impl App {
             session.provider = next.clone();
             self.session_store.upsert_session(session)?;
         }
-        self.set_info(format!(
-            "Changed CLI agent to \"{}\"",
-            next.as_str()
-        ));
+        self.set_info(format!("Changed CLI agent to \"{}\"", next.as_str()));
         Ok(())
     }
 
@@ -1212,6 +1221,7 @@ impl App {
             .projects
             .retain(|candidate| Path::new(&candidate.path) != Path::new(&project.path));
         save_config(&self.paths.config_path, &self.config)?;
+        self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
         self.set_info(format!(
@@ -1284,7 +1294,11 @@ impl App {
         while let Ok(event) = self.worker_rx.try_recv() {
             match event {
                 WorkerEvent::CreateAgentProgress(message) => self.set_busy(message),
-                WorkerEvent::CreateAgentReady { session, client, pty_size } => {
+                WorkerEvent::CreateAgentReady {
+                    session,
+                    client,
+                    pty_size,
+                } => {
                     self.create_agent_in_flight = false;
                     self.last_pty_size = pty_size;
                     if let Err(err) = self.session_store.upsert_session(&session) {
@@ -1297,6 +1311,7 @@ impl App {
                     }
                     self.providers.insert(session.id.clone(), client);
                     self.sessions.insert(0, session.clone());
+                    self.rebuild_left_items();
                     self.selected_left = self
                         .left_items()
                         .iter()
@@ -1346,7 +1361,11 @@ impl App {
     fn render(&mut self, frame: &mut Frame) {
         let term_w = frame.area().width as usize;
         let status_text_len = self.status.text().len() + 3; // " ● " prefix
-        let status_lines: u16 = if term_w > 0 && status_text_len > term_w { 2 } else { 1 };
+        let status_lines: u16 = if term_w > 0 && status_text_len > term_w {
+            2
+        } else {
+            1
+        };
         let footer_h = 1 + status_lines; // 1 for hints + status lines
         let [header, body, footer] = Layout::default()
             .direction(Direction::Vertical)
@@ -1460,10 +1479,7 @@ impl App {
                             .is_some_and(|next| matches!(next, LeftItem::Session(_)));
                         let connector = if is_last { "└" } else { "├" };
                         ListItem::new(Line::from(vec![
-                            Span::styled(
-                                connector,
-                                Style::default().fg(self.theme.project_icon),
-                            ),
+                            Span::styled(connector, Style::default().fg(self.theme.project_icon)),
                             Span::styled(dot.to_string(), Style::default().fg(dot_color)),
                         ]))
                     }
@@ -1481,10 +1497,10 @@ impl App {
             return;
         }
 
-        let session_counts: HashMap<i64, usize> = {
+        let session_counts: HashMap<String, usize> = {
             let mut counts = HashMap::new();
             for session in &self.sessions {
-                *counts.entry(session.project_id).or_insert(0) += 1;
+                *counts.entry(session.project_id.clone()).or_insert(0) += 1;
             }
             counts
         };
@@ -1525,10 +1541,7 @@ impl App {
                         .unwrap_or_else(|| session.branch_name.clone());
                     let (dot, dot_color) = self.theme.session_dot(&session.status);
                     ListItem::new(Line::from(vec![
-                        Span::styled(
-                            connector,
-                            Style::default().fg(self.theme.project_icon),
-                        ),
+                        Span::styled(connector, Style::default().fg(self.theme.project_icon)),
                         Span::styled(format!("{dot} "), Style::default().fg(dot_color)),
                         Span::styled(label, Style::default().fg(dot_color)),
                         Span::styled(
@@ -1657,10 +1670,7 @@ impl App {
                                     name.to_owned(),
                                     Style::default().fg(self.theme.branch_fg),
                                 ),
-                                Span::styled(
-                                    "...",
-                                    Style::default().fg(self.theme.hint_desc_fg),
-                                ),
+                                Span::styled("...", Style::default().fg(self.theme.hint_desc_fg)),
                             ];
                             (spans, text_len)
                         }
@@ -1742,8 +1752,7 @@ impl App {
                                 if cell.inverse() {
                                     modifier |= Modifier::REVERSED;
                                 }
-                                let style =
-                                    Style::default().fg(fg).bg(bg).add_modifier(modifier);
+                                let style = Style::default().fg(fg).bg(bg).add_modifier(modifier);
                                 let contents = cell.contents();
                                 let ratatui_cell = &mut buf[(x, y)];
                                 if contents.is_empty() {
@@ -1761,8 +1770,7 @@ impl App {
                         let (cursor_row, cursor_col) = screen.cursor_position();
                         let cx = term_area.x + cursor_col;
                         let cy = term_area.y + cursor_row;
-                        if cx < term_area.x + term_area.width
-                            && cy < term_area.y + term_area.height
+                        if cx < term_area.x + term_area.width && cy < term_area.y + term_area.height
                         {
                             let cursor_cell = &mut buf[(cx, cy)];
                             cursor_cell.set_style(
@@ -1781,9 +1789,7 @@ impl App {
             let hint_line = if is_input {
                 let desc_style = Style::default().fg(self.theme.hint_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
-                let cli_name = session_provider_name
-                    .as_deref()
-                    .unwrap_or("the agent");
+                let cli_name = session_provider_name.as_deref().unwrap_or("the agent");
                 spans.push(Span::styled("Press ", desc_style));
                 spans.extend(self.theme.key_badge("ctrl+g", Color::Reset));
                 spans.push(Span::styled(
@@ -1962,14 +1968,8 @@ impl App {
             status_text
         };
         let status_line = Line::from(vec![
-            Span::styled(
-                prefix,
-                Style::default().fg(dot_color).bg(status_bg),
-            ),
-            Span::styled(
-                truncated,
-                Style::default().fg(msg_color).bg(status_bg),
-            ),
+            Span::styled(prefix, Style::default().fg(dot_color).bg(status_bg)),
+            Span::styled(truncated, Style::default().fg(msg_color).bg(status_bg)),
         ]);
         Paragraph::new(status_line)
             .style(Style::default().bg(status_bg))
@@ -2014,15 +2014,10 @@ impl App {
                     ("Esc", "Close diff view"),
                 ],
             ),
-            (
-                "Files pane",
-                &[("Enter", "Open selected file diff")],
-            ),
+            ("Files pane", &[("Enter", "Open selected file diff")]),
             (
                 "Key notation",
-                &[
-                    ("^X", "Hold Ctrl and press X (e.g. ^P = Ctrl+P)"),
-                ],
+                &[("^X", "Hold Ctrl and press X (e.g. ^P = Ctrl+P)")],
             ),
         ];
         let mut lines: Vec<Line> = Vec::new();
@@ -2058,8 +2053,16 @@ impl App {
         )));
         let session_states: &[(&str, Color, &str)] = &[
             ("●", self.theme.session_active, "Active — agent is running"),
-            ("◐", self.theme.session_detached, "Detached — agent process disconnected"),
-            ("○", self.theme.session_exited, "Exited — agent has finished"),
+            (
+                "◐",
+                self.theme.session_detached,
+                "Detached — agent process disconnected",
+            ),
+            (
+                "○",
+                self.theme.session_exited,
+                "Exited — agent has finished",
+            ),
         ];
         for (dot, color, desc) in session_states {
             lines.push(Line::from(vec![
@@ -2261,9 +2264,15 @@ impl App {
                     let mut bottom_spans = vec![Span::raw(" ")];
                     if *editing_path {
                         bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
-                        bottom_spans.push(Span::styled(" go  ", Style::default().fg(self.theme.hint_desc_fg)));
+                        bottom_spans.push(Span::styled(
+                            " go  ",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ));
                         bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
-                        bottom_spans.push(Span::styled(" cancel", Style::default().fg(self.theme.hint_desc_fg)));
+                        bottom_spans.push(Span::styled(
+                            " cancel",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ));
                     } else if *searching {
                         bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
                         bottom_spans.push(Span::styled(
@@ -2478,10 +2487,7 @@ impl App {
                 let btn_width = 16u16;
                 let gap = 2u16;
                 let total = btn_width * 2 + gap;
-                let left_offset = buttons_area
-                    .width
-                    .saturating_sub(total)
-                    / 2;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
 
                 let cancel_area = Rect {
                     x: buttons_area.x + left_offset,
@@ -2553,12 +2559,19 @@ impl App {
                     ])
                     .areas(inner);
 
-                let agent_word = if *active_count == 1 { "agent" } else { "agents" };
+                let agent_word = if *active_count == 1 {
+                    "agent"
+                } else {
+                    "agents"
+                };
                 let lines = vec![
                     Line::from(""),
                     Line::from(vec![
                         Span::raw(format!(" {active_count} running {agent_word} will be ")),
-                        Span::styled("killed", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+                        Span::styled(
+                            "killed",
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                        ),
                         Span::raw(" if you quit."),
                     ]),
                     Line::from(""),
@@ -2709,7 +2722,11 @@ impl App {
         }
     }
 
-    fn left_items(&self) -> Vec<LeftItem> {
+    fn left_items(&self) -> &[LeftItem] {
+        &self.left_items_cache
+    }
+
+    fn rebuild_left_items(&mut self) {
         let mut items = Vec::new();
         for (project_index, project) in self.projects.iter().enumerate() {
             items.push(LeftItem::Project(project_index));
@@ -2722,17 +2739,18 @@ impl App {
                 }
             }
         }
-        items
+        self.left_items_cache = items;
     }
 
     fn toggle_collapse_selected_project(&mut self) {
         if let Some(project) = self.selected_project() {
-            let id = project.id;
+            let id = project.id.clone();
             if self.collapsed_projects.contains(&id) {
                 self.collapsed_projects.remove(&id);
             } else {
                 self.collapsed_projects.insert(id);
             }
+            self.rebuild_left_items();
         }
     }
 
@@ -2812,7 +2830,10 @@ impl App {
 
     fn themed_block<'a>(&self, title: &'a str, focused: bool) -> Block<'a> {
         Block::default()
-            .title(Line::from(Span::styled(title, self.theme.title_style(focused))))
+            .title(Line::from(Span::styled(
+                title,
+                self.theme.title_style(focused),
+            )))
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
             .border_style(self.theme.border_style(focused))
@@ -2877,7 +2898,8 @@ fn run_create_agent_job(
     ));
     let session = AgentSession {
         id: Uuid::new_v4().to_string(),
-        project_id: project.id,
+        project_id: project.id.clone(),
+        project_path: Some(project.path.clone()),
         provider: project.default_provider.clone(),
         source_branch: project.current_branch.clone(),
         branch_name,
@@ -2927,12 +2949,16 @@ fn run_create_agent_job(
         }
     };
     logger::info(&format!("PTY session started for {}", session.id));
-    let _ = worker_tx.send(WorkerEvent::CreateAgentReady { session, client, pty_size: (rows, cols) });
+    let _ = worker_tx.send(WorkerEvent::CreateAgentReady {
+        session,
+        client,
+        pty_size: (rows, cols),
+    });
 }
 
 fn load_projects(config: &Config) -> Vec<Project> {
     let mut projects = Vec::new();
-    for (index, project) in config.projects.iter().enumerate() {
+    for project in config.projects.iter() {
         let path = PathBuf::from(&project.path);
         if !path.exists() || !git::is_git_repo(&path) {
             continue;
@@ -2943,7 +2969,7 @@ fn load_projects(config: &Config) -> Vec<Project> {
             .map(ProviderKind::from_str)
             .unwrap_or_else(|| config.default_provider());
         projects.push(Project {
-            id: index as i64 + 1,
+            id: project.id.clone(),
             name: project.name.clone().unwrap_or_else(|| {
                 path.file_name()
                     .and_then(|name| name.to_str())

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::model::ProviderKind;
 
@@ -48,9 +49,15 @@ pub struct ProviderCommandConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectConfig {
+    #[serde(default = "new_project_id")]
+    pub id: String,
     pub path: String,
     pub name: Option<String>,
     pub default_provider: Option<String>,
+}
+
+fn new_project_id() -> String {
+    Uuid::new_v4().to_string()
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -80,8 +87,7 @@ impl Default for Config {
 
 impl Default for Defaults {
     fn default() -> Self {
-        let start_directory = home::home_dir()
-            .map(|p| p.to_string_lossy().to_string());
+        let start_directory = home::home_dir().map(|p| p.to_string_lossy().to_string());
         Self {
             provider: "codex".to_string(),
             start_directory,
@@ -229,20 +235,25 @@ right_width_pct = {right_width}
 # default_provider can override the global default for one project.
 projects = []
 "#,
-        provider = default.defaults.provider,
-        start_directory = default.defaults.start_directory.as_deref().unwrap_or(""),
-        claude_command = default
-            .providers
-            .get("claude")
-            .map(|config| config.command.as_str())
-            .unwrap_or("claude"),
-        codex_command = default
-            .providers
-            .get("codex")
-            .map(|config| config.command.as_str())
-            .unwrap_or("codex"),
-        log_level = default.logging.level,
-        log_path = default.logging.path,
+        provider = escape_toml_string(&default.defaults.provider),
+        start_directory =
+            escape_toml_string(default.defaults.start_directory.as_deref().unwrap_or("")),
+        claude_command = escape_toml_string(
+            default
+                .providers
+                .get("claude")
+                .map(|config| config.command.as_str())
+                .unwrap_or("claude")
+        ),
+        codex_command = escape_toml_string(
+            default
+                .providers
+                .get("codex")
+                .map(|config| config.command.as_str())
+                .unwrap_or("codex")
+        ),
+        log_level = escape_toml_string(&default.logging.level),
+        log_path = escape_toml_string(&default.logging.path),
         left_width = default.ui.left_width_pct,
         right_width = default.ui.right_width_pct,
     )
@@ -261,19 +272,31 @@ fn render_config(config: &Config) -> String {
     out.push_str("# Every value is materialized here so the file doubles as documentation.\n\n");
     out.push_str("[defaults]\n");
     out.push_str("# Which provider new sessions use unless a project overrides it.\n");
-    out.push_str(&format!("provider = \"{}\"\n", config.defaults.provider));
+    out.push_str(&format!(
+        "provider = \"{}\"\n",
+        escape_toml_string(&config.defaults.provider)
+    ));
     out.push_str("# Starting directory for the project browser.\n");
     if let Some(dir) = &config.defaults.start_directory {
-        out.push_str(&format!("start_directory = \"{}\"\n\n", dir));
+        out.push_str(&format!(
+            "start_directory = \"{}\"\n\n",
+            escape_toml_string(dir)
+        ));
     } else {
         out.push_str("start_directory = \"\"\n\n");
     }
     render_provider_configs(&mut out, &config.providers);
     out.push_str("[logging]\n");
     out.push_str("# Log level can be error, info, or debug.\n");
-    out.push_str(&format!("level = \"{}\"\n", config.logging.level));
+    out.push_str(&format!(
+        "level = \"{}\"\n",
+        escape_toml_string(&config.logging.level)
+    ));
     out.push_str("# Relative paths are resolved from the dux config directory.\n");
-    out.push_str(&format!("path = \"{}\"\n\n", config.logging.path));
+    out.push_str(&format!(
+        "path = \"{}\"\n\n",
+        escape_toml_string(&config.logging.path)
+    ));
     out.push_str("[ui]\n");
     out.push_str("# Initial pane sizing percentages. They can still be resized at runtime.\n");
     out.push_str(&format!("left_width_pct = {}\n", config.ui.left_width_pct));
@@ -287,12 +310,19 @@ fn render_config(config: &Config) -> String {
     out.push_str("# default_provider can override the global default for one project.\n");
     for project in &config.projects {
         out.push_str("[[projects]]\n");
-        out.push_str(&format!("path = \"{}\"\n", project.path));
+        out.push_str(&format!("id = \"{}\"\n", escape_toml_string(&project.id)));
+        out.push_str(&format!(
+            "path = \"{}\"\n",
+            escape_toml_string(&project.path)
+        ));
         if let Some(name) = &project.name {
-            out.push_str(&format!("name = \"{}\"\n", name));
+            out.push_str(&format!("name = \"{}\"\n", escape_toml_string(name)));
         }
         if let Some(provider) = &project.default_provider {
-            out.push_str(&format!("default_provider = \"{}\"\n", provider));
+            out.push_str(&format!(
+                "default_provider = \"{}\"\n",
+                escape_toml_string(provider)
+            ));
         }
         out.push('\n');
     }
@@ -302,10 +332,28 @@ fn render_config(config: &Config) -> String {
     out
 }
 
+fn escape_toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 fn render_string_list(values: &[String]) -> String {
     let rendered = values
         .iter()
-        .map(|value| format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\"")))
+        .map(|value| format!("\"{}\"", escape_toml_string(value)))
         .collect::<Vec<_>>()
         .join(", ");
     format!("[{rendered}]")
@@ -352,7 +400,10 @@ fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommand
     } else if name == "codex" {
         out.push_str("# Example: command = \"codex\"\n");
     }
-    out.push_str(&format!("command = \"{}\"\n", config.command));
+    out.push_str(&format!(
+        "command = \"{}\"\n",
+        escape_toml_string(&config.command)
+    ));
     out.push_str(&format!("args = {}\n\n", render_string_list(&config.args)));
 }
 
@@ -412,6 +463,36 @@ mod tests {
         assert!(rendered.contains("[providers.claude]"));
         assert!(rendered.contains("[providers.codex]"));
         assert!(rendered.contains("[ui]"));
+    }
+
+    #[test]
+    fn render_config_escapes_special_chars() {
+        let mut config = Config::default();
+        config.projects.push(ProjectConfig {
+            id: new_project_id(),
+            path: r#"/home/user/"test"\project"#.to_string(),
+            name: Some(r#"te"st"#.to_string()),
+            default_provider: None,
+        });
+        let rendered = render_config(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("should parse back");
+        assert_eq!(parsed.projects[0].path, config.projects[0].path);
+        assert_eq!(parsed.projects[0].name, config.projects[0].name);
+    }
+
+    #[test]
+    fn render_config_escapes_newlines_and_control_chars() {
+        let mut config = Config::default();
+        config.projects.push(ProjectConfig {
+            id: new_project_id(),
+            path: "/home/user/path\nwith\nnewlines".to_string(),
+            name: Some("name\twith\ttabs".to_string()),
+            default_provider: None,
+        });
+        let rendered = render_config(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("should parse back");
+        assert_eq!(parsed.projects[0].path, config.projects[0].path);
+        assert_eq!(parsed.projects[0].name, config.projects[0].name);
     }
 
     #[cfg(target_os = "macos")]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -6,9 +6,7 @@ use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use similar::{ChangeTag, TextDiff};
 use syntect::easy::HighlightLines;
-use syntect::highlighting::{
-    Color as SynColor, FontStyle, Style as SynStyle, ThemeSet,
-};
+use syntect::highlighting::{Color as SynColor, FontStyle, Style as SynStyle, ThemeSet};
 use syntect::parsing::SyntaxSet;
 
 use crate::theme::Theme as AppTheme;
@@ -22,13 +20,8 @@ pub struct DiffOutput {
 ///
 /// `worktree_path` is the root of the git worktree and `rel_path` is the
 /// file path relative to it (as reported by `git status --porcelain`).
-pub fn diff_file(
-    worktree_path: &Path,
-    rel_path: &str,
-    theme: &AppTheme,
-) -> Result<DiffOutput> {
-    let old_text = crate::git::file_at_head(worktree_path, rel_path)?
-        .unwrap_or_default();
+pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Result<DiffOutput> {
+    let old_text = crate::git::file_at_head(worktree_path, rel_path)?.unwrap_or_default();
     let abs_path = worktree_path.join(rel_path);
     let new_text = fs::read_to_string(&abs_path).unwrap_or_default();
 
@@ -87,8 +80,18 @@ pub fn diff_file(
             let text = change.value();
 
             let (prefix, base_fg, bg, highlighter) = match tag {
-                ChangeTag::Delete => ("-", theme.diff_remove, Some(Color::Rgb(60, 20, 20)), &mut hl_old),
-                ChangeTag::Insert => ("+", theme.diff_add, Some(Color::Rgb(20, 50, 20)), &mut hl_new),
+                ChangeTag::Delete => (
+                    "-",
+                    theme.diff_remove,
+                    Some(Color::Rgb(60, 20, 20)),
+                    &mut hl_old,
+                ),
+                ChangeTag::Insert => (
+                    "+",
+                    theme.diff_add,
+                    Some(Color::Rgb(20, 50, 20)),
+                    &mut hl_new,
+                ),
                 ChangeTag::Equal => (" ", Color::Reset, None, &mut hl_new),
             };
 
@@ -101,9 +104,11 @@ pub fn diff_file(
                         prefix.to_string(),
                         Style::default().fg(base_fg),
                     )];
-                    out.extend(ranges.into_iter().map(|(s, t)| {
-                        Span::styled(t.to_string(), syntect_to_ratatui(s))
-                    }));
+                    out.extend(
+                        ranges
+                            .into_iter()
+                            .map(|(s, t)| Span::styled(t.to_string(), syntect_to_ratatui(s))),
+                    );
                     out
                 }
                 Ok(ranges) => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -104,7 +104,8 @@ pub fn create_worktree(
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    Ok((branch_name, worktree_path))
+    let canonical = worktree_path.canonicalize().unwrap_or(worktree_path);
+    Ok((branch_name, canonical))
 }
 
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path, branch_name: &str) -> Result<()> {
@@ -188,6 +189,13 @@ pub fn diff_for_file(worktree_path: &Path, path: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+pub fn is_under(base: &Path, candidate: &Path) -> bool {
+    match (base.canonicalize(), candidate.canonicalize()) {
+        (Ok(b), Ok(c)) => c.starts_with(b),
+        _ => false,
+    }
+}
+
 pub fn ellipsize_middle(input: &str, max_width: usize) -> String {
     if input.chars().count() <= max_width {
         return input.to_string();
@@ -227,6 +235,21 @@ mod tests {
             ellipsize_middle("src/components/app.rs", 12),
             "src/...pp.rs"
         );
+    }
+
+    #[test]
+    fn is_under_checks_real_paths() {
+        let tmp = std::env::temp_dir();
+        let child = tmp.join("is_under_test_child");
+        std::fs::create_dir_all(&child).unwrap();
+        assert!(is_under(&tmp, &child));
+        std::fs::remove_dir(&child).unwrap();
+    }
+
+    #[test]
+    fn is_under_rejects_nonexistent_candidate() {
+        let tmp = std::env::temp_dir();
+        assert!(!is_under(&tmp, Path::new("/nonexistent/path/xyz")));
     }
 
     #[test]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use chrono::Utc;
@@ -85,7 +85,7 @@ fn log(level: LogLevel, message: &str) {
     }
 }
 
-fn resolve_log_path(config: &LoggingConfig, paths: &DuxPaths) -> PathBuf {
+pub fn resolve_log_path(config: &LoggingConfig, paths: &DuxPaths) -> PathBuf {
     let configured = PathBuf::from(&config.path);
     if configured.as_os_str().is_empty() {
         return paths.root.join("dux.log");
@@ -95,9 +95,4 @@ fn resolve_log_path(config: &LoggingConfig, paths: &DuxPaths) -> PathBuf {
     } else {
         paths.root.join(configured)
     }
-}
-
-#[allow(dead_code)]
-fn _is_under(base: &Path, candidate: &Path) -> bool {
-    candidate.starts_with(base)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,13 @@ fn run_reset(keep_config: bool) -> Result<()> {
                 if let Ok(sessions) = store.load_sessions() {
                     for session in &sessions {
                         let wt = std::path::Path::new(&session.worktree_path);
+                        if !git::is_under(&paths.worktrees_root, wt) {
+                            eprintln!(
+                                "warning: skipping worktree outside of managed root: {}",
+                                session.worktree_path
+                            );
+                            continue;
+                        }
                         if wt.exists() {
                             // Best-effort: try git worktree remove, fall back to rm.
                             let _ = std::process::Command::new("git")
@@ -52,10 +59,16 @@ fn run_reset(keep_config: bool) -> Result<()> {
                                 let _ = std::fs::remove_dir_all(wt);
                             }
                         }
-                        // Also try to delete the branch.
-                        let _ = std::process::Command::new("git")
-                            .args(["branch", "-D", &session.branch_name])
-                            .output();
+                        // Try to delete the branch in the source repo.
+                        if let Some(ref project_path) = session.project_path {
+                            let _ = std::process::Command::new("git")
+                                .arg("-C")
+                                .arg(project_path)
+                                .arg("branch")
+                                .arg("-D")
+                                .arg(&session.branch_name)
+                                .output();
+                        }
                     }
                     println!("removed {} session worktree(s)", sessions.len());
                 }
@@ -79,7 +92,16 @@ fn run_reset(keep_config: bool) -> Result<()> {
     }
 
     // Remove log files (resolve the same way logger.rs does).
-    let log_path = paths.root.join("dux.log");
+    let log_config = if paths.config_path.exists() {
+        std::fs::read_to_string(&paths.config_path)
+            .ok()
+            .and_then(|raw| toml::from_str::<config::Config>(&raw).ok())
+            .map(|cfg| cfg.logging)
+            .unwrap_or_default()
+    } else {
+        config::LoggingConfig::default()
+    };
+    let log_path = logger::resolve_log_path(&log_config, &paths);
     if log_path.exists() {
         std::fs::remove_file(&log_path)?;
         println!("removed {}", log_path.display());
@@ -95,7 +117,10 @@ fn run_reset(keep_config: bool) -> Result<()> {
 
     // Remove the root dir if it's now empty.
     if paths.root.exists() {
-        let is_empty = paths.root.read_dir().map_or(true, |mut d| d.next().is_none());
+        let is_empty = paths
+            .root
+            .read_dir()
+            .map_or(true, |mut d| d.next().is_none());
         if is_empty {
             std::fs::remove_dir(&paths.root)?;
             println!("removed {}", paths.root.display());

--- a/src/model.rs
+++ b/src/model.rs
@@ -24,7 +24,7 @@ impl ProviderKind {
 
 #[derive(Clone, Debug)]
 pub struct Project {
-    pub id: i64,
+    pub id: String,
     pub name: String,
     pub path: String,
     pub default_provider: ProviderKind,
@@ -59,7 +59,8 @@ impl SessionStatus {
 #[derive(Clone, Debug)]
 pub struct AgentSession {
     pub id: String,
-    pub project_id: i64,
+    pub project_id: String,
+    pub project_path: Option<String>,
     pub provider: ProviderKind,
     pub source_branch: String,
     pub branch_name: String,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -22,12 +22,13 @@ impl SessionStore {
             r#"
             create table if not exists agent_sessions (
                 id text primary key,
-                project_id integer not null,
+                project_id text not null,
                 provider text not null,
                 source_branch text not null,
                 branch_name text not null,
                 worktree_path text not null,
                 title text,
+                project_path text,
                 status text not null,
                 created_at text not null,
                 updated_at text not null
@@ -35,6 +36,7 @@ impl SessionStore {
             "#,
         )?;
         ensure_column(&self.conn, "agent_sessions", "title", "text")?;
+        ensure_column(&self.conn, "agent_sessions", "project_path", "text")?;
         Ok(())
     }
 
@@ -42,10 +44,11 @@ impl SessionStore {
         self.conn.execute(
             r#"
             insert into agent_sessions
-                (id, project_id, provider, source_branch, branch_name, worktree_path, title, status, created_at, updated_at)
+                (id, project_id, project_path, provider, source_branch, branch_name, worktree_path, title, status, created_at, updated_at)
             values
-                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
             on conflict(id) do update set
+                project_path=excluded.project_path,
                 provider=excluded.provider,
                 source_branch=excluded.source_branch,
                 branch_name=excluded.branch_name,
@@ -57,6 +60,7 @@ impl SessionStore {
             params![
                 session.id,
                 session.project_id,
+                session.project_path,
                 session.provider.as_str(),
                 session.source_branch,
                 session.branch_name,
@@ -73,23 +77,24 @@ impl SessionStore {
     pub fn load_sessions(&self) -> Result<Vec<AgentSession>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select id, project_id, provider, source_branch, branch_name, worktree_path, title, status, created_at, updated_at
+            select id, project_id, provider, source_branch, branch_name, worktree_path, title, project_path, status, created_at, updated_at
             from agent_sessions
             order by updated_at desc
             "#,
         )?;
         let rows = stmt.query_map([], |row| {
-            let created_at: String = row.get(8)?;
-            let updated_at: String = row.get(9)?;
+            let created_at: String = row.get(9)?;
+            let updated_at: String = row.get(10)?;
             Ok(AgentSession {
                 id: row.get(0)?,
-                project_id: row.get(1)?,
+                project_id: row.get::<_, String>(1).unwrap_or_default(),
                 provider: crate::model::ProviderKind::from_str(row.get::<_, String>(2)?.as_str()),
                 source_branch: row.get(3)?,
                 branch_name: row.get(4)?,
                 worktree_path: row.get(5)?,
                 title: row.get(6)?,
-                status: SessionStatus::from_str(row.get::<_, String>(7)?.as_str()),
+                project_path: row.get(7)?,
+                status: SessionStatus::from_str(row.get::<_, String>(8)?.as_str()),
                 created_at: parse_time(&created_at).unwrap_or_else(Utc::now),
                 updated_at: parse_time(&updated_at).unwrap_or_else(Utc::now),
             })


### PR DESCRIPTION
## Summary

- Replaces integer project IDs with UUID strings for stable identity across config reloads and session persistence.
- Adds `project_path` to sessions so branch cleanup (`git branch -D`) targets the correct source repository.
- Caches `left_items` to avoid rebuilding every frame, and fixes a missing cache invalidation after collapse toggle.
- Escapes newlines, control characters, and TOML-special chars in config rendering to prevent silent corruption on round-trip.
- Canonicalizes paths in `is_under`, `create_worktree`, and `add_project` to prevent path traversal via `..` components.

## Test plan

- [x] `cargo test` passes (12 tests across 2 suites)
- [x] `cargo check` compiles cleanly
- [ ] Manual: add a project, create a session, verify UUID-based ID persists across restarts
- [ ] Manual: collapse/expand a project in the left panel and verify it updates immediately
- [ ] Manual: run `dux reset` and verify worktree cleanup works correctly