### PR TITLE
Return focus to Changed Files pane when ESC closes diff

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -488,6 +488,7 @@ impl App {
             }
             KeyCode::Esc => {
                 self.center_mode = CenterMode::Agent;
+                self.focus = FocusPane::Files;
                 self.set_info("Returned to agent view.");
             }
             _ => {}


### PR DESCRIPTION
When pressing ESC to close a diff view, focus remained on the center (Agent) pane instead of returning to the Changed Files pane. This adds `self.focus = FocusPane::Files` to the ESC handler in `handle_center_key`, so focus goes back to where the user came from.