### PR TITLE
Improve Enter key behavior in projects pane

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -500,13 +500,16 @@ impl App {
                     );
                 }
             }
-            KeyCode::Char('r') => {
-                // Allow relaunching an exited agent from the center pane.
+            KeyCode::Char('r') | KeyCode::Enter => {
+                // Allow relaunching an exited agent from the center pane,
+                // or entering interactive mode if the agent is active.
                 let has_provider = self
                     .selected_session()
                     .map(|s| self.providers.contains_key(&s.id))
                     .unwrap_or(false);
-                if !has_provider {
+                if has_provider {
+                    self.input_target = InputTarget::Agent;
+                } else if self.selected_session().is_some() {
                     self.reconnect_selected_session()?;
                 }
             }
@@ -1870,26 +1873,40 @@ impl App {
         // Hint bar with top border.
         if hint_area.height > 0 {
             let hint_line = if is_input {
-                let desc_style = Style::default().fg(self.theme.hint_desc_fg);
+                let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
-                let cli_name = session_provider_name.as_deref().unwrap_or("the agent");
-                spans.push(Span::styled("Press ", desc_style));
-                spans.extend(self.theme.key_badge("ctrl+g", Color::Reset));
+                let cli_name = session_provider_name.as_deref().unwrap_or("agent");
+                let capitalized = {
+                    let mut c = cli_name.chars();
+                    match c.next() {
+                        Some(first) => format!("{}{}", first.to_uppercase(), c.as_str()),
+                        None => String::new(),
+                    }
+                };
                 spans.push(Span::styled(
-                    format!(" to manage dux instead of {cli_name}."),
+                    format!("{capitalized} is holding focus. Press "),
+                    desc_style,
+                ));
+                spans.extend(self.theme.dim_key_badge("ctrl+g", Color::Reset));
+                spans.push(Span::styled(
+                    " to bring the focus back to dux.",
                     desc_style,
                 ));
                 Line::from(spans)
             } else {
-                let desc_style = Style::default().fg(self.theme.hint_desc_fg);
+                let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
                 if session_active {
                     spans.push(Span::styled("Press ", desc_style));
-                    spans.extend(self.theme.key_badge("i", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge("i", Color::Reset));
+                    spans.push(Span::styled(" or ", desc_style));
+                    spans.extend(self.theme.dim_key_badge("enter", Color::Reset));
                     spans.push(Span::styled(" to interact with the agent.", desc_style));
                 } else if session_id.is_some() {
                     spans.push(Span::styled("Agent CLI exited. Press ", desc_style));
-                    spans.extend(self.theme.key_badge("r", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge("r", Color::Reset));
+                    spans.push(Span::styled(" or ", desc_style));
+                    spans.extend(self.theme.dim_key_badge("enter", Color::Reset));
                     spans.push(Span::styled(" to relaunch.", desc_style));
                 } else {
                     spans.push(Span::styled("No agent selected.", desc_style));

--- a/src/app.rs
+++ b/src/app.rs
@@ -405,9 +405,49 @@ impl App {
                 }
             }
             KeyCode::Enter => {
-                self.center_mode = CenterMode::Agent;
-                self.focus = FocusPane::Center;
-                self.reload_changed_files();
+                match self.left_items().get(self.selected_left) {
+                    Some(LeftItem::Project(project_index)) => {
+                        let project_id = self.projects[*project_index].id.clone();
+                        let has_sessions = self.sessions.iter().any(|s| s.project_id == project_id);
+                        if has_sessions {
+                            // Expand the project if collapsed so the session items are visible
+                            if self.collapsed_projects.contains(&project_id) {
+                                self.collapsed_projects.remove(&project_id);
+                                self.rebuild_left_items();
+                            }
+                            // Find the first session belonging to this project
+                            if let Some(pos) = self.left_items().iter().position(|item| {
+                                matches!(item, LeftItem::Session(si) if self.sessions[*si].project_id == project_id)
+                            }) {
+                                self.selected_left = pos;
+                                self.center_mode = CenterMode::Agent;
+                                self.focus = FocusPane::Center;
+                                self.reload_changed_files();
+                                if self.selected_session()
+                                    .map(|s| self.providers.contains_key(&s.id))
+                                    .unwrap_or(false)
+                                {
+                                    self.input_target = InputTarget::Agent;
+                                }
+                            }
+                        } else {
+                            // Project has no agents: create one
+                            self.create_agent_for_selected_project()?;
+                        }
+                    }
+                    Some(LeftItem::Session(_)) => {
+                        self.center_mode = CenterMode::Agent;
+                        self.focus = FocusPane::Center;
+                        self.reload_changed_files();
+                        if self.selected_session()
+                            .map(|s| self.providers.contains_key(&s.id))
+                            .unwrap_or(false)
+                        {
+                            self.input_target = InputTarget::Agent;
+                        }
+                    }
+                    None => {}
+                }
             }
             KeyCode::Char('a') => {
                 self.open_project_browser()?;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -33,6 +33,9 @@ pub struct Theme {
     pub hint_bracket_fg: Color,
     pub hint_key_bg: Color,
     pub hint_desc_fg: Color,
+    pub hint_dim_key_fg: Color,
+    pub hint_dim_bracket_fg: Color,
+    pub hint_dim_desc_fg: Color,
     pub hint_bar_bg: Color,
     pub overlay_border: Color,
     pub overlay_bg: Color,
@@ -75,6 +78,9 @@ impl Theme {
             hint_bracket_fg: Color::DarkGray,
             hint_key_bg: Color::Rgb(35, 35, 35),
             hint_desc_fg: Color::Rgb(160, 160, 160),
+            hint_dim_key_fg: Color::Rgb(80, 140, 160),
+            hint_dim_bracket_fg: Color::Rgb(60, 60, 60),
+            hint_dim_desc_fg: Color::Rgb(100, 100, 100),
             hint_bar_bg: Color::Rgb(25, 25, 25),
             overlay_border: Color::Cyan,
             overlay_bg: Color::Rgb(20, 20, 20),
@@ -147,6 +153,20 @@ impl Theme {
 
     /// Render a key badge as `<key>` with the angle brackets in an accent color
     /// and the key name in bold. Returns 3 spans.
+    pub fn dim_key_badge<'a>(&self, key: &'a str, bg: Color) -> Vec<Span<'a>> {
+        vec![
+            Span::styled("<", Style::default().fg(self.hint_dim_bracket_fg).bg(bg)),
+            Span::styled(
+                key,
+                Style::default()
+                    .fg(self.hint_dim_key_fg)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(">", Style::default().fg(self.hint_dim_bracket_fg).bg(bg)),
+        ]
+    }
+
     pub fn key_badge<'a>(&self, key: &'a str, bg: Color) -> Vec<Span<'a>> {
         vec![
             Span::styled("<", Style::default().fg(self.hint_bracket_fg).bg(bg)),


### PR DESCRIPTION
## Summary
- Pressing Enter on a project with no agents now creates one immediately instead of just switching to an empty agent pane.
- Pressing Enter on a project with existing agents expands it (if collapsed), selects the first agent, and enters interactive mode so you can start chatting right away.
- Pressing Enter on an agent directly also enters interactive mode automatically.

## Test plan
- [ ] Select a project with no agents, press Enter — should start creating a new agent
- [ ] Select a project with 1+ agents, press Enter — should focus the first agent in interactive mode
- [ ] Select a collapsed project with agents, press Enter — should expand and focus the first agent
- [ ] Select an agent directly, press Enter — should focus it in interactive mode
- [ ] Select an agent whose provider has exited, press Enter — should focus it without entering interactive mode