### PR TITLE
Close diff view with ESC from any focused pane

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -514,9 +514,9 @@ impl App {
                 }
             }
             KeyCode::Esc => {
-                self.center_mode = CenterMode::Agent;
-                self.focus = FocusPane::Files;
-                self.set_info("Returned to agent view.");
+                // When no diff is open, ESC from the center pane is a no-op.
+                // Diff closing is handled globally by close_top_overlay so it
+                // works regardless of which pane is focused.
             }
             _ => {}
         }
@@ -2742,6 +2742,12 @@ impl App {
         if self.help_overlay {
             self.help_overlay = false;
             self.set_info("Closed overlay.");
+            return true;
+        }
+        if matches!(self.center_mode, CenterMode::Diff(_)) {
+            self.center_mode = CenterMode::Agent;
+            self.focus = FocusPane::Files;
+            self.set_info("Returned to agent view.");
             return true;
         }
         false


### PR DESCRIPTION
## Summary
- Moves diff-closing logic from `handle_center_key` into `close_top_overlay`, which runs at the top of the key handler before pane-specific routing.
- ESC now closes the diff and returns focus to Changed Files regardless of which pane is currently focused.
- The previous fix (#25) only worked when the Center pane had focus, so pressing ESC from the Files pane left the diff open.

## Test plan
- [ ] Open a changed file diff from the right sidebar (Enter)
- [ ] Press ESC — verify the diff closes and focus returns to Changed Files
- [ ] Open a diff, Tab to another pane, press ESC — verify it still closes the diff