### PR TITLE
Add scrolling and hint bar to diff viewer, fix vt100 crash

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -172,9 +172,10 @@ impl App {
     }
 
     fn handle_center_key(&mut self, key: KeyEvent) -> Result<()> {
+        let in_diff = matches!(self.center_mode, CenterMode::Diff { .. });
         if let Some(action) = keybindings::lookup(&key, BindingScope::Center) {
             match action {
-                Action::InteractAgent => {
+                Action::InteractAgent if !in_diff => {
                     if self.selected_session().is_some()
                         && self
                             .selected_session()
@@ -192,7 +193,7 @@ impl App {
                         );
                     }
                 }
-                Action::ReconnectAgent => {
+                Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.
                     let has_provider = self
@@ -207,10 +208,21 @@ impl App {
                     }
                 }
                 Action::ScrollPageUp => {
-                    self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        let page = self.last_diff_height.max(1);
+                        *scroll = scroll.saturating_sub(page);
+                    } else if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+                    }
                 }
                 Action::ScrollPageDown => {
-                    self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+                    if let CenterMode::Diff { ref lines, ref mut scroll } = self.center_mode {
+                        let page = self.last_diff_height.max(1);
+                        let max_scroll = (lines.len() as u16).saturating_sub(1);
+                        *scroll = (*scroll + page).min(max_scroll);
+                    } else if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+                    }
                 }
                 _ => {}
             }
@@ -732,12 +744,17 @@ impl App {
                         self.reload_changed_files();
                     }
                 }
+                FocusPane::Center => {
+                    if let CenterMode::Diff { ref lines, ref mut scroll } = self.center_mode {
+                        let max_scroll = (lines.len() as u16).saturating_sub(1);
+                        *scroll = (*scroll + 3).min(max_scroll);
+                    }
+                }
                 FocusPane::Files => {
                     if self.selected_file + 1 < self.changed_files.len() {
                         self.selected_file += 1;
                     }
                 }
-                _ => {}
             },
             MouseEventKind::ScrollUp => match self.focus {
                 FocusPane::Left => {
@@ -746,12 +763,16 @@ impl App {
                         self.reload_changed_files();
                     }
                 }
+                FocusPane::Center => {
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        *scroll = scroll.saturating_sub(3);
+                    }
+                }
                 FocusPane::Files => {
                     if self.selected_file > 0 {
                         self.selected_file -= 1;
                     }
                 }
