### PR TITLE
Add `o` keybind to add current folder in project browser

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -619,21 +619,20 @@ impl App {
                             .collect()
                     };
                     if let Some(entry) = visible.get(*selected).cloned() {
-                        if entry.is_git_repo {
-                            let path = entry.path.to_string_lossy().to_string();
-                            self.prompt = PromptState::None;
-                            if let Err(e) = self.add_project(path, String::new()) {
-                                self.set_error(format!("{e:#}"));
-                            }
-                        } else {
-                            let new_dir = entry.path.clone();
-                            *current_dir = new_dir.clone();
-                            entries.clear();
-                            *loading = true;
-                            *selected = 0;
-                            filter.clear();
-                            browse_to = Some(new_dir);
-                        }
+                        let new_dir = entry.path.clone();
+                        *current_dir = new_dir.clone();
+                        entries.clear();
+                        *loading = true;
+                        *selected = 0;
+                        filter.clear();
+                        browse_to = Some(new_dir);
+                    }
+                }
+                KeyCode::Char('o') if !*searching => {
+                    let path = current_dir.to_string_lossy().to_string();
+                    self.prompt = PromptState::None;
+                    if let Err(e) = self.add_project(path, String::new()) {
+                        self.set_error(format!("{e:#}"));
                     }
                 }
                 KeyCode::Char(c) if *searching => {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1050,6 +1050,11 @@ impl App {
                         " open  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
+                    bottom_spans.extend(self.theme.key_badge("o", Color::Reset));
+                    bottom_spans.push(Span::styled(
+                        " add current  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
                     bottom_spans.extend(self.theme.key_badge("g", Color::Reset));
                     bottom_spans.push(Span::styled(
                         " go to  ",

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -30,7 +30,7 @@ impl App {
         };
         self.spawn_browser_entries(&start_dir);
         self.set_info(
-            "Project browser: Enter opens or adds a repo, / to search, g to go to a path.",
+            "Project browser: Enter opens folders, o adds current dir, / to search, g to go to a path.",
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Fixes Enter key inconsistency in the project browser: Enter now always navigates into the selected directory, regardless of whether it's a git repo or a plain folder.
- Adds new `o` keybind that adds the current browsing directory as a project, eliminating the need to go up one level and re-select the folder.
- Updates hint bar and info message to reflect the new keybindings.

## Test plan

- [ ] Open project browser with `a`, navigate folders with Enter — confirm it always opens the directory (even git repos)
- [ ] Press `o` inside a git repo directory — confirm it gets added as a project
- [ ] Press `o` inside a non-git directory — confirm an error message is shown
- [ ] Enter search mode with `/`, type `o` — confirm it types the letter instead of triggering add
- [ ] Verify hint bar shows `/ search  Enter open  o add current  g go to  Esc cancel`