### PR TITLE
Add keyboard scrollback for PTY output (Ctrl+B/F, PgUp/PgDn)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,12 @@ enum InputTarget {
     Agent,
 }
 
+#[derive(Clone, Copy)]
+enum ScrollDirection {
+    Up,
+    Down,
+}
+
 #[derive(Clone, Copy, Debug)]
 enum LeftItem {
     Project(usize),
@@ -492,6 +498,7 @@ impl App {
                         .map(|s| self.providers.contains_key(&s.id))
                         .unwrap_or(false)
                 {
+                    self.reset_pty_scrollback();
                     self.input_target = InputTarget::Agent;
                     self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                 } else {
@@ -508,6 +515,7 @@ impl App {
                     .map(|s| self.providers.contains_key(&s.id))
                     .unwrap_or(false);
                 if has_provider {
+                    self.reset_pty_scrollback();
                     self.input_target = InputTarget::Agent;
                 } else if self.selected_session().is_some() {
                     self.reconnect_selected_session()?;
@@ -518,9 +526,44 @@ impl App {
                 self.focus = FocusPane::Files;
                 self.set_info("Returned to agent view.");
             }
+            // Page-up style scrolling: ctrl+b or PageUp
+            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+            }
+            KeyCode::PageUp => {
+                self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+            }
+            // Page-down style scrolling: ctrl+f or PageDown
+            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+            }
+            KeyCode::PageDown => {
+                self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+            }
             _ => {}
         }
         Ok(())
+    }
+
+    fn scroll_pty(&mut self, direction: ScrollDirection, amount: usize) {
+        let sid = match self.selected_session() {
+            Some(s) => s.id.clone(),
+            None => return,
+        };
+        let provider = match self.providers.get(&sid) {
+            Some(p) => p,
+            None => return,
+        };
+        let up = matches!(direction, ScrollDirection::Up);
+        provider.scroll(up, amount);
+    }
+
+    fn reset_pty_scrollback(&self) {
+        if let Some(session) = self.selected_session() {
+            if let Some(provider) = self.providers.get(&session.id) {
+                provider.set_scrollback(0);
+            }
+        }
     }
 
     fn handle_files_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -569,14 +612,12 @@ impl App {
             KeyCode::Esc => {
                 let _ = provider.write_bytes(b"\x1b");
             }
-            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                let _ = provider.write_bytes(b"\x03");
-            }
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                let _ = provider.write_bytes(b"\x04");
-            }
-            KeyCode::Char('z') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                let _ = provider.write_bytes(b"\x1a");
+            KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                // Map ctrl+a..=ctrl+z to the corresponding control character (0x01..=0x1a).
+                if c.is_ascii_lowercase() {
+                    let ctrl_byte = c as u8 - b'a' + 1;
+                    let _ = provider.write_bytes(&[ctrl_byte]);
+                }
             }
             KeyCode::Char(c) => {
                 let mut buf = [0u8; 4];
@@ -612,6 +653,12 @@ impl App {
             }
             KeyCode::Delete => {
                 let _ = provider.write_bytes(b"\x1b[3~");
+            }
+            KeyCode::PageUp => {
+                let _ = provider.write_bytes(b"\x1b[5~");
+            }
+            KeyCode::PageDown => {
+                let _ = provider.write_bytes(b"\x1b[6~");
             }
             _ => {}
         }
@@ -1712,6 +1759,7 @@ impl App {
         }
 
         let is_input = self.input_target == InputTarget::Agent;
+        let mut scrollback_offset: usize = 0;
 
         // Reserve 2 lines at the bottom for the hint bar (top border + text).
         let hint_height = 2;
