### PR TITLE
Add VS Code-style git staging UI to right pane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ When making changes, edit only the relevant submodule. If you need to add a new 
 ## Recommendations For Future Changes
 
 - Keep the status line centralized. New async operations should report progress through the shared status API, not ad hoc strings.
+- Status line messages must be verbose and actionable. Do not write terse messages like "Done." or "Pushed." — instead explain what happened and, when relevant, what the user can do next. Example: "Changes committed successfully. Press ^U to push to remote." rather than "Committed."
 - Code must be production ready and modular to allow future Open Source contributors to integrate new features with ease. Do not take shortcuts.
 - Route new modal UI through `PromptState` so `Esc` keeps working uniformly.
 - Prefer command-palette actions over adding many more global hotkeys.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -402,6 +402,14 @@ impl App {
             }
         }
         self.reload_changed_files();
+        // If the section we were in is now empty, move to the other one.
+        if self.right_section == RightSection::Staged && self.staged_files.is_empty() {
+            self.right_section = RightSection::Unstaged;
+            self.clamp_files_cursor();
+        } else if self.right_section == RightSection::Unstaged && self.unstaged_files.is_empty() {
+            self.right_section = RightSection::Staged;
+            self.clamp_files_cursor();
+        }
         Ok(())
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -14,6 +14,13 @@ impl App {
         if self.input_target == InputTarget::Agent {
             return self.handle_agent_input(key);
         }
+        // When typing a commit message, route all keys to the commit input
+        // handler so that q, ?, [ etc. are typed instead of triggering
+        // global shortcuts.
+        if self.input_target == InputTarget::CommitMessage {
+            self.handle_commit_input_key(key)?;
+            return Ok(false);
+        }
         if let Some(action) = keybindings::lookup(&key, BindingScope::Global) {
             match action {
                 Action::Quit => {
@@ -39,10 +46,46 @@ impl App {
                     self.set_info("Command palette opened.");
                 }
                 Action::FocusNext => {
-                    self.focus = self.focus.next();
+                    let has_staged = !self.staged_files.is_empty();
+                    if self.focus == FocusPane::Files {
+                        match self.right_section.next(has_staged) {
+                            Some(next) => {
+                                self.right_section = next;
+                                self.clamp_files_cursor();
+                            }
+                            None => {
+                                self.focus = self.focus.next();
+                            }
+                        }
+                    } else {
+                        self.focus = self.focus.next();
+                        if self.focus == FocusPane::Files {
+                            self.right_section = RightSection::first();
+                            self.clamp_files_cursor();
+                        }
+                    }
+                    self.input_target = InputTarget::None;
                 }
                 Action::FocusPrev => {
-                    self.focus = self.focus.previous();
+                    let has_staged = !self.staged_files.is_empty();
+                    if self.focus == FocusPane::Files {
+                        match self.right_section.previous() {
+                            Some(prev) => {
+                                self.right_section = prev;
+                                self.clamp_files_cursor();
+                            }
+                            None => {
+                                self.focus = self.focus.previous();
+                            }
+                        }
+                    } else {
+                        self.focus = self.focus.previous();
+                        if self.focus == FocusPane::Files {
+                            self.right_section = RightSection::last(has_staged);
+                            self.clamp_files_cursor();
+                        }
+                    }
+                    self.input_target = InputTarget::None;
                 }
                 Action::ToggleSidebar => {
                     self.left_collapsed = !self.left_collapsed;
@@ -249,21 +292,234 @@ impl App {
     }
 
     fn handle_files_key(&mut self, key: KeyEvent) -> Result<()> {
-        if let Some(action) = keybindings::lookup(&key, BindingScope::Files) {
-            match action {
-                Action::MoveDown => {
-                    if self.selected_file + 1 < self.changed_files.len() {
-                        self.selected_file += 1;
-                    }
+        match key.code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                let len = self.current_files_len();
+                if self.files_index + 1 < len {
+                    self.files_index += 1;
                 }
-                Action::MoveUp => {
-                    if self.selected_file > 0 {
-                        self.selected_file -= 1;
-                    }
-                }
-                Action::OpenDiff => self.open_diff_for_selected_file()?,
-                _ => {}
             }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.files_index > 0 {
+                    self.files_index -= 1;
+                }
+            }
+            KeyCode::Char(' ') => {
+                self.toggle_stage_selected_file()?;
+            }
+            KeyCode::Char('c') if !self.staged_files.is_empty() => {
+                self.execute_commit()?;
+            }
+            KeyCode::Enter => self.open_diff_for_selected_file()?,
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.confirm_discard_selected_file()?;
+            }
+            KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.trigger_ai_commit_message()?;
+            }
+            KeyCode::Char('i') if !self.staged_files.is_empty() => {
+                self.input_target = InputTarget::CommitMessage;
+            }
+            KeyCode::Char('u') => {
+                self.push_to_remote()?;
+            }
+            KeyCode::Char('p') => {
+                self.pull_from_remote()?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_commit_input_key(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.input_target = InputTarget::None;
+            }
+            KeyCode::Esc => {
+                self.input_target = InputTarget::None;
+            }
+            KeyCode::Enter => {
+                self.commit_input.insert(self.commit_input_cursor, '\n');
+                self.commit_input_cursor += 1;
+            }
+            KeyCode::Char(ch) => {
+                self.commit_input.insert(self.commit_input_cursor, ch);
+                self.commit_input_cursor += ch.len_utf8();
+            }
+            KeyCode::Backspace => {
+                if self.commit_input_cursor > 0 {
+                    let prev = self.commit_input[..self.commit_input_cursor]
+                        .char_indices()
+                        .next_back()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                    self.commit_input.remove(prev);
+                    self.commit_input_cursor = prev;
+                }
+            }
+            KeyCode::Left => {
+                if self.commit_input_cursor > 0 {
+                    self.commit_input_cursor = self.commit_input[..self.commit_input_cursor]
+                        .char_indices()
+                        .next_back()
+                        .map(|(i, _)| i)
+                        .unwrap_or(0);
+                }
+            }
+            KeyCode::Right => {
+                if self.commit_input_cursor < self.commit_input.len() {
+                    self.commit_input_cursor = self.commit_input[self.commit_input_cursor..]
+                        .char_indices()
+                        .nth(1)
+                        .map(|(i, _)| self.commit_input_cursor + i)
+                        .unwrap_or(self.commit_input.len());
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn toggle_stage_selected_file(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session() else {
+            self.set_error("Select a session first.");
+            return Ok(());
+        };
+        let worktree = PathBuf::from(&session.worktree_path);
+        let file = match self.right_section {
+            RightSection::Staged => self.staged_files.get(self.files_index),
+            RightSection::Unstaged => self.unstaged_files.get(self.files_index),
+        };
+        let Some(file) = file else { return Ok(()) };
+        let path = file.path.clone();
+        match self.right_section {
+            RightSection::Unstaged => {
+                git::stage_file(&worktree, &path)?;
+            }
+            RightSection::Staged => {
+                git::unstage_file(&worktree, &path)?;
+            }
+        }
+        self.reload_changed_files();
+        Ok(())
+    }
+
+    fn confirm_discard_selected_file(&mut self) -> Result<()> {
+        let file = match self.right_section {
+            RightSection::Unstaged => self.unstaged_files.get(self.files_index),
+            RightSection::Staged => {
+                self.set_error("Unstage the file first to discard changes.");
+                return Ok(());
+            }
+        };
+        let Some(file) = file else { return Ok(()) };
+        self.prompt = PromptState::ConfirmDiscardFile {
+            file_path: file.path.clone(),
+            is_untracked: file.status == "?",
+            confirm_selected: false,
+        };
+        Ok(())
+    }
+
+    fn trigger_ai_commit_message(&mut self) -> Result<()> {
+        if self.staged_files.is_empty() {
+            self.set_error("Stage files first.");
+            return Ok(());
+        }
+        if self.commit_generating {
+            return Ok(());
+        }
+        let Some(session) = self.selected_session() else {
+            self.set_error("Select a session first.");
+            return Ok(());
+        };
+        let worktree = PathBuf::from(&session.worktree_path);
+        let diff = git::staged_diff(&worktree)?;
+        let diff = if diff.len() > 50_000 {
+            diff[..50_000].to_string()
+        } else {
+            diff
+        };
+        let cfg = provider_config(&self.config, &session.provider);
+        let prov = provider::create_provider(&session.provider, cfg);
+        let tx = self.worker_tx.clone();
+        self.commit_generating = true;
+        self.set_busy("Generating AI commit message from staged diff…");
+        thread::spawn(move || {
+            let prompt = format!(
+                "Write a git commit message for the following diff.\n\n\
+                 Rules:\n\
+                 - Subject line: imperative mood, max 72 chars, no period. Summarize WHAT changed and WHY.\n\
+                 - If the change is simple, output ONLY the subject line with no body.\n\
+                 - If the change touches multiple concerns, add a blank line then a body with short bullet points \
+                 (one per logical change, each under 80 chars).\n\
+                 - No preamble, no quotes, no markdown fences. Output ONLY the raw commit message text.\n\
+                 - Do not repeat filenames unless essential for clarity.\n\
+                 - Focus on intent and impact, not mechanical description of lines added/removed.\n\n\
+                 Diff:\n{diff}"
+            );
+            match prov.run_oneshot(&prompt, &worktree) {
+                Ok(msg) => { let _ = tx.send(WorkerEvent::CommitMessageGenerated(msg)); }
+                Err(e) => { let _ = tx.send(WorkerEvent::CommitMessageFailed(e.to_string())); }
+            }
+        });
+        Ok(())
+    }
+
+    fn execute_commit(&mut self) -> Result<()> {
+        if self.staged_files.is_empty() {
+            self.set_error("No staged changes to commit.");
+            return Ok(());
+        }
+        if self.commit_input.trim().is_empty() {
+            self.set_error("Enter a commit message first.");
+            return Ok(());
+        }
+        let Some(session) = self.selected_session() else {
+            self.set_error("Select a session first.");
+            return Ok(());
+        };
+        let worktree = PathBuf::from(&session.worktree_path);
+        match git::commit(&worktree, &self.commit_input) {
+            Ok(_) => {
+                self.commit_input.clear();
+                self.commit_input_cursor = 0;
+                self.set_info("Changes committed successfully. Press u to push to remote.");
+                self.reload_changed_files();
+            }
+            Err(e) => self.set_error(format!("Commit failed: {e}")),
+        }
+        Ok(())
+    }
+
+    fn push_to_remote(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session() else {
+            self.set_error("Select a session first.");
+            return Ok(());
+        };
+        let worktree = PathBuf::from(&session.worktree_path);
+        self.set_busy("Pushing to remote…");
+        match git::push(&worktree) {
+            Ok(_) => self.set_info("Pushed to remote successfully."),
+            Err(e) => self.set_error(format!("Push to remote failed: {e}")),
+        }
+        Ok(())
+    }
+
+    fn pull_from_remote(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session() else {
+            self.set_error("Select a session first.");
+            return Ok(());
+        };
+        let worktree = PathBuf::from(&session.worktree_path);
+        self.set_busy("Pulling latest changes from remote…");
+        match git::pull_current_branch(&worktree) {
+            Ok(_) => {
+                self.set_info("Pulled latest changes from remote successfully.");
+                self.reload_changed_files();
+            }
+            Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
         }
         Ok(())
     }
@@ -701,6 +957,41 @@ impl App {
             }
         }
 
+        if let PromptState::ConfirmDiscardFile {
+            file_path,
+            is_untracked,
+            confirm_selected,
+        } = &mut self.prompt
+        {
+            match key.code {
+                KeyCode::Esc => self.prompt = PromptState::None,
+                KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::Char('h') | KeyCode::Char('l') => {
+                    *confirm_selected = !*confirm_selected;
+                }
+                KeyCode::Enter => {
+                    if *confirm_selected {
+                        let fp = file_path.clone();
+                        let ut = *is_untracked;
+                        self.prompt = PromptState::None;
+                        if let Some(session) = self.selected_session() {
+                            let worktree = PathBuf::from(&session.worktree_path);
+                            match git::discard_file(&worktree, &fp, ut) {
+                                Ok(()) => {
+                                    self.set_info(format!("Discarded changes to \"{fp}\". File restored to last committed state."));
+                                    self.reload_changed_files();
+                                }
+                                Err(e) => self.set_error(format!("Discard failed: {e}")),
+                            }
+                        }
+                    } else {
+                        self.prompt = PromptState::None;
+                    }
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         Ok(false)
     }
 
@@ -752,8 +1043,8 @@ impl App {
                     }
                 }
                 FocusPane::Files => {
-                    if self.selected_file + 1 < self.changed_files.len() {
-                        self.selected_file += 1;
+                    if self.files_index + 1 < self.current_files_len() {
+                        self.files_index += 1;
                     }
                 }
             },
@@ -770,8 +1061,8 @@ impl App {
                     }
                 }
                 FocusPane::Files => {
-                    if self.selected_file > 0 {
-                        self.selected_file -= 1;
+                    if self.files_index > 0 {
+                        self.files_index -= 1;
                     }
                 }
             },

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -292,6 +292,29 @@ impl App {
     }
 
     fn handle_files_key(&mut self, key: KeyEvent) -> Result<()> {
+        // When hovering over the commit input section, i/Enter engages it.
+        if self.right_section == RightSection::CommitInput {
+            match key.code {
+                KeyCode::Char('i') | KeyCode::Enter => {
+                    self.input_target = InputTarget::CommitMessage;
+                }
+                KeyCode::Char('c') if !self.staged_files.is_empty() => {
+                    self.execute_commit()?;
+                }
+                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.trigger_ai_commit_message()?;
+                }
+                KeyCode::Char('u') => {
+                    self.push_to_remote()?;
+                }
+                KeyCode::Char('p') => {
+                    self.pull_from_remote()?;
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
+
         match key.code {
             KeyCode::Char('j') | KeyCode::Down => {
                 let len = self.current_files_len();

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -390,6 +390,7 @@ impl App {
         let file = match self.right_section {
             RightSection::Staged => self.staged_files.get(self.files_index),
             RightSection::Unstaged => self.unstaged_files.get(self.files_index),
+            RightSection::CommitInput => return Ok(()),
         };
         let Some(file) = file else { return Ok(()) };
         let path = file.path.clone();
@@ -400,6 +401,7 @@ impl App {
             RightSection::Staged => {
                 git::unstage_file(&worktree, &path)?;
             }
+            RightSection::CommitInput => {}
         }
         self.reload_changed_files();
         // If the section we were in is now empty, move to the other one.
@@ -420,6 +422,7 @@ impl App {
                 self.set_error("Unstage the file first to discard changes.");
                 return Ok(());
             }
+            RightSection::CommitInput => return Ok(()),
         };
         let Some(file) = file else { return Ok(()) };
         self.prompt = PromptState::ConfirmDiscardFile {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -437,7 +437,11 @@ impl App {
         let worktree = PathBuf::from(&session.worktree_path);
         let diff = git::staged_diff(&worktree)?;
         let diff = if diff.len() > 50_000 {
-            diff[..50_000].to_string()
+            let mut end = 50_000;
+            while !diff.is_char_boundary(end) {
+                end -= 1;
+            }
+            diff[..end].to_string()
         } else {
             diff
         };
@@ -486,7 +490,7 @@ impl App {
                 self.commit_input.clear();
                 self.commit_input_cursor = 0;
                 self.commit_scroll = 0;
-                self.set_info("Changes committed successfully. Press u to push to remote.");
+                self.set_info("Changes committed successfully. Press u to push to remote, or ^G to generate an AI message.");
                 self.reload_changed_files();
             }
             Err(e) => self.set_error(format!("Commit failed: {e}")),
@@ -500,11 +504,12 @@ impl App {
             return Ok(());
         };
         let worktree = PathBuf::from(&session.worktree_path);
+        let tx = self.worker_tx.clone();
         self.set_busy("Pushing to remote…");
-        match git::push(&worktree) {
-            Ok(_) => self.set_info("Pushed to remote successfully."),
-            Err(e) => self.set_error(format!("Push to remote failed: {e}")),
-        }
+        thread::spawn(move || {
+            let result = git::push(&worktree).map(|_| ()).map_err(|e| e.to_string());
+            let _ = tx.send(WorkerEvent::PushCompleted(result));
+        });
         Ok(())
     }
 
@@ -514,14 +519,12 @@ impl App {
             return Ok(());
         };
         let worktree = PathBuf::from(&session.worktree_path);
+        let tx = self.worker_tx.clone();
         self.set_busy("Pulling latest changes from remote…");
-        match git::pull_current_branch(&worktree) {
-            Ok(_) => {
-                self.set_info("Pulled latest changes from remote successfully.");
-                self.reload_changed_files();
-            }
-            Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
-        }
+        thread::spawn(move || {
+            let result = git::pull_current_branch(&worktree).map(|_| ()).map_err(|e| e.to_string());
+            let _ = tx.send(WorkerEvent::PullCompleted(result));
+        });
         Ok(())
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -485,6 +485,7 @@ impl App {
             Ok(_) => {
                 self.commit_input.clear();
                 self.commit_input_cursor = 0;
+                self.commit_scroll = 0;
                 self.set_info("Changes committed successfully. Press u to push to remote.");
                 self.reload_changed_files();
             }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1034,14 +1034,27 @@ impl App {
     }
 
     fn handle_resize_key(&mut self, key: KeyEvent) {
-        match key.code {
-            KeyCode::Char('h') | KeyCode::Left => {
-                self.left_width_pct = self.left_width_pct.saturating_sub(2).max(14)
+        if self.focus == FocusPane::Files {
+            // When focused on the right pane, resize it instead of the left.
+            match key.code {
+                KeyCode::Char('h') | KeyCode::Left => {
+                    self.right_width_pct = self.right_width_pct.saturating_add(2).min(50)
+                }
+                KeyCode::Char('l') | KeyCode::Right => {
+                    self.right_width_pct = self.right_width_pct.saturating_sub(2).max(14)
+                }
+                _ => {}
             }
-            KeyCode::Char('l') | KeyCode::Right => {
-                self.left_width_pct = self.left_width_pct.saturating_add(2).min(38)
+        } else {
+            match key.code {
+                KeyCode::Char('h') | KeyCode::Left => {
+                    self.left_width_pct = self.left_width_pct.saturating_sub(2).max(14)
+                }
+                KeyCode::Char('l') | KeyCode::Right => {
+                    self.left_width_pct = self.left_width_pct.saturating_add(2).min(38)
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -100,23 +100,27 @@ impl FocusPane {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum RightSection {
-    Staged,
     Unstaged,
+    Staged,
+    CommitInput,
 }
 
 impl RightSection {
     /// Returns the next section, or `None` to exit the pane.
-    /// Order: Unstaged (top) → Staged (bottom).
+    /// Order: Unstaged → Staged → CommitInput.
     pub(crate) fn next(self, has_staged: bool) -> Option<Self> {
         match self {
             Self::Unstaged if has_staged => Some(Self::Staged),
-            Self::Unstaged | Self::Staged => None,
+            Self::Unstaged => None,
+            Self::Staged => Some(Self::CommitInput),
+            Self::CommitInput => None,
         }
     }
 
     /// Returns the previous section, or `None` to exit the pane.
     pub(crate) fn previous(self) -> Option<Self> {
         match self {
+            Self::CommitInput => Some(Self::Staged),
             Self::Staged => Some(Self::Unstaged),
             Self::Unstaged => None,
         }
@@ -129,7 +133,7 @@ impl RightSection {
 
     pub(crate) fn last(has_staged: bool) -> Self {
         if has_staged {
-            Self::Staged
+            Self::CommitInput
         } else {
             Self::Unstaged
         }
@@ -475,6 +479,7 @@ impl App {
         match self.right_section {
             RightSection::Staged => self.staged_files.get(self.files_index),
             RightSection::Unstaged => self.unstaged_files.get(self.files_index),
+            RightSection::CommitInput => None,
         }
     }
 
@@ -482,10 +487,14 @@ impl App {
         match self.right_section {
             RightSection::Staged => self.staged_files.len(),
             RightSection::Unstaged => self.unstaged_files.len(),
+            RightSection::CommitInput => 0,
         }
     }
 
     pub(crate) fn clamp_files_cursor(&mut self) {
+        if self.right_section == RightSection::CommitInput {
+            return;
+        }
         let len = self.current_files_len();
         if len == 0 {
             self.files_index = 0;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,6 +27,7 @@ use crate::config::{
 use crate::git;
 use crate::keybindings::{self, Action, BindingScope, HintContext};
 use crate::logger;
+use crate::provider;
 use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
 use crate::pty::PtyClient;
 use crate::statusline::{StatusLine, StatusTone};
@@ -39,9 +40,15 @@ pub struct App {
     pub(crate) session_store: SessionStore,
     pub(crate) projects: Vec<Project>,
     pub(crate) sessions: Vec<AgentSession>,
-    pub(crate) changed_files: Vec<ChangedFile>,
+    pub(crate) staged_files: Vec<ChangedFile>,
+    pub(crate) unstaged_files: Vec<ChangedFile>,
     pub(crate) selected_left: usize,
-    pub(crate) selected_file: usize,
+    pub(crate) right_section: RightSection,
+    pub(crate) files_index: usize,
+    pub(crate) commit_input: String,
+    pub(crate) commit_input_cursor: usize,
+    pub(crate) commit_scroll: u16,
+    pub(crate) commit_generating: bool,
     pub(crate) left_width_pct: u16,
     pub(crate) right_width_pct: u16,
     pub(crate) focus: FocusPane,
@@ -91,6 +98,44 @@ impl FocusPane {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RightSection {
+    Staged,
+    Unstaged,
+}
+
+impl RightSection {
+    /// Returns the next section, or `None` to exit the pane.
+    /// Order: Unstaged (top) → Staged (bottom).
+    pub(crate) fn next(self, has_staged: bool) -> Option<Self> {
+        match self {
+            Self::Unstaged if has_staged => Some(Self::Staged),
+            Self::Unstaged | Self::Staged => None,
+        }
+    }
+
+    /// Returns the previous section, or `None` to exit the pane.
+    pub(crate) fn previous(self) -> Option<Self> {
+        match self {
+            Self::Staged => Some(Self::Unstaged),
+            Self::Unstaged => None,
+        }
+    }
+
+    /// First section when entering the pane (always Changes/Unstaged on top).
+    pub(crate) fn first() -> Self {
+        Self::Unstaged
+    }
+
+    pub(crate) fn last(has_staged: bool) -> Self {
+        if has_staged {
+            Self::Staged
+        } else {
+            Self::Unstaged
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum CenterMode {
     Agent,
@@ -129,6 +174,11 @@ pub(crate) enum PromptState {
         active_count: usize,
         confirm_selected: bool, // false = Cancel (default), true = Quit
     },
+    ConfirmDiscardFile {
+        file_path: String,
+        is_untracked: bool,
+        confirm_selected: bool, // false = Cancel (default), true = Discard
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -142,6 +192,7 @@ pub(crate) struct BrowserEntry {
 pub(crate) enum InputTarget {
     None,
     Agent,
+    CommitMessage,
 }
 
 #[derive(Clone, Copy)]
@@ -164,7 +215,12 @@ pub(crate) enum WorkerEvent {
         pty_size: (u16, u16), // (rows, cols) the PTY was spawned with
     },
     CreateAgentFailed(String),
-    ChangedFilesReady(Vec<ChangedFile>),
+    ChangedFilesReady {
+        staged: Vec<ChangedFile>,
+        unstaged: Vec<ChangedFile>,
+    },
+    CommitMessageGenerated(String),
+    CommitMessageFailed(String),
     BrowserEntriesReady {
         dir: PathBuf,
         entries: Vec<BrowserEntry>,
@@ -195,9 +251,15 @@ impl App {
             session_store,
             projects,
             sessions,
-            changed_files: Vec::new(),
+            staged_files: Vec::new(),
+            unstaged_files: Vec::new(),
             selected_left: 0,
-            selected_file: 0,
+            right_section: RightSection::Unstaged,
+            files_index: 0,
+            commit_input: String::new(),
+            commit_input_cursor: 0,
+            commit_scroll: 0,
+            commit_generating: false,
             left_collapsed: false,
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
@@ -399,11 +461,34 @@ impl App {
         if let Ok(mut guard) = self.watched_worktree.lock() {
             *guard = worktree.clone();
         }
-        self.changed_files = worktree
+        let (staged, unstaged) = worktree
             .and_then(|p| git::changed_files(&p).ok())
             .unwrap_or_default();
-        if self.selected_file >= self.changed_files.len() {
-            self.selected_file = self.changed_files.len().saturating_sub(1);
+        self.staged_files = staged;
+        self.unstaged_files = unstaged;
+        self.clamp_files_cursor();
+    }
+
+    pub(crate) fn selected_changed_file(&self) -> Option<&ChangedFile> {
+        match self.right_section {
+            RightSection::Staged => self.staged_files.get(self.files_index),
+            RightSection::Unstaged => self.unstaged_files.get(self.files_index),
+        }
+    }
+
+    pub(crate) fn current_files_len(&self) -> usize {
+        match self.right_section {
+            RightSection::Staged => self.staged_files.len(),
+            RightSection::Unstaged => self.unstaged_files.len(),
+        }
+    }
+
+    pub(crate) fn clamp_files_cursor(&mut self) {
+        let len = self.current_files_len();
+        if len == 0 {
+            self.files_index = 0;
+        } else if self.files_index >= len {
+            self.files_index = len.saturating_sub(1);
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -221,6 +221,8 @@ pub(crate) enum WorkerEvent {
     },
     CommitMessageGenerated(String),
     CommitMessageFailed(String),
+    PushCompleted(Result<(), String>),
+    PullCompleted(Result<(), String>),
     BrowserEntriesReady {
         dir: PathBuf,
         entries: Vec<BrowserEntry>,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -500,11 +500,10 @@ impl App {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
                 if session_active {
-                    spans.push(Span::styled("Press ", desc_style));
                     spans.extend(self.theme.dim_key_badge("i", Color::Reset));
                     spans.push(Span::styled(" or ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("enter", Color::Reset));
-                    spans.push(Span::styled(" to interact with the agent. ", desc_style));
+                    spans.extend(self.theme.dim_key_badge("Enter", Color::Reset));
+                    spans.push(Span::styled(" to interact. ", desc_style));
                     spans.extend(self.theme.dim_key_badge("^B", Color::Reset));
                     spans.push(Span::styled("/", desc_style));
                     spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1535,7 +1535,7 @@ impl App {
                     Line::from(""),
                     Line::from(Span::styled(
                         " This action cannot be undone.",
-                        Style::default().fg(Color::Yellow),
+                        Style::default().fg(self.theme.warning_fg),
                     )),
                 ];
                 Paragraph::new(lines)
@@ -1561,12 +1561,12 @@ impl App {
                 };
 
                 let (cancel_border, cancel_fg) = if !confirm_selected {
-                    (Color::Cyan, Color::White)
+                    (self.theme.button_confirm_border, self.theme.button_active_fg)
                 } else {
                     (self.theme.border_normal, self.theme.hint_desc_fg)
                 };
                 let (discard_border, discard_fg) = if *confirm_selected {
-                    (Color::Red, Color::White)
+                    (self.theme.button_danger_border, self.theme.button_active_fg)
                 } else {
                     (self.theme.border_normal, self.theme.hint_desc_fg)
                 };

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -586,8 +586,8 @@ impl App {
             pane_focused,
         );
 
-        // Commit input — untitled block.
-        self.render_commit_input_inner(frame, commit_area);
+        // Commit input block.
+        self.render_commit_input_inner(frame, commit_area, pane_focused);
     }
 
     fn render_file_list(
@@ -676,11 +676,12 @@ impl App {
         );
     }
 
-    /// Render the commit input as its own bordered block (no title).
-    fn render_commit_input_inner(&mut self, frame: &mut Frame, area: Rect) {
+    /// Render the commit input as its own bordered block.
+    fn render_commit_input_inner(&mut self, frame: &mut Frame, area: Rect, pane_focused: bool) {
+        let is_active_section = pane_focused && self.right_section == RightSection::CommitInput;
         let focused = self.input_target == InputTarget::CommitMessage;
 
-        let block = self.themed_block("", focused);
+        let block = self.themed_block("Commit Message", is_active_section || focused);
         let inner = block.inner(area);
         block.render(area, frame.buffer_mut());
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -534,15 +534,79 @@ impl App {
         }
     }
 
-    fn render_files(&self, frame: &mut Frame, area: Rect) {
+    fn render_files(&mut self, frame: &mut Frame, area: Rect) {
+        let has_staged = !self.staged_files.is_empty();
+        let focused = self.focus == FocusPane::Files;
+
+        if has_staged {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Min(3), // Changes (unstaged) — always on top
+                    Constraint::Min(3), // Staged Changes (with commit input)
+                ])
+                .split(area);
+            self.render_file_list(
+                frame,
+                chunks[0],
+                "Changes",
+                &self.unstaged_files,
+                RightSection::Unstaged,
+                focused,
+            );
+            self.render_staged_with_commit(frame, chunks[1], focused);
+        } else {
+            self.render_file_list(
+                frame,
+                area,
+                "Changes",
+                &self.unstaged_files,
+                RightSection::Unstaged,
+                focused,
+            );
+        }
+    }
+
+    /// Render the "Staged Changes" file list and the commit input as two
+    /// separate bordered blocks (bubbles).
+    fn render_staged_with_commit(&mut self, frame: &mut Frame, area: Rect, pane_focused: bool) {
+        let commit_height = 10u16;
+        let [files_area, commit_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(3), Constraint::Length(commit_height)])
+            .areas(area);
+
+        // Staged files — normal titled block.
+        self.render_file_list(
+            frame,
+            files_area,
+            "Staged Changes",
+            &self.staged_files,
+            RightSection::Staged,
+            pane_focused,
+        );
+
+        // Commit input — untitled block.
+        self.render_commit_input_inner(frame, commit_area);
+    }
+
+    fn render_file_list(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        title_prefix: &str,
+        files: &[ChangedFile],
+        section: RightSection,
+        pane_focused: bool,
+    ) {
         let inner_width = area.width.saturating_sub(2) as usize; // minus borders
+        let is_active_section = pane_focused && self.right_section == section;
         let sel_style = self.theme.selection_style();
-        let items = self
-            .changed_files
+        let items = files
             .iter()
             .enumerate()
             .map(|(index, file)| {
-                let is_selected = index == self.selected_file;
+                let is_selected = is_active_section && index == self.files_index;
 
                 // Build the right-aligned stats string, e.g. "+12 -3".
                 let stats = format_line_stats(file.additions, file.deletions);
@@ -597,15 +661,133 @@ impl App {
                 ListItem::new(Line::from(spans))
             })
             .collect::<Vec<_>>();
-        let focused = self.focus == FocusPane::Files;
-        let title = format!("Changed Files ({})", self.changed_files.len());
-        let mut state = ListState::default().with_selected(Some(self.selected_file));
+        let title = format!("{title_prefix} ({})", files.len());
+        let selected = if is_active_section {
+            Some(self.files_index)
+        } else {
+            None
+        };
+        let mut state = ListState::default().with_selected(selected);
         StatefulWidget::render(
-            List::new(items).block(self.themed_block(&title, focused)),
+            List::new(items).block(self.themed_block(&title, is_active_section)),
             area,
             frame.buffer_mut(),
             &mut state,
         );
+    }
+
+    /// Render the commit input as its own bordered block (no title).
+    fn render_commit_input_inner(&mut self, frame: &mut Frame, area: Rect) {
+        let focused = self.input_target == InputTarget::CommitMessage;
+
+        let block = self.themed_block("", focused);
+        let inner = block.inner(area);
+        block.render(area, frame.buffer_mut());
+
+        // Reserve 1 line at the bottom for the hint bar.
+        let [text_area, hint_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .areas(inner);
+
+        if self.commit_generating {
+            let dots = ".".repeat((self.tick_count as usize / 5) % 4);
+            let text = format!("Generating commit message{dots}");
+            Paragraph::new(text)
+                .style(Style::default().fg(self.theme.hint_desc_fg))
+                .render(text_area, frame.buffer_mut());
+        } else if self.commit_input.is_empty() && !focused {
+            // Placeholder text when not engaged.
+        } else {
+            let display_text = if self.commit_input.is_empty() {
+                "Type your commit message…"
+            } else {
+                &self.commit_input
+            };
+            let style = if self.commit_input.is_empty() {
+                Style::default().fg(self.theme.hint_desc_fg)
+            } else {
+                Style::default()
+            };
+
+            let visible_h = text_area.height;
+            let text_w = text_area.width as usize;
+            if text_w > 0 && !self.commit_input.is_empty() {
+                let mut row: u16 = 0;
+                let mut col: usize = 0;
+                for (i, ch) in self.commit_input.char_indices() {
+                    if i == self.commit_input_cursor {
+                        break;
+                    }
+                    if ch == '\n' {
+                        row += 1;
+                        col = 0;
+                    } else {
+                        col += 1;
+                        if col >= text_w {
+                            row += 1;
+                            col = 0;
+                        }
+                    }
+                }
+                if row < self.commit_scroll {
+                    self.commit_scroll = row;
+                } else if row >= self.commit_scroll + visible_h {
+                    self.commit_scroll = row - visible_h + 1;
+                }
+            } else {
+                self.commit_scroll = 0;
+            }
+
+            Paragraph::new(display_text)
+                .style(style)
+                .wrap(Wrap { trim: false })
+                .scroll((self.commit_scroll, 0))
+                .render(text_area, frame.buffer_mut());
+
+            if focused {
+                let (mut cursor_row, mut cursor_col) = (0u16, 0usize);
+                for (i, ch) in self.commit_input.char_indices() {
+                    if i == self.commit_input_cursor {
+                        break;
+                    }
+                    if ch == '\n' {
+                        cursor_row += 1;
+                        cursor_col = 0;
+                    } else {
+                        cursor_col += 1;
+                        if text_w > 0 && cursor_col >= text_w {
+                            cursor_row += 1;
+                            cursor_col = 0;
+                        }
+                    }
+                }
+                let screen_row = cursor_row.saturating_sub(self.commit_scroll);
+                let cx = text_area.x + cursor_col as u16;
+                let cy = text_area.y + screen_row;
+                if cx < text_area.x + text_area.width && cy < text_area.y + text_area.height {
+                    frame.set_cursor_position((cx, cy));
+                }
+            }
+        }
+
+        // Hint bar.
+        if hint_area.height > 0 {
+            let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+            let mut spans: Vec<Span> = Vec::new();
+            if focused {
+                spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
+                spans.push(Span::styled(" Exit", desc_style));
+            } else {
+                spans.extend(self.theme.dim_key_badge("i", Color::Reset));
+                spans.push(Span::styled(" Commit msg  ", desc_style));
+                spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
+                spans.push(Span::styled(" AI msg  ", desc_style));
+                spans.extend(self.theme.dim_key_badge("c", Color::Reset));
+                spans.push(Span::styled(" Commit", desc_style));
+            }
+            Paragraph::new(Line::from(spans)).render(hint_area, frame.buffer_mut());
+        }
     }
 
     fn render_footer(&self, frame: &mut Frame, area: Rect) {
@@ -1318,6 +1500,102 @@ impl App {
                         .border_style(Style::default().fg(quit_border)),
                 )
                 .render(quit_area, frame.buffer_mut());
+            }
+            PromptState::ConfirmDiscardFile {
+                file_path,
+                confirm_selected,
+                ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(56, 30, frame.area());
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Discard Changes");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                let lines = vec![
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::raw(" Discard all changes to \""),
+                        Span::styled(
+                            file_path.as_str(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw("\"?"),
+                    ]),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " This action cannot be undone.",
+                        Style::default().fg(Color::Yellow),
+                    )),
+                ];
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = 16u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let discard_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) = if !confirm_selected {
+                    (Color::Cyan, Color::White)
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+                let (discard_border, discard_fg) = if *confirm_selected {
+                    (Color::Red, Color::White)
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Discard",
+                    Style::default().fg(discard_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(discard_border)),
+                )
+                .render(discard_area, frame.buffer_mut());
             }
             PromptState::None => {}
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -785,7 +785,7 @@ impl App {
                 spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
                 spans.push(Span::styled(" AI msg  ", desc_style));
                 spans.extend(self.theme.dim_key_badge("c", Color::Reset));
-                spans.push(Span::styled(" Submit commit", desc_style));
+                spans.push(Span::styled(" Commit", desc_style));
             }
             Paragraph::new(Line::from(spans)).render(hint_area, frame.buffer_mut());
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -478,7 +478,7 @@ impl App {
                     desc_style,
                 ));
                 spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
-                spans.push(Span::styled(" to bring the focus back to dux.", desc_style));
+                spans.push(Span::styled(" to bring the focus back.", desc_style));
                 Line::from(spans)
             } else if scrollback_offset > 0 {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -785,7 +785,7 @@ impl App {
                 spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
                 spans.push(Span::styled(" AI msg  ", desc_style));
                 spans.extend(self.theme.dim_key_badge("c", Color::Reset));
-                spans.push(Span::styled(" Commit", desc_style));
+                spans.push(Span::styled(" Submit commit", desc_style));
             }
             Paragraph::new(Line::from(spans)).render(hint_area, frame.buffer_mut());
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -780,8 +780,8 @@ impl App {
                 spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
                 spans.push(Span::styled(" Exit", desc_style));
             } else {
-                spans.extend(self.theme.dim_key_badge("i", Color::Reset));
-                spans.push(Span::styled(" Commit msg  ", desc_style));
+                spans.extend(self.theme.dim_key_badge("i/Enter", Color::Reset));
+                spans.push(Span::styled(" Edit  ", desc_style));
                 spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
                 spans.push(Span::styled(" AI msg  ", desc_style));
                 spans.extend(self.theme.dim_key_badge("c", Color::Reset));

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -366,7 +366,7 @@ impl App {
             self.set_error("Select a session first.");
             return Ok(());
         };
-        let Some(file) = self.changed_files.get(self.selected_file) else {
+        let Some(file) = self.selected_changed_file() else {
             return Ok(());
         };
         let output =

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -44,11 +44,26 @@ impl App {
                     self.create_agent_in_flight = false;
                     self.set_error(message);
                 }
-                WorkerEvent::ChangedFilesReady(files) => {
-                    self.changed_files = files;
-                    if self.selected_file >= self.changed_files.len() {
-                        self.selected_file = self.changed_files.len().saturating_sub(1);
-                    }
+                WorkerEvent::ChangedFilesReady { staged, unstaged } => {
+                    self.staged_files = staged;
+                    self.unstaged_files = unstaged;
+                    self.clamp_files_cursor();
+                }
+                WorkerEvent::CommitMessageGenerated(msg) => {
+                    self.commit_input = msg;
+                    self.commit_input_cursor = self.commit_input.len();
+                    self.commit_generating = false;
+                    self.input_target = InputTarget::CommitMessage;
+                    self.set_info(
+                        "AI commit message generated. Press Esc to exit, then c to commit.",
+                    );
+                }
+                WorkerEvent::CommitMessageFailed(err) => {
+                    self.commit_generating = false;
+                    self.set_error(format!(
+                        "Failed to generate AI commit message: {err}. \
+                         You can write one manually or retry with ^G.",
+                    ));
                 }
                 WorkerEvent::BrowserEntriesReady { dir, entries } => {
                     if let PromptState::BrowseProjects {
@@ -125,8 +140,8 @@ impl App {
                 thread::sleep(interval);
                 let path = watched.lock().ok().and_then(|guard| guard.clone());
                 if let Some(worktree_path) = path {
-                    if let Ok(files) = git::changed_files(&worktree_path) {
-                        if tx.send(WorkerEvent::ChangedFilesReady(files)).is_err() {
+                    if let Ok((staged, unstaged)) = git::changed_files(&worktree_path) {
+                        if tx.send(WorkerEvent::ChangedFilesReady { staged, unstaged }).is_err() {
                             break; // receiver dropped, app is shutting down
                         }
                     }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -65,6 +65,21 @@ impl App {
                          You can write one manually or retry with ^G.",
                     ));
                 }
+                WorkerEvent::PushCompleted(result) => match result {
+                    Ok(()) => self.set_info(
+                        "Pushed to remote successfully. Your changes are now available to collaborators.",
+                    ),
+                    Err(e) => self.set_error(format!("Push to remote failed: {e}")),
+                },
+                WorkerEvent::PullCompleted(result) => match result {
+                    Ok(()) => {
+                        self.set_info(
+                            "Pulled latest changes from remote successfully. Local branch is up to date.",
+                        );
+                        self.reload_changed_files();
+                    }
+                    Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
+                },
                 WorkerEvent::BrowserEntriesReady { dir, entries } => {
                     if let PromptState::BrowseProjects {
                         current_dir,

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, anyhow};
 
-use crate::model::ChangedFile;
+use crate::model::{ChangedFile, FileStage};
 
 pub fn current_branch(repo_path: &Path) -> Result<String> {
     let output = Command::new("git")
@@ -160,10 +160,9 @@ pub fn remove_worktree(
     })
 }
 
-pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {
+pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<ChangedFile>)> {
     let wt = worktree_path.to_string_lossy();
 
-    // 1. Get file statuses via porcelain (config-immune).
     let output = Command::new("git")
         .args(["-C", wt.as_ref(), "status", "--porcelain"])
         .output()?;
@@ -173,39 +172,58 @@ pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    let mut files = Vec::new();
+
+    let mut staged = Vec::new();
+    let mut unstaged = Vec::new();
+
     for line in String::from_utf8_lossy(&output.stdout).lines() {
-        if line.trim().is_empty() || line.len() < 4 {
+        if line.len() < 4 {
             continue;
         }
-        let status = line[..2].trim().to_string();
+        let bytes = line.as_bytes();
+        let index_status = bytes[0] as char;
+        let worktree_status = bytes[1] as char;
         let path = line[3..].to_string();
-        files.push(ChangedFile {
-            status,
-            path,
-            additions: 0,
-            deletions: 0,
-        });
+
+        if index_status == '?' && worktree_status == '?' {
+            unstaged.push(ChangedFile {
+                status: "?".to_string(),
+                path,
+                additions: 0,
+                deletions: 0,
+                stage: FileStage::Unstaged,
+            });
+            continue;
+        }
+
+        if index_status != ' ' {
+            staged.push(ChangedFile {
+                status: index_status.to_string(),
+                path: path.clone(),
+                additions: 0,
+                deletions: 0,
+                stage: FileStage::Staged,
+            });
+        }
+
+        if worktree_status != ' ' {
+            unstaged.push(ChangedFile {
+                status: worktree_status.to_string(),
+                path: path.clone(),
+                additions: 0,
+                deletions: 0,
+                stage: FileStage::Unstaged,
+            });
+        }
     }
 
-    // 2. Get line-level stats via diff --numstat (plumbing-style output).
     if let Ok(ns) = Command::new("git")
         .args(["-C", wt.as_ref(), "diff", "--numstat"])
         .output()
     {
         if ns.status.success() {
-            let text = String::from_utf8_lossy(&ns.stdout);
-            let stats: HashMap<String, (usize, usize)> = text
-                .lines()
-                .filter_map(|line| {
-                    let mut parts = line.split('\t');
-                    let add = parts.next()?.parse::<usize>().ok()?;
-                    let del = parts.next()?.parse::<usize>().ok()?;
-                    let path = parts.next()?.to_string();
-                    Some((path, (add, del)))
-                })
-                .collect();
-            for file in &mut files {
+            let stats = parse_numstat(&ns.stdout);
+            for file in &mut unstaged {
                 if let Some(&(a, d)) = stats.get(&file.path) {
                     file.additions = a;
                     file.deletions = d;
@@ -214,7 +232,129 @@ pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {
         }
     }
 
-    Ok(files)
+    if let Ok(ns) = Command::new("git")
+        .args(["-C", wt.as_ref(), "diff", "--cached", "--numstat"])
+        .output()
+    {
+        if ns.status.success() {
+            let stats = parse_numstat(&ns.stdout);
+            for file in &mut staged {
+                if let Some(&(a, d)) = stats.get(&file.path) {
+                    file.additions = a;
+                    file.deletions = d;
+                }
+            }
+        }
+    }
+
+    Ok((staged, unstaged))
+}
+
+fn parse_numstat(raw: &[u8]) -> HashMap<String, (usize, usize)> {
+    String::from_utf8_lossy(raw)
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split('\t');
+            let add = parts.next()?.parse::<usize>().ok()?;
+            let del = parts.next()?.parse::<usize>().ok()?;
+            let path = parts.next()?.to_string();
+            Some((path, (add, del)))
+        })
+        .collect()
+}
+
+pub fn stage_file(worktree_path: &Path, file_path: &str) -> Result<()> {
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "add", "--", file_path])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
+pub fn unstage_file(worktree_path: &Path, file_path: &str) -> Result<()> {
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "reset", "HEAD", "--", file_path])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git reset failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
+pub fn discard_file(worktree_path: &Path, file_path: &str, is_untracked: bool) -> Result<()> {
+    if is_untracked {
+        let full = worktree_path.join(file_path);
+        if full.is_dir() {
+            fs::remove_dir_all(&full)?;
+        } else {
+            fs::remove_file(&full)?;
+        }
+        return Ok(());
+    }
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "checkout", "--", file_path])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git checkout failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
+pub fn commit(worktree_path: &Path, message: &str) -> Result<String> {
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "commit", "-m", message])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+pub fn staged_diff(worktree_path: &Path) -> Result<String> {
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "diff", "--cached"])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git diff --cached failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn push(worktree_path: &Path) -> Result<String> {
+    let wt = worktree_path.to_string_lossy();
+    let branch = current_branch(worktree_path)?;
+    let output = Command::new("git")
+        .args(["-C", wt.as_ref(), "push", "-u", "origin", &branch])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git push failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Return the contents of a file as it exists at HEAD, or `None` for new

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -507,7 +507,7 @@ pub const BINDINGS: &[Binding] = &[
             label: "c",
             description: "Commit staged changes",
         }),
-        hints: &[(HintContext::Files, "c", "Submit commit")],
+        hints: &[(HintContext::Files, "c", "Commit")],
         palette: None,
         native: true,
     },

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -507,7 +507,7 @@ pub const BINDINGS: &[Binding] = &[
             label: "c",
             description: "Commit staged changes",
         }),
-        hints: &[(HintContext::Files, "c", "Commit")],
+        hints: &[(HintContext::Files, "c", "Submit commit")],
         palette: None,
         native: true,
     },

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -49,6 +49,7 @@ pub enum HintContext {
     LeftSession,
     Center,
     Files,
+    /// In-pane hint bar inside the commit message area.
     CommitInput,
 }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -27,6 +27,10 @@ pub enum Action {
     Quit,
     DeleteProject,
     RemoveProject,
+    // ── Commit input (native / informational) ─────────────────────
+    GenerateCommitMessage,
+    InsertNewline,
+    CommitChanges,
 }
 
 /// Where a binding's key combo is matched.
@@ -45,6 +49,7 @@ pub enum HintContext {
     LeftSession,
     Center,
     Files,
+    CommitInput,
 }
 
 /// A physical key combination to match against.
@@ -94,6 +99,10 @@ pub struct Binding {
     pub help: Option<HelpEntry>,
     pub hints: &'static [(HintContext, &'static str, &'static str)],
     pub palette: Option<PaletteEntry>,
+    /// When `true`, the key combo is handled natively by the input handler
+    /// (not via the `lookup()` dispatch). The binding exists only for
+    /// documentation, hints, and the help overlay.
+    pub native: bool,
 }
 
 impl Binding {
@@ -138,6 +147,7 @@ pub const BINDINGS: &[Binding] = &[
             (HintContext::Files, "j/k", "Move"),
         ],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::MoveUp,
@@ -146,6 +156,7 @@ pub const BINDINGS: &[Binding] = &[
         help: None, // covered by MoveDown's "j/k" label
         hints: &[],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::ToggleProject,
@@ -162,6 +173,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Collapse or expand the selected project's agents",
             shortcut: Some("Space"),
         }),
+        native: false,
     },
     Binding {
         action: Action::NewAgent,
@@ -178,6 +190,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Create a new agent for the selected project",
             shortcut: Some("n"),
         }),
+        native: false,
     },
     Binding {
         action: Action::FocusAgent,
@@ -186,6 +199,7 @@ pub const BINDINGS: &[Binding] = &[
         help: None,
         hints: &[(HintContext::LeftSession, "Enter", "Focus")],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::OpenProjectBrowser,
@@ -205,6 +219,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Open the project browser",
             shortcut: Some("a"),
         }),
+        native: false,
     },
     Binding {
         action: Action::CopyPath,
@@ -220,6 +235,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Copy the selected agent's worktree path",
             shortcut: Some("y"),
         }),
+        native: false,
     },
     Binding {
         action: Action::CycleProvider,
@@ -236,6 +252,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Toggle the selected project's default provider",
             shortcut: Some("d"),
         }),
+        native: false,
     },
     Binding {
         action: Action::RefreshProject,
@@ -252,6 +269,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Git pull the selected project checkout",
             shortcut: Some("u"),
         }),
+        native: false,
     },
     Binding {
         action: Action::ReconnectAgent,
@@ -268,6 +286,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Restart the CLI for the selected agent",
             shortcut: None,
         }),
+        native: false,
     },
     Binding {
         action: Action::DeleteSession,
@@ -284,6 +303,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Delete the selected agent session",
             shortcut: None,
         }),
+        native: false,
     },
     // ── Center pane ────────────────────────────────────────────────
     Binding {
@@ -297,6 +317,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[(HintContext::Center, "i", "Interact")],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::ScrollPageUp,
@@ -309,6 +330,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::ScrollPageDown,
@@ -321,6 +343,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[],
         palette: None,
+        native: false,
     },
     // ── Files pane ─────────────────────────────────────────────────
     Binding {
@@ -334,6 +357,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[(HintContext::Files, "Enter", "Diff")],
         palette: None,
+        native: false,
     },
     // ── Global ─────────────────────────────────────────────────────
     // (placed after pane bindings so ^P / ? appear last in hints)
@@ -351,6 +375,7 @@ pub const BINDINGS: &[Binding] = &[
             (HintContext::Files, "Tab", "Next"),
         ],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::FocusPrev,
@@ -359,6 +384,7 @@ pub const BINDINGS: &[Binding] = &[
         help: None,
         hints: &[],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::OpenPalette,
@@ -376,6 +402,7 @@ pub const BINDINGS: &[Binding] = &[
             (HintContext::Files, "^P", "Palette"),
         ],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::ToggleResizeMode,
@@ -388,6 +415,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[],
         palette: None,
+        native: false,
     },
     Binding {
         action: Action::ToggleSidebar,
@@ -404,6 +432,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Collapse or expand the projects sidebar",
             shortcut: Some("["),
         }),
+        native: false,
     },
     Binding {
         action: Action::ToggleHelp,
@@ -425,6 +454,7 @@ pub const BINDINGS: &[Binding] = &[
             description: "Open the help overlay",
             shortcut: Some("?"),
         }),
+        native: false,
     },
     Binding {
         action: Action::Quit,
@@ -437,6 +467,7 @@ pub const BINDINGS: &[Binding] = &[
         }),
         hints: &[],
         palette: None,
+        native: false,
     },
     // ── Palette-only (no direct keybinding) ────────────────────────
     Binding {
@@ -450,6 +481,100 @@ pub const BINDINGS: &[Binding] = &[
             description: "Remove the selected project and its sessions",
             shortcut: None,
         }),
+        native: false,
+    },
+    // ── Files pane (native — handled directly in handle_files_key) ──────
+    Binding {
+        action: Action::ToggleProject, // reused: Space in files = stage/unstage
+        keys: &[KeyCombo::char(' ')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            label: "Space",
+            description: "Stage or unstage selected file",
+        }),
+        hints: &[(HintContext::Files, "Space", "Stage/Unstage")],
+        palette: None,
+        native: true,
+    },
+    Binding {
+        action: Action::CommitChanges,
+        keys: &[KeyCombo::char('c')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            label: "c",
+            description: "Commit staged changes",
+        }),
+        hints: &[(HintContext::Files, "c", "Commit")],
+        palette: None,
+        native: true,
+    },
+    Binding {
+        action: Action::GenerateCommitMessage,
+        keys: &[KeyCombo::ctrl('g')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            label: "^G",
+            description: "Generate AI commit message",
+        }),
+        hints: &[(HintContext::Files, "^G", "AI msg")],
+        palette: None,
+        native: true,
+    },
+    Binding {
+        action: Action::DeleteSession, // reused: ^D in files = discard
+        keys: &[KeyCombo::ctrl('d')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            label: "^D",
+            description: "Discard changes to selected file",
+        }),
+        hints: &[(HintContext::Files, "^D", "Discard")],
+        palette: None,
+        native: true,
+    },
+    Binding {
+        action: Action::InteractAgent, // reused: i in files = engage commit input
+        keys: &[KeyCombo::char('i')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            label: "i",
+            description: "Write a commit message",
+        }),
+        hints: &[(HintContext::Files, "i", "Commit msg")],
+        palette: None,
+        native: true,
+    },
+    // ── Commit input (native keybindings — handled directly, not via lookup) ──
+    Binding {
+        action: Action::GenerateCommitMessage, // ^G exits commit input
+        keys: &[KeyCombo::ctrl('g')],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Commit input",
+            label: "^G",
+            description: "Exit commit input",
+        }),
+        hints: &[], // works but not shown in hint bar
+        palette: None,
+        native: true,
+    },
+    Binding {
+        action: Action::InsertNewline,
+        keys: &[KeyCombo::key(KeyCode::Esc)],
+        scopes: &[],
+        help: Some(HelpEntry {
+            section: "Commit input",
+            label: "Esc",
+            description: "Exit commit input",
+        }),
+        hints: &[(HintContext::CommitInput, "Esc", "Exit")],
+        palette: None,
+        native: true,
     },
     Binding {
         action: Action::RemoveProject,
@@ -462,10 +587,11 @@ pub const BINDINGS: &[Binding] = &[
             description: "Remove project from app (keeps files on disk)",
             shortcut: None,
         }),
+        native: false,
     },
 ];
 
-const HELP_SECTION_ORDER: &[&str] = &["Global", "Projects pane", "Agent pane", "Files pane"];
+const HELP_SECTION_ORDER: &[&str] = &["Global", "Projects pane", "Agent pane", "Files pane", "Commit input"];
 
 /// Find the action for a key event in the given scope.
 pub fn lookup(key: &KeyEvent, scope: BindingScope) -> Option<Action> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod git;
 mod keybindings;
 mod logger;
 mod model;
+mod provider;
 mod pty;
 mod statusline;
 mod storage;

--- a/src/model.rs
+++ b/src/model.rs
@@ -71,10 +71,17 @@ pub struct AgentSession {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileStage {
+    Staged,
+    Unstaged,
+}
+
 #[derive(Clone, Debug)]
 pub struct ChangedFile {
     pub status: String,
     pub path: String,
     pub additions: usize,
     pub deletions: usize,
+    pub stage: FileStage,
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,94 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::Result;
+
+use crate::config::ProviderCommandConfig;
+use crate::model::ProviderKind;
+
+/// Trait abstracting CLI provider capabilities beyond interactive PTY sessions.
+pub trait Provider: Send {
+    /// The provider kind (Claude, Codex).
+    fn kind(&self) -> ProviderKind;
+
+    /// The CLI command name (e.g. "claude", "codex").
+    fn command(&self) -> &str;
+
+    /// Build a [`Command`] for a non-interactive one-shot prompt.
+    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>);
+
+    /// Run a non-interactive prompt and return the response text.
+    fn run_oneshot(&self, prompt: &str, cwd: &Path) -> Result<String> {
+        let (mut cmd, tmpfile) = self.build_oneshot_command(prompt, cwd);
+        let output = cmd.output()?;
+        if let Some(path) = tmpfile {
+            let text = std::fs::read_to_string(&path)?;
+            let _ = std::fs::remove_file(&path);
+            Ok(text.trim().to_string())
+        } else {
+            if !output.status.success() {
+                anyhow::bail!(
+                    "{} failed: {}",
+                    self.command(),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        }
+    }
+}
+
+pub struct ClaudeProvider {
+    pub config: ProviderCommandConfig,
+}
+
+impl Provider for ClaudeProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Claude
+    }
+
+    fn command(&self) -> &str {
+        &self.config.command
+    }
+
+    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>) {
+        let mut cmd = Command::new(&self.config.command);
+        cmd.current_dir(cwd);
+        cmd.args(["-p", prompt]);
+        (cmd, None)
+    }
+}
+
+pub struct CodexProvider {
+    pub config: ProviderCommandConfig,
+}
+
+impl Provider for CodexProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Codex
+    }
+
+    fn command(&self) -> &str {
+        &self.config.command
+    }
+
+    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>) {
+        let tmpfile =
+            std::env::temp_dir().join(format!("dux-codex-{}.txt", std::process::id()));
+        let mut cmd = Command::new(&self.config.command);
+        cmd.current_dir(cwd);
+        cmd.args(["exec", "-o", &tmpfile.to_string_lossy(), prompt]);
+        (cmd, Some(tmpfile))
+    }
+}
+
+/// Create a boxed [`Provider`] from a [`ProviderKind`] and its config.
+pub fn create_provider(
+    kind: &ProviderKind,
+    config: ProviderCommandConfig,
+) -> Box<dyn Provider> {
+    match kind {
+        ProviderKind::Claude => Box::new(ClaudeProvider { config }),
+        ProviderKind::Codex => Box::new(CodexProvider { config }),
+    }
+}

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -21,18 +21,18 @@ pub trait Provider: Send {
     fn run_oneshot(&self, prompt: &str, cwd: &Path) -> Result<String> {
         let (mut cmd, tmpfile) = self.build_oneshot_command(prompt, cwd);
         let output = cmd.output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "{} failed: {}",
+                self.command(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
         if let Some(path) = tmpfile {
             let text = std::fs::read_to_string(&path)?;
             let _ = std::fs::remove_file(&path);
             Ok(text.trim().to_string())
         } else {
-            if !output.status.success() {
-                anyhow::bail!(
-                    "{} failed: {}",
-                    self.command(),
-                    String::from_utf8_lossy(&output.stderr)
-                );
-            }
             Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
         }
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -44,6 +44,10 @@ pub struct Theme {
     pub provider_label_fg: Color,
     pub branch_fg: Color,
     pub terminal_hint_fg: Color,
+    pub warning_fg: Color,
+    pub button_active_fg: Color,
+    pub button_confirm_border: Color,
+    pub button_danger_border: Color,
 }
 
 impl Theme {
@@ -89,6 +93,10 @@ impl Theme {
             provider_label_fg: Color::Rgb(100, 100, 100),
             branch_fg: Color::Cyan,
             terminal_hint_fg: Color::Rgb(80, 80, 80),
+            warning_fg: Color::Yellow,
+            button_active_fg: Color::White,
+            button_confirm_border: Color::Cyan,
+            button_danger_border: Color::Red,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a VS Code Source Control-style right pane with **Staged Changes** and **Changes** sub-panes, supporting stage/unstage (Space), discard with confirmation (^D), and inline diff (Enter)
- Adds a **commit message input area** with a hint bar matching the agent pane styling, supporting AI-generated commit messages (^G via a new `Provider` trait), manual editing with newlines (^J), and commit (^Enter)
- Introduces `src/provider.rs` with a `Provider` trait abstracting CLI non-interactive mode (`claude -p` / `codex exec`) for one-shot prompts like commit message generation
- Extends `src/git.rs` with staging, unstaging, discarding, committing, staged diff, push, and pull operations
- Adds Tab/Shift-Tab cycling within right pane sections (Staged → Unstaged → CommitInput) with pane exit at boundaries, and registers commit input keybindings as `native` (documentation-only) in the centralized keybindings registry

## Test plan

- [ ] Select a session with changed files — right pane shows "Staged Changes" and "Changes" sub-panes
- [ ] Space on an unstaged file stages it; Space on a staged file unstages it
- [ ] ^D on an unstaged file shows confirmation dialog; confirming discards the file
- [ ] `c` or Tab into commit input, type a message, ^Enter commits staged changes
- [ ] ^G generates an AI commit message (requires working claude/codex CLI)
- [ ] `u` pushes to remote, `p` pulls from remote (statusline feedback)
- [ ] Tab/Shift-Tab cycles within right pane sections and exits to other panes at boundaries
- [ ] Enter on a file opens the scrollable diff viewer in the center pane