-                _ => {}
             },
             _ => {}
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -57,6 +57,7 @@ pub struct App {
     pub(crate) providers: HashMap<String, PtyClient>,
     pub(crate) create_agent_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
+    pub(crate) last_diff_height: u16,
     pub(crate) theme: Theme,
     pub(crate) tick_count: u64,
     pub(crate) watched_worktree: Arc<Mutex<Option<PathBuf>>>,
@@ -93,7 +94,10 @@ impl FocusPane {
 #[derive(Clone, Debug)]
 pub(crate) enum CenterMode {
     Agent,
-    Diff(Vec<Line<'static>>),
+    Diff {
+        lines: Vec<Line<'static>>,
+        scroll: u16,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -207,6 +211,7 @@ impl App {
             providers: HashMap::new(),
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
+            last_diff_height: 0,
             theme: Theme::default_dark(),
             tick_count: 0,
             watched_worktree: Arc::clone(&watched_worktree),
@@ -274,7 +279,7 @@ impl App {
             self.set_info("Closed overlay.");
             return true;
         }
-        if matches!(self.center_mode, CenterMode::Diff(_)) {
+        if matches!(self.center_mode, CenterMode::Diff { .. }) {
             self.center_mode = CenterMode::Agent;
             self.focus = FocusPane::Files;
             self.set_info("Returned to agent view.");

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -208,21 +208,82 @@ impl App {
     }
 
     fn render_center(&mut self, frame: &mut Frame, area: Rect) {
-        let title = match self.center_mode {
-            CenterMode::Agent => "Agent",
-            CenterMode::Diff(_) => "Diff",
-        };
         let focused = self.focus == FocusPane::Center;
         match &self.center_mode {
-            CenterMode::Diff(diff_lines) => {
-                Paragraph::new(diff_lines.clone())
-                    .block(self.themed_block(title, focused))
-                    .wrap(Wrap { trim: false })
-                    .render(area, frame.buffer_mut());
+            CenterMode::Diff { .. } => {
+                self.render_diff(frame, area, focused);
             }
             CenterMode::Agent => {
-                self.render_agent_terminal(frame, area, title, focused);
+                self.render_agent_terminal(frame, area, "Agent", focused);
             }
+        }
+    }
+
+    fn render_diff(&mut self, frame: &mut Frame, area: Rect, focused: bool) {
+        let (lines, scroll) = match &self.center_mode {
+            CenterMode::Diff { lines, scroll } => (lines.clone(), *scroll),
+            _ => return,
+        };
+
+        let outer_block = self.themed_block("Diff", focused);
+        let inner = outer_block.inner(area);
+        outer_block.render(area, frame.buffer_mut());
+
+        if inner.height < 3 || inner.width < 4 {
+            return;
+        }
+
+        let hint_height = 2;
+        let [content_area, hint_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(hint_height)])
+            .areas(inner);
+
+        self.last_diff_height = content_area.height;
+
+        Paragraph::new(lines.clone())
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0))
+            .render(content_area, frame.buffer_mut());
+
+        // Hint bar with top border (same style as agent terminal).
+        if hint_area.height > 0 {
+            let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+            let mut spans: Vec<Span> = Vec::new();
+
+            if scroll > 0 {
+                spans.push(Span::styled(
+                    format!("Scrolled back {scroll} lines. "),
+                    Style::default().fg(self.theme.hint_key_fg),
+                ));
+                spans.extend(self.theme.dim_key_badge("ctrl+f", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.push(Span::styled(" down, ", desc_style));
+                spans.extend(self.theme.dim_key_badge("ctrl+b", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.push(Span::styled(" up. ", desc_style));
+            } else {
+                spans.extend(self.theme.dim_key_badge("^B", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.push(Span::styled(" ", desc_style));
+                spans.extend(self.theme.dim_key_badge("^F", Color::Reset));
+                spans.push(Span::styled("/", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.push(Span::styled(" to scroll. ", desc_style));
+            }
+            spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
+            spans.push(Span::styled(" close diff.", desc_style));
+
+            Paragraph::new(Line::from(spans))
+                .block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_style(Style::default().fg(self.theme.border_normal)),
+                )
+                .render(hint_area, frame.buffer_mut());
         }
     }
 

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -343,7 +343,7 @@ impl App {
         };
         let output =
             crate::diff::diff_file(Path::new(&session.worktree_path), &file.path, &self.theme)?;
-        self.center_mode = CenterMode::Diff(output.lines);
+        self.center_mode = CenterMode::Diff { lines: output.lines, scroll: 0 };
         self.focus = FocusPane::Center;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Adds keyboard scrolling (Ctrl+B/F, PgUp/PgDn) and mouse wheel scrolling to the diff viewer
- Adds a hint bar at the bottom of the diff view matching the agent terminal's styling, showing scroll position and available keys (including Esc to close)
- Fixes a vt100 subtract-with-overflow crash when pressing scroll keys while viewing a diff by routing scroll actions based on `CenterMode` instead of always targeting the PTY
- Guards `InteractAgent`/`ReconnectAgent` actions to no-op in diff mode

## Test plan
- [ ] Open a diff, press Ctrl+B/F or PgUp/PgDn — diff scrolls with hint bar visible
- [ ] Hint bar shows scroll position when scrolled back, Esc hint always visible
- [ ] Use mouse wheel on a diff — scrolls 3 lines per tick
- [ ] Switch to agent view — PTY scroll still works as before
- [ ] Open a diff while an agent is running, press scroll keys — no crash