### PR TITLE
Fix worktree deletion when manually removed, add remove-project command

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -89,18 +89,16 @@ impl App {
                         self.reload_changed_files();
                     }
                 }
-                Action::FocusAgent => {
-                    match self.left_items().get(self.selected_left) {
-                        Some(LeftItem::Project(project_index)) => {
-                            let project_id = self.projects[*project_index].id.clone();
-                            let has_sessions =
-                                self.sessions.iter().any(|s| s.project_id == project_id);
-                            if has_sessions {
-                                if self.collapsed_projects.contains(&project_id) {
-                                    self.collapsed_projects.remove(&project_id);
-                                    self.rebuild_left_items();
-                                }
-                                if let Some(pos) =
+                Action::FocusAgent => match self.left_items().get(self.selected_left) {
+                    Some(LeftItem::Project(project_index)) => {
+                        let project_id = self.projects[*project_index].id.clone();
+                        let has_sessions = self.sessions.iter().any(|s| s.project_id == project_id);
+                        if has_sessions {
+                            if self.collapsed_projects.contains(&project_id) {
+                                self.collapsed_projects.remove(&project_id);
+                                self.rebuild_left_items();
+                            }
+                            if let Some(pos) =
                                     self.left_items().iter().position(|item| {
                                         matches!(item, LeftItem::Session(si) if self.sessions[*si].project_id == project_id)
                                     })
@@ -117,25 +115,24 @@ impl App {
                                         self.input_target = InputTarget::Agent;
                                     }
                                 }
-                            } else {
-                                self.create_agent_for_selected_project()?;
-                            }
+                        } else {
+                            self.create_agent_for_selected_project()?;
                         }
-                        Some(LeftItem::Session(_)) => {
-                            self.center_mode = CenterMode::Agent;
-                            self.focus = FocusPane::Center;
-                            self.reload_changed_files();
-                            if self
-                                .selected_session()
-                                .map(|s| self.providers.contains_key(&s.id))
-                                .unwrap_or(false)
-                            {
-                                self.input_target = InputTarget::Agent;
-                            }
-                        }
-                        None => {}
                     }
-                }
+                    Some(LeftItem::Session(_)) => {
+                        self.center_mode = CenterMode::Agent;
+                        self.focus = FocusPane::Center;
+                        self.reload_changed_files();
+                        if self
+                            .selected_session()
+                            .map(|s| self.providers.contains_key(&s.id))
+                            .unwrap_or(false)
+                        {
+                            self.input_target = InputTarget::Agent;
+                        }
+                    }
+                    None => {}
+                },
                 Action::OpenProjectBrowser => {
                     self.open_project_browser()?;
                 }
@@ -156,9 +153,7 @@ impl App {
                         self.focus = FocusPane::Center;
                         self.center_mode = CenterMode::Agent;
                         self.input_target = InputTarget::Agent;
-                        self.set_info(
-                            "Interactive mode. Keys forwarded to agent. ctrl+g exits.",
-                        );
+                        self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                     } else {
                         self.set_error(
                             "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
@@ -184,9 +179,7 @@ impl App {
                     {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
-                        self.set_info(
-                            "Interactive mode. Keys forwarded to agent. ctrl+g exits.",
-                        );
+                        self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
                     } else {
                         self.set_error(
                             "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
@@ -216,7 +209,11 @@ impl App {
                     }
                 }
                 Action::ScrollPageDown => {
-                    if let CenterMode::Diff { ref lines, ref mut scroll } = self.center_mode {
+                    if let CenterMode::Diff {
+                        ref lines,
+                        ref mut scroll,
+                    } = self.center_mode
+                    {
                         let page = self.last_diff_height.max(1);
                         let max_scroll = (lines.len() as u16).saturating_sub(1);
                         *scroll = (*scroll + page).min(max_scroll);
@@ -406,7 +403,8 @@ impl App {
                     if *searching {
                         *searching = false;
                     } else {
-                        let command = if let Some(binding) = keybindings::filtered_palette(input).get(*selected)
+                        let command = if let Some(binding) =
+                            keybindings::filtered_palette(input).get(*selected)
                         {
                             binding.palette.as_ref().unwrap().name.to_string()
                         } else {
@@ -744,7 +742,11 @@ impl App {
                     }
                 }
                 FocusPane::Center => {
-                    if let CenterMode::Diff { ref lines, ref mut scroll } = self.center_mode {
+                    if let CenterMode::Diff {
+                        ref lines,
+                        ref mut scroll,
+                    } = self.center_mode
+                    {
                         let max_scroll = (lines.len() as u16).saturating_sub(1);
                         *scroll = (*scroll + 3).min(max_scroll);
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -307,6 +307,7 @@ impl App {
             "provider" => self.cycle_selected_project_provider(),
             "refresh-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
+            "remove-project" => self.remove_selected_project(),
             "delete-agent" => self.confirm_delete_selected_session(),
             "reconnect-agent" => self.reconnect_selected_session(),
             "add-project" => self.open_project_browser(),
@@ -457,4 +458,3 @@ pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> Provi
             args: Vec::new(),
         })
 }
-

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -801,11 +801,7 @@ impl App {
                     let badge_col = commands
                         .iter()
                         .filter_map(|b| {
-                            b.palette
-                                .as_ref()
-                                .unwrap()
-                                .shortcut
-                                .map(|s| s.len() + 3) // <key>
+                            b.palette.as_ref().unwrap().shortcut.map(|s| s.len() + 3) // <key>
                         })
                         .max()
                         .unwrap_or(0);
@@ -846,9 +842,7 @@ impl App {
                                     let badge_len = shortcut.len() + 3;
                                     let pre_pad = gap + badge_col - badge_len;
                                     spans.push(Span::raw(" ".repeat(pre_pad)));
-                                    spans.extend(
-                                        self.theme.key_badge(shortcut, Color::Reset),
-                                    );
+                                    spans.extend(self.theme.key_badge(shortcut, Color::Reset));
                                 } else {
                                     spans.push(Span::raw(" ".repeat(gap + badge_col)));
                                 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -188,7 +188,7 @@ impl App {
         else {
             return Ok(());
         };
-        git::remove_worktree(
+        let result = git::remove_worktree(
             Path::new(&project.path),
             Path::new(&session.worktree_path),
             &session.branch_name,
@@ -199,12 +199,19 @@ impl App {
         self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
-        self.set_info(format!(
-            "Deleted {} agent from project \"{}\" with branch \"{}\"",
-            session.provider.as_str(),
-            project.name,
-            session.branch_name
-        ));
+        if result.branch_already_deleted {
+            self.set_info(format!(
+                "Deleted agent (branch \"{}\" was already removed)",
+                session.branch_name
+            ));
+        } else {
+            self.set_info(format!(
+                "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                session.provider.as_str(),
+                project.name,
+                session.branch_name
+            ));
+        }
         Ok(())
     }
 
@@ -242,6 +249,27 @@ impl App {
             self.session_store.upsert_session(session)?;
         }
         self.set_info(format!("Changed CLI agent to \"{}\"", next.as_str()));
+        Ok(())
+    }
+
+    pub(crate) fn remove_selected_project(&mut self) -> Result<()> {
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+        let has_sessions = self.sessions.iter().any(|s| s.project_id == project.id);
+        if has_sessions {
+            self.set_error("Delete all agents in this project first.");
+            return Ok(());
+        }
+        self.projects.retain(|p| p.id != project.id);
+        self.config
+            .projects
+            .retain(|p| Path::new(&p.path) != Path::new(&project.path));
+        save_config(&self.paths.config_path, &self.config)?;
+        self.rebuild_left_items();
+        self.selected_left = self.selected_left.saturating_sub(1);
+        self.set_info(format!("Removed project \"{}\" from app", project.name));
         Ok(())
     }
 
@@ -343,7 +371,10 @@ impl App {
         };
         let output =
             crate::diff::diff_file(Path::new(&session.worktree_path), &file.path, &self.theme)?;
-        self.center_mode = CenterMode::Diff { lines: output.lines, scroll: 0 };
+        self.center_mode = CenterMode::Diff {
+            lines: output.lines,
+            scroll: 0,
+        };
         self.focus = FocusPane::Center;
         Ok(())
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -109,7 +109,15 @@ pub fn create_worktree(
     Ok((branch_name, canonical))
 }
 
-pub fn remove_worktree(repo_path: &Path, worktree_path: &Path, branch_name: &str) -> Result<()> {
+pub struct RemoveResult {
+    pub branch_already_deleted: bool,
+}
+
+pub fn remove_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    branch_name: &str,
+) -> Result<RemoveResult> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -121,12 +129,24 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path, branch_name: &str
         ])
         .output()?;
     if !output.status.success() {
-        return Err(anyhow!(
-            "git worktree remove failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+        if worktree_path.exists() {
+            return Err(anyhow!(
+                "git worktree remove failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        // Worktree already gone from disk — prune stale git refs.
+        let _ = Command::new("git")
+            .args([
+                "-C",
+                repo_path.to_string_lossy().as_ref(),
+                "worktree",
+                "prune",
+            ])
+            .output();
     }
-    let output = Command::new("git")
+    // Best-effort branch deletion.
+    let branch_output = Command::new("git")
         .args([
             "-C",
             repo_path.to_string_lossy().as_ref(),
@@ -135,13 +155,9 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path, branch_name: &str
             branch_name,
         ])
         .output()?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "git branch delete failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    Ok(())
+    Ok(RemoveResult {
+        branch_already_deleted: !branch_output.status.success(),
+    })
 }
 
 pub fn changed_files(worktree_path: &Path) -> Result<Vec<ChangedFile>> {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -26,6 +26,7 @@ pub enum Action {
     ToggleHelp,
     Quit,
     DeleteProject,
+    RemoveProject,
 }
 
 /// Where a binding's key combo is matched.
@@ -299,10 +300,7 @@ pub const BINDINGS: &[Binding] = &[
     },
     Binding {
         action: Action::ScrollPageUp,
-        keys: &[
-            KeyCombo::ctrl('b'),
-            KeyCombo::key(KeyCode::PageUp),
-        ],
+        keys: &[KeyCombo::ctrl('b'), KeyCombo::key(KeyCode::PageUp)],
         scopes: &[BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
@@ -314,10 +312,7 @@ pub const BINDINGS: &[Binding] = &[
     },
     Binding {
         action: Action::ScrollPageDown,
-        keys: &[
-            KeyCombo::ctrl('f'),
-            KeyCombo::key(KeyCode::PageDown),
-        ],
+        keys: &[KeyCombo::ctrl('f'), KeyCombo::key(KeyCode::PageDown)],
         scopes: &[BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
@@ -453,6 +448,18 @@ pub const BINDINGS: &[Binding] = &[
         palette: Some(PaletteEntry {
             name: "delete-project",
             description: "Remove the selected project and its sessions",
+            shortcut: None,
+        }),
+    },
+    Binding {
+        action: Action::RemoveProject,
+        keys: &[],
+        scopes: &[],
+        help: None,
+        hints: &[],
+        palette: Some(PaletteEntry {
+            name: "remove-project",
+            description: "Remove project from app (keeps files on disk)",
             shortcut: None,
         }),
     },


### PR DESCRIPTION
## Summary
- Fix a bug where deleting a session whose worktree was manually removed from disk would error and leave the session permanently undeletable. Now prunes stale git refs and continues cleanup gracefully.
- Branch deletion during session removal is now best-effort, with a statusline note when the branch was already gone.
- Add a new `remove-project` palette command that unlinks a project from the app config without touching the filesystem. Requires all agents to be deleted first.

## Test plan
- [ ] Add a project, create a session, manually `rm -rf` the worktree directory, then Ctrl+D the session — should succeed
- [ ] Add a project with no sessions, run "remove-project" from palette — should remove from sidebar
- [ ] Try "remove-project" on a project with sessions — should show red error in statusline