@@ -1811,7 +1859,11 @@ impl App {
                     }
                 } else {
                     // Render vt100 screen into ratatui buffer.
-                    let screen = provider.screen();
+                    // Use a single lock to get both screen and scrollback
+                    // offset atomically, avoiding race conditions with the
+                    // background reader thread.
+                    let (screen, sb_offset) = provider.screen_and_scrollback();
+                    scrollback_offset = sb_offset;
                     let buf = frame.buffer_mut();
                     let (screen_rows, screen_cols) = screen.size();
                     for row in 0..screen_rows.min(term_area.height) {
@@ -1893,6 +1945,22 @@ impl App {
                     desc_style,
                 ));
                 Line::from(spans)
+            } else if scrollback_offset > 0 {
+                let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+                let mut spans: Vec<Span> = Vec::new();
+                spans.push(Span::styled(
+                    format!("Scrolled back {scrollback_offset} lines. "),
+                    Style::default().fg(self.theme.hint_key_fg),
+                ));
+                spans.extend(self.theme.dim_key_badge("ctrl+f", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.push(Span::styled(" down, ", desc_style));
+                spans.extend(self.theme.dim_key_badge("ctrl+b", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.push(Span::styled(" up.", desc_style));
+                Line::from(spans)
             } else {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
@@ -1901,7 +1969,15 @@ impl App {
                     spans.extend(self.theme.dim_key_badge("i", Color::Reset));
                     spans.push(Span::styled(" or ", desc_style));
                     spans.extend(self.theme.dim_key_badge("enter", Color::Reset));
-                    spans.push(Span::styled(" to interact with the agent.", desc_style));
+                    spans.push(Span::styled(" to interact with the agent. ", desc_style));
+                    spans.extend(self.theme.dim_key_badge("^B", Color::Reset));
+                    spans.push(Span::styled("/", desc_style));
+                    spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                    spans.push(Span::styled(" ", desc_style));
+                    spans.extend(self.theme.dim_key_badge("^F", Color::Reset));
+                    spans.push(Span::styled("/", desc_style));
+                    spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                    spans.push(Span::styled(" to scroll.", desc_style));
                 } else if session_id.is_some() {
                     spans.push(Span::styled("Agent CLI exited. Press ", desc_style));
                     spans.extend(self.theme.dim_key_badge("r", Color::Reset));
@@ -2133,6 +2209,8 @@ impl App {
                 "Agent pane",
                 &[
                     ("i", "Start a prompt turn for the agent"),
+                    ("^B/PgUp", "Scroll up one page"),
+                    ("^F/PgDn", "Scroll down one page"),
                     ("Esc", "Close diff view"),
                 ],
             ),

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -58,7 +58,7 @@ impl PtyClient {
             .take_writer()
             .context("failed to take PTY writer")?;
 
-        let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 200)));
+        let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 10_000)));
         let exited = Arc::new(AtomicBool::new(false));
         let has_output = Arc::new(AtomicBool::new(false));
 
@@ -124,13 +124,36 @@ impl PtyClient {
         Ok(())
     }
 
-    /// Get a snapshot of the current terminal screen.
-    pub fn screen(&self) -> vt100::Screen {
-        self.parser
-            .lock()
-            .expect("parser mutex poisoned")
-            .screen()
-            .clone()
+    /// Get a snapshot of the terminal screen together with its scrollback
+    /// offset in a single lock acquisition, avoiding race conditions with the
+    /// background reader thread.
+    pub fn screen_and_scrollback(&self) -> (vt100::Screen, usize) {
+        let p = self.parser.lock().expect("parser mutex poisoned");
+        let screen = p.screen().clone();
+        let offset = screen.scrollback();
+        (screen, offset)
+    }
+
+    /// Atomically adjust the scrollback offset by the given amount in the
+    /// given direction, returning the new offset. Uses a single lock to avoid
+    /// races between reading the current offset and writing the new one.
+    pub fn scroll(&self, up: bool, amount: usize) {
+        if let Ok(mut p) = self.parser.lock() {
+            let current = p.screen().scrollback();
+            let new_offset = if up {
+                current.saturating_add(amount)
+            } else {
+                current.saturating_sub(amount)
+            };
+            p.set_scrollback(new_offset);
+        }
+    }
+
+    /// Set the scrollback offset (0 = normal view, positive = scrolled back).
+    pub fn set_scrollback(&self, rows: usize) {
+        if let Ok(mut p) = self.parser.lock() {
+            p.set_scrollback(rows);
+        }
     }
 
     /// Resize the PTY and the internal terminal parser.
@@ -149,7 +172,7 @@ impl PtyClient {
             .context("failed to resize PTY")?;
         if let Ok(mut p) = self.parser.lock() {
             let contents = p.screen().contents_formatted();
-            let mut fresh = vt100::Parser::new(rows, cols, 200);
+            let mut fresh = vt100::Parser::new(rows, cols, 10_000);
             fresh.process(&contents);
             *p = fresh;
         }


### PR DESCRIPTION
## Summary
- Add Ctrl+B/PgUp and Ctrl+F/PgDn to scroll the PTY output one page at a time in non-interactive mode
- Increase scrollback buffer from 200 to 10,000 lines so long agent output is preserved
- Generalize ctrl+key handling in interactive mode to forward all ctrl+a..z as control characters
- Forward PgUp/PgDn escape sequences to the PTY in interactive mode
- Show scrollback hints in the status bar, both when scrolled back and in the default view
- Reset scrollback position when entering interactive mode

## Test plan
- [ ] Run an agent that produces long output, press Ctrl+B to scroll up and Ctrl+F to scroll down
- [ ] Verify PgUp/PgDn work the same way
- [ ] Confirm the hint bar shows scroll position when scrolled back
- [ ] Enter interactive mode and verify scrollback resets to bottom
- [ ] Verify text selection in the terminal still works normally