### PR TITLE
Add fully configurable keybindings via config.toml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ When making changes, edit only the relevant submodule. If you need to add a new 
 
 - When adding, removing, or changing keybindings, update `README.md` if it documents controls or shortcuts.
 - When changing features, pane layouts, config paths, or provider behavior, verify that `README.md` still accurately describes the application.
-- The README intentionally omits a full keybinding reference to avoid staleness. Do not add a Controls or Keybindings section back to it. The in-app `?` help overlay is the authoritative reference for key combinations.
+- The README intentionally omits a full keybinding reference to avoid staleness. Do not add a section listing specific key combinations back to it. The in-app `?` help overlay is the authoritative reference for key combinations. Documenting how to configure keybindings (the `[keys]` config format, syntax, and examples) is acceptable — just avoid enumerating individual bindings that would go stale.
 
 ## Recommendations For Debugging
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm 0.29.0",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm 0.29.0",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +361,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "chrono",
+ "crokey",
  "crossterm 0.29.0",
  "home",
  "petname",
@@ -1322,6 +1349,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ vt100 = "0.15"
 petname = { version = "2.0.2", default-features = false, features = ["default-rng", "default-words"] }
 similar = "2"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
+crokey = "1.4.0"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/README.md
+++ b/README.md
@@ -44,3 +44,27 @@ To use a different CLI tool, set the `command` field in the `[providers.<name>]`
 - `level = "error" | "info" | "debug"`
 - `path = "dux.log"` uses a path relative to the config directory
 - absolute paths also work if you want the log elsewhere
+
+## Keybindings
+
+All keybindings are configured in the `[keys]` section of `config.toml`. On first launch, every binding is written out with its default value and a description comment.
+
+Key format: single characters (`"j"`), special names (`"enter"`, `"space"`, `"pageup"`, `"shift-tab"`, `"esc"`), or modifier combos (`"ctrl-d"`, `"ctrl-p"`).
+
+Each action maps to an array of key combos. For example, to rebind quit from `q`/`ctrl-c` to just `ctrl-q`:
+
+```toml
+[keys]
+quit = ["ctrl-q"]
+```
+
+The `show_terminal_keys` option controls whether hints for terminal-native keys (like `ctrl-j` for newline) appear in the UI. These keys work regardless of this setting — dux documents them but does not control them.
+
+```toml
+[keys]
+show_terminal_keys = false
+```
+
+Text input keys (Backspace, typing characters, Enter in the commit editor) and PTY passthrough keys in interactive mode are not rebindable.
+
+Invalid key strings cause the app to refuse to start with a clear error pointing to the broken entry.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2,7 +2,9 @@ use super::*;
 
 impl App {
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
-        if key.code == KeyCode::Esc && self.close_top_overlay() {
+        if self.bindings.lookup(&key, BindingScope::Global) == Some(Action::CloseOverlay)
+            && self.close_top_overlay()
+        {
             return Ok(false);
         }
         if !matches!(self.prompt, PromptState::None) {
@@ -21,7 +23,7 @@ impl App {
             self.handle_commit_input_key(key)?;
             return Ok(false);
         }
-        if let Some(action) = keybindings::lookup(&key, BindingScope::Global) {
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Global) {
             match action {
                 Action::Quit => {
                     let active_count = self.providers.len();
@@ -93,7 +95,9 @@ impl App {
                 Action::ToggleResizeMode => {
                     self.resize_mode = !self.resize_mode;
                     if self.resize_mode {
-                        self.set_info("Resize mode on: h/l/←/→ resize side panes.");
+                        let grow = self.bindings.labels_for(Action::ResizeGrow);
+                        let shrink = self.bindings.labels_for(Action::ResizeShrink);
+                        self.set_info(format!("Resize mode on: {shrink}/{grow} resize side panes."));
                     } else {
                         self.persist_pane_widths();
                         self.set_info("Resize mode off.");
@@ -118,7 +122,7 @@ impl App {
 
     fn handle_left_key(&mut self, key: KeyEvent) -> Result<()> {
         let item_count = self.left_items().len();
-        if let Some(action) = keybindings::lookup(&key, BindingScope::Left) {
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Left) {
             match action {
                 Action::MoveDown => {
                     if self.selected_left + 1 < item_count {
@@ -196,10 +200,13 @@ impl App {
                         self.focus = FocusPane::Center;
                         self.center_mode = CenterMode::Agent;
                         self.input_target = InputTarget::Agent;
-                        self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
+                        let exit_key = self.bindings.label_for(Action::ExitInteractive);
+                        self.set_info(format!("Interactive mode. Keys forwarded to agent. {exit_key} exits."));
                     } else {
+                        let r = self.bindings.label_for(Action::ReconnectAgent);
+                        let n = self.bindings.label_for(Action::NewAgent);
                         self.set_error(
-                            "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
+                            format!("No active agent. Press \"{r}\" to restart or \"{n}\" to create a new one."),
                         );
                     }
                 }
@@ -211,7 +218,7 @@ impl App {
 
     fn handle_center_key(&mut self, key: KeyEvent) -> Result<()> {
         let in_diff = matches!(self.center_mode, CenterMode::Diff { .. });
-        if let Some(action) = keybindings::lookup(&key, BindingScope::Center) {
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Center) {
             match action {
                 Action::InteractAgent if !in_diff => {
                     if self.selected_session().is_some()
@@ -222,10 +229,13 @@ impl App {
                     {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
-                        self.set_info("Interactive mode. Keys forwarded to agent. ctrl+g exits.");
+                        let exit_key = self.bindings.label_for(Action::ExitInteractive);
+                        self.set_info(format!("Interactive mode. Keys forwarded to agent. {exit_key} exits."));
                     } else {
+                        let r = self.bindings.label_for(Action::ReconnectAgent);
+                        let n = self.bindings.label_for(Action::NewAgent);
                         self.set_error(
-                            "No active agent. Press \"r\" to restart or \"n\" to create a new one.",
+                            format!("No active agent. Press \"{r}\" to restart or \"{n}\" to create a new one."),
                         );
                     }
                 }
@@ -292,76 +302,72 @@ impl App {
     }
 
     fn handle_files_key(&mut self, key: KeyEvent) -> Result<()> {
-        // When hovering over the commit input section, i/Enter engages it.
-        if self.right_section == RightSection::CommitInput {
-            match key.code {
-                KeyCode::Char('i') | KeyCode::Enter => {
-                    self.input_target = InputTarget::CommitMessage;
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Files) {
+            match action {
+                Action::MoveDown => {
+                    if self.right_section != RightSection::CommitInput {
+                        let len = self.current_files_len();
+                        if self.files_index + 1 < len {
+                            self.files_index += 1;
+                        }
+                    }
                 }
-                KeyCode::Char('c') if !self.staged_files.is_empty() => {
+                Action::MoveUp => {
+                    if self.right_section != RightSection::CommitInput {
+                        if self.files_index > 0 {
+                            self.files_index -= 1;
+                        }
+                    }
+                }
+                Action::StageUnstage => {
+                    if self.right_section != RightSection::CommitInput {
+                        self.toggle_stage_selected_file()?;
+                    }
+                }
+                Action::CommitChanges if !self.staged_files.is_empty() => {
                     self.execute_commit()?;
                 }
-                KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                Action::OpenDiff => {
+                    if self.right_section == RightSection::CommitInput {
+                        if !self.staged_files.is_empty() {
+                            self.input_target = InputTarget::CommitMessage;
+                        }
+                    } else {
+                        self.open_diff_for_selected_file()?;
+                    }
+                }
+                Action::DiscardChanges => {
+                    if self.right_section != RightSection::CommitInput {
+                        self.confirm_discard_selected_file()?;
+                    }
+                }
+                Action::GenerateCommitMessage => {
                     self.trigger_ai_commit_message()?;
                 }
-                KeyCode::Char('u') => {
+                Action::EngageCommitInput if !self.staged_files.is_empty() => {
+                    self.input_target = InputTarget::CommitMessage;
+                }
+                Action::PushToRemote => {
                     self.push_to_remote()?;
                 }
-                KeyCode::Char('p') => {
+                Action::PullFromRemote => {
                     self.pull_from_remote()?;
                 }
                 _ => {}
             }
-            return Ok(());
-        }
-
-        match key.code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                let len = self.current_files_len();
-                if self.files_index + 1 < len {
-                    self.files_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                if self.files_index > 0 {
-                    self.files_index -= 1;
-                }
-            }
-            KeyCode::Char(' ') => {
-                self.toggle_stage_selected_file()?;
-            }
-            KeyCode::Char('c') if !self.staged_files.is_empty() => {
-                self.execute_commit()?;
-            }
-            KeyCode::Enter => self.open_diff_for_selected_file()?,
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.confirm_discard_selected_file()?;
-            }
-            KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.trigger_ai_commit_message()?;
-            }
-            KeyCode::Char('i') if !self.staged_files.is_empty() => {
-                self.input_target = InputTarget::CommitMessage;
-            }
-            KeyCode::Char('u') => {
-                self.push_to_remote()?;
-            }
-            KeyCode::Char('p') => {
-                self.pull_from_remote()?;
-            }
-            _ => {}
         }
         Ok(())
     }
 
     fn handle_commit_input_key(&mut self, key: KeyEvent) -> Result<()> {
+        // Exit actions are dispatched via bindings; text input stays hardcoded.
+        if let Some(Action::ExitCommitInput) =
+            self.bindings.lookup(&key, BindingScope::CommitInput)
+        {
+            self.input_target = InputTarget::None;
+            return Ok(());
+        }
         match key.code {
-            KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.input_target = InputTarget::None;
-            }
-            KeyCode::Esc => {
-                self.input_target = InputTarget::None;
-            }
             KeyCode::Enter => {
                 self.commit_input.insert(self.commit_input_cursor, '\n');
                 self.commit_input_cursor += 1;
@@ -524,7 +530,9 @@ impl App {
                 self.commit_input.clear();
                 self.commit_input_cursor = 0;
                 self.commit_scroll = 0;
-                self.set_info("Changes committed successfully. Press u to push to remote, or ^G to generate an AI message.");
+                let push_key = self.bindings.label_for(Action::PushToRemote);
+                let ai_key = self.bindings.label_for(Action::GenerateCommitMessage);
+                self.set_info(format!("Changes committed successfully. Press {push_key} to push to remote, or {ai_key} to generate an AI message."));
                 self.reload_changed_files();
             }
             Err(e) => self.set_error(format!("Commit failed: {e}")),
@@ -579,8 +587,10 @@ impl App {
             }
         };
 
-        // ctrl+g exits interactive mode (like classic terminal escape).
-        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('g') {
+        // Exit interactive mode via configured binding (default: ctrl-g).
+        if let Some(Action::ExitInteractive) =
+            self.bindings.lookup(&key, BindingScope::Interactive)
+        {
             self.input_target = InputTarget::None;
             self.set_info("Exited interactive mode.");
             return Ok(false);
@@ -662,7 +672,7 @@ impl App {
                     *searching = true;
                 }
                 KeyCode::Char('j') | KeyCode::Down if !*searching => {
-                    let count = keybindings::filtered_palette(input).len();
+                    let count = self.bindings.filtered_palette(input).len();
                     if *selected + 1 < count {
                         *selected += 1;
                     }
@@ -673,7 +683,7 @@ impl App {
                     }
                 }
                 KeyCode::Down if *searching => {
-                    let count = keybindings::filtered_palette(input).len();
+                    let count = self.bindings.filtered_palette(input).len();
                     if *selected + 1 < count {
                         *selected += 1;
                     }
@@ -688,8 +698,8 @@ impl App {
                     *selected = 0;
                 }
                 KeyCode::Tab => {
-                    if let Some(binding) = keybindings::filtered_palette(input).get(*selected) {
-                        *input = binding.palette.as_ref().unwrap().name.to_string();
+                    if let Some(binding) = self.bindings.filtered_palette(input).get(*selected) {
+                        *input = binding.palette_name.unwrap().to_string();
                         *selected = 0;
                     }
                 }
@@ -698,9 +708,9 @@ impl App {
                         *searching = false;
                     } else {
                         let command = if let Some(binding) =
-                            keybindings::filtered_palette(input).get(*selected)
+                            self.bindings.filtered_palette(input).get(*selected)
                         {
-                            binding.palette.as_ref().unwrap().name.to_string()
+                            binding.palette_name.unwrap().to_string()
                         } else {
                             input.trim().to_string()
                         };
@@ -1034,26 +1044,27 @@ impl App {
     }
 
     fn handle_resize_key(&mut self, key: KeyEvent) {
-        if self.focus == FocusPane::Files {
-            // When focused on the right pane, resize it instead of the left.
-            match key.code {
-                KeyCode::Char('h') | KeyCode::Left => {
-                    self.right_width_pct = self.right_width_pct.saturating_add(2).min(50)
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Resize) {
+            if self.focus == FocusPane::Files {
+                match action {
+                    Action::ResizeShrink => {
+                        self.right_width_pct = self.right_width_pct.saturating_add(2).min(50)
+                    }
+                    Action::ResizeGrow => {
+                        self.right_width_pct = self.right_width_pct.saturating_sub(2).max(14)
+                    }
+                    _ => {}
                 }
-                KeyCode::Char('l') | KeyCode::Right => {
-                    self.right_width_pct = self.right_width_pct.saturating_sub(2).max(14)
+            } else {
+                match action {
+                    Action::ResizeShrink => {
+                        self.left_width_pct = self.left_width_pct.saturating_sub(2).max(14)
+                    }
+                    Action::ResizeGrow => {
+                        self.left_width_pct = self.left_width_pct.saturating_add(2).min(38)
+                    }
+                    _ => {}
                 }
-                _ => {}
-            }
-        } else {
-            match key.code {
-                KeyCode::Char('h') | KeyCode::Left => {
-                    self.left_width_pct = self.left_width_pct.saturating_sub(2).max(14)
-                }
-                KeyCode::Char('l') | KeyCode::Right => {
-                    self.left_width_pct = self.left_width_pct.saturating_add(2).min(38)
-                }
-                _ => {}
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -22,10 +22,10 @@ use uuid::Uuid;
 
 use crate::config::{
     Config, DuxPaths, ProjectConfig, ProviderCommandConfig, check_provider_available,
-    ensure_config, save_config,
+    ensure_config, save_config, validate_keys,
 };
 use crate::git;
-use crate::keybindings::{self, Action, BindingScope, HintContext};
+use crate::keybindings::{Action, BindingScope, HintContext, RuntimeBindings};
 use crate::logger;
 use crate::provider;
 use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
@@ -37,6 +37,7 @@ use crate::theme::Theme;
 pub struct App {
     pub(crate) config: Config,
     pub(crate) paths: DuxPaths,
+    pub(crate) bindings: RuntimeBindings,
     pub(crate) session_store: SessionStore,
     pub(crate) projects: Vec<Project>,
     pub(crate) sessions: Vec<AgentSession>,
@@ -244,6 +245,14 @@ impl App {
         let config = ensure_config(&paths)?;
         logger::init(&config.logging, &paths);
         logger::info("bootstrapping dux");
+
+        // Validate and build runtime keybindings from config.
+        if let Err(msg) = validate_keys(&config.keys) {
+            eprintln!("Configuration error in {}: {msg}", paths.config_path.display());
+            std::process::exit(1);
+        }
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+
         let session_store = SessionStore::open(&paths.sessions_db_path)?;
         let projects = load_projects(&config);
         let sessions = session_store.load_sessions()?;
@@ -252,6 +261,7 @@ impl App {
         let mut app = Self {
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
+            bindings,
             config,
             paths,
             session_store,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -249,6 +249,9 @@ impl App {
         // Hint bar with top border (same style as agent terminal).
         if hint_area.height > 0 {
             let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+            let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
+            let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
+            let close = self.bindings.label_for(Action::CloseOverlay);
             let mut spans: Vec<Span> = Vec::new();
 
             if scroll > 0 {
@@ -256,25 +259,17 @@ impl App {
                     format!("Scrolled back {scroll} lines. "),
                     Style::default().fg(self.theme.hint_key_fg),
                 ));
-                spans.extend(self.theme.dim_key_badge("ctrl+f", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" down, ", desc_style));
-                spans.extend(self.theme.dim_key_badge("ctrl+b", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                 spans.push(Span::styled(" up. ", desc_style));
             } else {
-                spans.extend(self.theme.dim_key_badge("^B", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                 spans.push(Span::styled(" ", desc_style));
-                spans.extend(self.theme.dim_key_badge("^F", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" to scroll. ", desc_style));
             }
-            spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
+            spans.extend(self.theme.dim_key_badge(&close, Color::Reset));
             spans.push(Span::styled(" close diff.", desc_style));
 
             Paragraph::new(Line::from(spans))
@@ -462,6 +457,13 @@ impl App {
 
         // Hint bar with top border.
         if hint_area.height > 0 {
+            // Pre-compute all key labels so they outlive the Span borrows.
+            let exit_key = self.bindings.label_for(Action::ExitInteractive);
+            let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
+            let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
+            let interact = self.bindings.labels_for(Action::InteractAgent);
+            let reconnect = self.bindings.labels_for(Action::ReconnectAgent);
+
             let hint_line = if is_input {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
@@ -477,7 +479,7 @@ impl App {
                     format!("{capitalized} is holding focus. Press "),
                     desc_style,
                 ));
-                spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&exit_key, Color::Reset));
                 spans.push(Span::styled(" to bring the focus back.", desc_style));
                 Line::from(spans)
             } else if scrollback_offset > 0 {
@@ -487,36 +489,24 @@ impl App {
                     format!("Scrolled back {scrollback_offset} lines. "),
                     Style::default().fg(self.theme.hint_key_fg),
                 ));
-                spans.extend(self.theme.dim_key_badge("ctrl+f", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" down, ", desc_style));
-                spans.extend(self.theme.dim_key_badge("ctrl+b", Color::Reset));
-                spans.push(Span::styled("/", desc_style));
-                spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                 spans.push(Span::styled(" up.", desc_style));
                 Line::from(spans)
             } else {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
                 if session_active {
-                    spans.extend(self.theme.dim_key_badge("i", Color::Reset));
-                    spans.push(Span::styled(" or ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("Enter", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge(&interact, Color::Reset));
                     spans.push(Span::styled(" to interact. ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("^B", Color::Reset));
-                    spans.push(Span::styled("/", desc_style));
-                    spans.extend(self.theme.dim_key_badge("PgUp", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                     spans.push(Span::styled(" ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("^F", Color::Reset));
-                    spans.push(Span::styled("/", desc_style));
-                    spans.extend(self.theme.dim_key_badge("PgDn", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                     spans.push(Span::styled(" to scroll.", desc_style));
                 } else if session_id.is_some() {
                     spans.push(Span::styled("Agent CLI exited. Press ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("r", Color::Reset));
-                    spans.push(Span::styled(" or ", desc_style));
-                    spans.extend(self.theme.dim_key_badge("enter", Color::Reset));
+                    spans.extend(self.theme.dim_key_badge(&reconnect, Color::Reset));
                     spans.push(Span::styled(" to relaunch.", desc_style));
                 } else {
                     spans.push(Span::styled("No agent selected.", desc_style));
@@ -774,16 +764,20 @@ impl App {
         // Hint bar.
         if hint_area.height > 0 {
             let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+            let exit = self.bindings.labels_for(Action::ExitCommitInput);
+            let engage = self.bindings.labels_for(Action::EngageCommitInput);
+            let ai_msg = self.bindings.label_for(Action::GenerateCommitMessage);
+            let commit = self.bindings.label_for(Action::CommitChanges);
             let mut spans: Vec<Span> = Vec::new();
             if focused {
-                spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&exit, Color::Reset));
                 spans.push(Span::styled(" Exit", desc_style));
             } else {
-                spans.extend(self.theme.dim_key_badge("i/Enter", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&engage, Color::Reset));
                 spans.push(Span::styled(" Edit  ", desc_style));
-                spans.extend(self.theme.dim_key_badge("^G", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&ai_msg, Color::Reset));
                 spans.push(Span::styled(" AI msg  ", desc_style));
-                spans.extend(self.theme.dim_key_badge("c", Color::Reset));
+                spans.extend(self.theme.dim_key_badge(&commit, Color::Reset));
                 spans.push(Span::styled(" Commit", desc_style));
             }
             Paragraph::new(Line::from(spans)).render(hint_area, frame.buffer_mut());
@@ -801,7 +795,7 @@ impl App {
             FocusPane::Center => HintContext::Center,
             FocusPane::Files => HintContext::Files,
         };
-        let hints = keybindings::hints_for(ctx);
+        let hints = self.bindings.hints_for(ctx);
         let [hints_area, status_area] = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(1), Constraint::Min(1)])
@@ -877,7 +871,7 @@ impl App {
         self.render_dim_overlay(frame);
         let area = centered_rect(72, 70, frame.area());
         Clear.render(area, frame.buffer_mut());
-        let help_bindings = keybindings::help_sections();
+        let help_bindings = self.bindings.help_sections();
         let mut lines: Vec<Line> = Vec::new();
         for (section_idx, (section, bindings)) in help_bindings.iter().enumerate() {
             if section_idx > 0 {
@@ -910,8 +904,8 @@ impl App {
                 .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )));
         {
-            let key = "^X";
-            let desc = "Hold Ctrl and press X (e.g. ^P = Ctrl+P)";
+            let key = "Ctrl-x";
+            let desc = "Hold Ctrl and press X (e.g. Ctrl-p)";
             let padding = 14usize.saturating_sub(key.len() + 2);
             let mut spans = vec![Span::raw("  ")];
             spans.extend(self.theme.key_badge(key, Color::Reset));
@@ -970,44 +964,30 @@ impl App {
                 self.render_dim_overlay(frame);
                 let popup = centered_rect(72, 40, frame.area());
                 Clear.render(popup, frame.buffer_mut());
-                let commands = keybindings::filtered_palette(input);
+                let commands = self.bindings.filtered_palette(input);
                 let items = if commands.is_empty() {
                     vec![ListItem::new("No matching commands.")]
                 } else {
-                    // Compute column widths for aligned layout
                     let name_col = commands
                         .iter()
-                        .map(|b| b.palette.as_ref().unwrap().name.len())
+                        .map(|b| b.palette_name.unwrap().len())
                         .max()
                         .unwrap_or(0);
-                    let badge_col = commands
-                        .iter()
-                        .filter_map(|b| {
-                            b.palette.as_ref().unwrap().shortcut.map(|s| s.len() + 3) // <key>
-                        })
-                        .max()
-                        .unwrap_or(0);
-                    // Available width inside borders: popup.width - 2 (borders) - 1 (left pad)
                     let inner_w = popup.width as usize - 3;
-                    // Gap between columns
                     let gap = 2usize;
                     commands
                         .iter()
                         .map(|binding| {
-                            let p = binding.palette.as_ref().unwrap();
-                            // Pad name to fixed column width
-                            let name_padded = format!("{:width$}", p.name, width = name_col);
+                            let name = binding.palette_name.unwrap();
+                            let name_padded = format!("{:width$}", name, width = name_col);
                             let mut spans = vec![Span::styled(
                                 name_padded,
                                 Style::default()
                                     .fg(Color::Cyan)
                                     .add_modifier(Modifier::BOLD),
                             )];
-                            // Description column: fill the space between name and badge
-                            let desc_avail = inner_w
-                                .saturating_sub(name_col + gap)
-                                .saturating_sub(if badge_col > 0 { badge_col + gap } else { 0 });
-                            let desc = p.description;
+                            let desc_avail = inner_w.saturating_sub(name_col + gap);
+                            let desc = binding.palette_description.unwrap_or("");
                             let desc_display = if desc.len() > desc_avail && desc_avail > 1 {
                                 format!("  {}\u{2026}", &desc[..desc_avail - 1])
                             } else {
@@ -1017,18 +997,6 @@ impl App {
                                 desc_display,
                                 Style::default().fg(self.theme.hint_desc_fg),
                             ));
-                            // Right-aligned key badge
-                            if badge_col > 0 {
-                                if let Some(shortcut) = p.shortcut {
-                                    // Right-pad the gap, then the badge
-                                    let badge_len = shortcut.len() + 3;
-                                    let pre_pad = gap + badge_col - badge_len;
-                                    spans.push(Span::raw(" ".repeat(pre_pad)));
-                                    spans.extend(self.theme.key_badge(shortcut, Color::Reset));
-                                } else {
-                                    spans.push(Span::raw(" ".repeat(gap + badge_col)));
-                                }
-                            }
                             ListItem::new(Line::from(spans))
                         })
                         .collect::<Vec<_>>()

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::keybindings;
 use crate::model::ProviderKind;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -18,6 +19,15 @@ pub struct Config {
     pub logging: LoggingConfig,
     pub projects: Vec<ProjectConfig>,
     pub ui: UiConfig,
+    pub keys: KeysConfig,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct KeysConfig {
+    pub show_terminal_keys: bool,
+    #[serde(flatten)]
+    pub bindings: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -82,6 +92,28 @@ impl Default for Config {
                 left_width_pct: 20,
                 right_width_pct: 23,
             },
+            keys: KeysConfig::default(),
+        }
+    }
+}
+
+impl Default for KeysConfig {
+    fn default() -> Self {
+        let mut bindings = BTreeMap::new();
+        for def in keybindings::BINDING_DEFS {
+            if def.default_keys.is_empty() {
+                continue;
+            }
+            let keys: Vec<String> = def
+                .default_keys
+                .iter()
+                .map(|k| keybindings::format_key_for_config(*k))
+                .collect();
+            bindings.insert(def.action.config_name().to_string(), keys);
+        }
+        Self {
+            show_terminal_keys: true,
+            bindings,
         }
     }
 }
@@ -228,6 +260,8 @@ enum ConfigEntry {
     Providers,
     /// Renders the `[[projects]]` array.
     Projects,
+    /// Renders the `[keys]` section with all keybindings.
+    Keys,
 }
 
 fn config_schema() -> Vec<ConfigEntry> {
@@ -276,6 +310,8 @@ fn config_schema() -> Vec<ConfigEntry> {
             value_fn: |c| FieldValue::U16(c.ui.right_width_pct),
         },
         ConfigEntry::Blank,
+        ConfigEntry::Keys,
+        ConfigEntry::Blank,
         ConfigEntry::Projects,
     ]
 }
@@ -318,6 +354,7 @@ fn render_config(config: &Config) -> String {
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
             ConfigEntry::Projects => render_projects(&mut out, &config.projects),
+            ConfigEntry::Keys => render_keys_config(&mut out, &config.keys),
         }
     }
     out
@@ -332,6 +369,57 @@ pub fn save_config(config_path: &Path, config: &Config) -> Result<()> {
     fs::write(config_path, body)
         .with_context(|| format!("failed to write {}", config_path.display()))?;
     Ok(())
+}
+
+fn render_keys_config(out: &mut String, keys: &KeysConfig) {
+    out.push_str("[keys]\n");
+    out.push_str("# Keybindings configuration. Each action maps to one or more key combos.\n");
+    out.push_str("# Key format: single chars (\"j\"), special names (\"up\", \"enter\", \"space\",\n");
+    out.push_str("# \"tab\", \"shift-tab\", \"pageup\", \"esc\"), or modifier combos (\"ctrl-d\").\n");
+    out.push_str("#\n");
+    out.push_str("# Some keys shown in hints are terminal conventions (e.g. ctrl-j for newline)\n");
+    out.push_str("# that dux documents but does not control. Set this to false to hide them.\n");
+    let _ = writeln!(
+        out,
+        "show_terminal_keys = {}",
+        keys.show_terminal_keys
+    );
+    out.push('\n');
+
+    let mut last_section: Option<&str> = None;
+    for def in keybindings::BINDING_DEFS {
+        if def.default_keys.is_empty() {
+            continue;
+        }
+        let config_name = def.action.config_name();
+
+        // Section header based on help section.
+        let section = def.action.help_section().unwrap_or("Other");
+        if last_section != Some(section) {
+            if last_section.is_some() {
+                out.push('\n');
+            }
+            let _ = writeln!(out, "# -- {section} --");
+            last_section = Some(section);
+        }
+
+        // Description comment.
+        let _ = writeln!(out, "# {}", def.action.config_description());
+
+        // Value from config (or defaults if missing).
+        let key_strs = keys
+            .bindings
+            .get(config_name)
+            .cloned()
+            .unwrap_or_else(|| {
+                def.default_keys
+                    .iter()
+                    .map(|k| keybindings::format_key_for_config(*k))
+                    .collect()
+            });
+        let _ = writeln!(out, "{config_name} = {}", render_string_list(&key_strs));
+    }
+    out.push('\n');
 }
 
 fn render_projects(out: &mut String, projects: &[ProjectConfig]) {
@@ -436,6 +524,24 @@ fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommand
     out.push_str(&format!("args = {}\n\n", render_string_list(&config.args)));
 }
 
+/// Validate all key bindings in the config. Returns a descriptive error on failure.
+pub fn validate_keys(keys: &KeysConfig) -> Result<(), String> {
+    for (name, key_strs) in &keys.bindings {
+        let valid = keybindings::BINDING_DEFS
+            .iter()
+            .any(|d| d.action.config_name() == name);
+        if !valid {
+            return Err(format!("[keys] unknown action: \"{name}\""));
+        }
+        for s in key_strs {
+            crokey::parse(s).map_err(|_| {
+                format!("[keys] invalid key \"{s}\" for action \"{name}\"")
+            })?;
+        }
+    }
+    Ok(())
+}
+
 /// Check whether a provider command is available on PATH.
 /// Returns `Ok(())` if found, or `Err(message)` with a user-friendly install hint.
 pub fn check_provider_available(
@@ -492,6 +598,38 @@ mod tests {
         assert!(rendered.contains("[providers.claude]"));
         assert!(rendered.contains("[providers.codex]"));
         assert!(rendered.contains("[ui]"));
+        assert!(rendered.contains("[keys]"));
+        assert!(rendered.contains("show_terminal_keys = true"));
+        assert!(rendered.contains("move_down = "));
+        assert!(rendered.contains("quit = "));
+    }
+
+    #[test]
+    fn validate_keys_accepts_valid_config() {
+        let keys = KeysConfig::default();
+        assert!(validate_keys(&keys).is_ok());
+    }
+
+    #[test]
+    fn validate_keys_rejects_bad_key() {
+        let mut keys = KeysConfig::default();
+        keys.bindings.insert(
+            "quit".to_string(),
+            vec!["badkey!!!".to_string()],
+        );
+        let result = validate_keys(&keys);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("badkey!!!"));
+    }
+
+    #[test]
+    fn validate_keys_rejects_unknown_action() {
+        let mut keys = KeysConfig::default();
+        keys.bindings
+            .insert("nonexistent_action".to_string(), vec!["q".to_string()]);
+        let result = validate_keys(&keys);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("nonexistent_action"));
     }
 
     #[test]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,10 +1,13 @@
+use crokey::{key, KeyCombination, KeyCombinationFormat};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 /// Unique identifier for every bindable action.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Action {
+    // Navigation
     MoveDown,
     MoveUp,
+    // Projects pane
     ToggleProject,
     NewAgent,
     FocusAgent,
@@ -14,10 +17,23 @@ pub enum Action {
     RefreshProject,
     ReconnectAgent,
     DeleteSession,
+    // Agent pane
     InteractAgent,
+    ExitInteractive,
     ScrollPageUp,
     ScrollPageDown,
+    // Files pane (git staging)
     OpenDiff,
+    StageUnstage,
+    CommitChanges,
+    GenerateCommitMessage,
+    DiscardChanges,
+    EngageCommitInput,
+    PushToRemote,
+    PullFromRemote,
+    // Commit message editor
+    ExitCommitInput,
+    // Global
     FocusNext,
     FocusPrev,
     OpenPalette,
@@ -25,12 +41,20 @@ pub enum Action {
     ToggleSidebar,
     ToggleHelp,
     Quit,
+    CloseOverlay,
+    // Resize mode
+    ResizeGrow,
+    ResizeShrink,
+    // Overlays and dialogs
+    SearchToggle,
+    GoToPath,
+    OpenEntry,
+    AddCurrentDir,
+    Confirm,
+    ToggleSelection,
+    // Palette-only (no direct keybinding)
     DeleteProject,
     RemoveProject,
-    // ── Commit input (native / informational) ─────────────────────
-    GenerateCommitMessage,
-    InsertNewline,
-    CommitChanges,
 }
 
 /// Where a binding's key combo is matched.
@@ -40,6 +64,12 @@ pub enum BindingScope {
     Left,
     Center,
     Files,
+    Interactive,
+    Resize,
+    Palette,
+    Browser,
+    Dialog,
+    CommitInput,
 }
 
 /// Where a binding's hint appears in the status bar cheatsheet.
@@ -49,79 +79,152 @@ pub enum HintContext {
     LeftSession,
     Center,
     Files,
-    /// In-pane hint bar inside the commit message area.
     CommitInput,
-}
-
-/// A physical key combination to match against.
-#[derive(Clone, Copy, Debug)]
-pub struct KeyCombo {
-    pub code: KeyCode,
-    pub modifiers: KeyModifiers,
-}
-
-impl KeyCombo {
-    pub const fn char(c: char) -> Self {
-        Self {
-            code: KeyCode::Char(c),
-            modifiers: KeyModifiers::NONE,
-        }
-    }
-    pub const fn ctrl(c: char) -> Self {
-        Self {
-            code: KeyCode::Char(c),
-            modifiers: KeyModifiers::CONTROL,
-        }
-    }
-    pub const fn key(code: KeyCode) -> Self {
-        Self {
-            code,
-            modifiers: KeyModifiers::NONE,
-        }
-    }
 }
 
 pub struct HelpEntry {
     pub section: &'static str,
-    pub label: &'static str,
     pub description: &'static str,
 }
 
 pub struct PaletteEntry {
     pub name: &'static str,
     pub description: &'static str,
-    pub shortcut: Option<&'static str>,
 }
 
-pub struct Binding {
+/// Static definition of a binding. Used as the template for generating default
+/// config and for carrying metadata (scopes, help sections, palette entries,
+/// hint contexts). Key combos and display labels are resolved at runtime from
+/// the config file via [`RuntimeBindings`].
+pub struct BindingDef {
     pub action: Action,
-    pub keys: &'static [KeyCombo],
+    pub default_keys: &'static [KeyCombination],
     pub scopes: &'static [BindingScope],
     pub help: Option<HelpEntry>,
-    pub hints: &'static [(HintContext, &'static str, &'static str)],
+    pub hint_contexts: &'static [(HintContext, &'static str)],
     pub palette: Option<PaletteEntry>,
-    /// When `true`, the key combo is handled natively by the input handler
-    /// (not via the `lookup()` dispatch). The binding exists only for
-    /// documentation, hints, and the help overlay.
-    pub native: bool,
 }
 
-impl Binding {
-    /// Check whether a key event matches this binding.
-    /// Plain bindings (no modifiers) reject Ctrl/Alt combos so that e.g.
-    /// Ctrl+D does not accidentally match a plain `d` binding.
-    pub fn matches(&self, key: &KeyEvent) -> bool {
-        self.keys.iter().any(|k| {
-            if k.code != key.code {
-                return false;
+impl Action {
+    /// The snake_case config key for this action.
+    pub fn config_name(self) -> &'static str {
+        match self {
+            Action::MoveDown => "move_down",
+            Action::MoveUp => "move_up",
+            Action::ToggleProject => "toggle_project",
+            Action::NewAgent => "new_agent",
+            Action::FocusAgent => "focus_agent",
+            Action::OpenProjectBrowser => "open_project_browser",
+            Action::CopyPath => "copy_path",
+            Action::CycleProvider => "cycle_provider",
+            Action::RefreshProject => "refresh_project",
+            Action::ReconnectAgent => "reconnect_agent",
+            Action::DeleteSession => "delete_session",
+            Action::InteractAgent => "interact_agent",
+            Action::ExitInteractive => "exit_interactive",
+            Action::ScrollPageUp => "scroll_page_up",
+            Action::ScrollPageDown => "scroll_page_down",
+            Action::OpenDiff => "open_diff",
+            Action::StageUnstage => "stage_unstage",
+            Action::CommitChanges => "commit_changes",
+            Action::GenerateCommitMessage => "generate_commit_message",
+            Action::DiscardChanges => "discard_changes",
+            Action::EngageCommitInput => "engage_commit_input",
+            Action::PushToRemote => "push_to_remote",
+            Action::PullFromRemote => "pull_from_remote",
+            Action::ExitCommitInput => "exit_commit_input",
+            Action::FocusNext => "focus_next",
+            Action::FocusPrev => "focus_prev",
+            Action::OpenPalette => "open_palette",
+            Action::ToggleResizeMode => "toggle_resize_mode",
+            Action::ToggleSidebar => "toggle_sidebar",
+            Action::ToggleHelp => "toggle_help",
+            Action::Quit => "quit",
+            Action::CloseOverlay => "close_overlay",
+            Action::ResizeGrow => "resize_grow",
+            Action::ResizeShrink => "resize_shrink",
+            Action::SearchToggle => "search_toggle",
+            Action::GoToPath => "go_to_path",
+            Action::OpenEntry => "open_entry",
+            Action::AddCurrentDir => "add_current_dir",
+            Action::Confirm => "confirm",
+            Action::ToggleSelection => "toggle_selection",
+            Action::DeleteProject => "delete_project",
+            Action::RemoveProject => "remove_project",
+        }
+    }
+
+    /// Human description used as a TOML comment in the config file.
+    pub fn config_description(self) -> &'static str {
+        match self {
+            Action::MoveDown => "Navigate down through projects, sessions, files, and lists.",
+            Action::MoveUp => "Navigate up through projects, sessions, files, and lists.",
+            Action::ToggleProject => "Collapse or expand the selected project.",
+            Action::NewAgent => "Create a new agent session (worktree).",
+            Action::FocusAgent => "Focus the selected agent's output pane.",
+            Action::OpenProjectBrowser => "Open the project browser.",
+            Action::CopyPath => "Copy the selected agent's worktree path.",
+            Action::CycleProvider => "Cycle the default provider for the selected project.",
+            Action::RefreshProject => "Git pull the selected project checkout.",
+            Action::ReconnectAgent => "Restart the CLI for the selected agent.",
+            Action::DeleteSession => "Delete the selected session and worktree.",
+            Action::InteractAgent => "Start a prompt turn for the agent.",
+            Action::ExitInteractive => "Exit interactive mode (stop forwarding keys to agent).",
+            Action::ScrollPageUp => "Scroll up one page in the agent output.",
+            Action::ScrollPageDown => "Scroll down one page in the agent output.",
+            Action::OpenDiff => "Open the selected file's diff.",
+            Action::StageUnstage => "Stage or unstage the selected file.",
+            Action::CommitChanges => "Commit staged changes.",
+            Action::GenerateCommitMessage => "Generate an AI commit message.",
+            Action::DiscardChanges => "Discard changes to the selected file.",
+            Action::EngageCommitInput => "Open the commit message editor.",
+            Action::PushToRemote => "Push to remote.",
+            Action::PullFromRemote => "Pull from remote.",
+            Action::ExitCommitInput => "Exit the commit message editor.",
+            Action::FocusNext => "Focus the next pane.",
+            Action::FocusPrev => "Focus the previous pane.",
+            Action::OpenPalette => "Open the command palette.",
+            Action::ToggleResizeMode => "Enter resize mode (h/l to resize side panes).",
+            Action::ToggleSidebar => "Toggle the projects sidebar.",
+            Action::ToggleHelp => "Toggle the help overlay.",
+            Action::Quit => "Quit the application.",
+            Action::CloseOverlay => "Close the current overlay or dialog.",
+            Action::ResizeGrow => "Grow the left pane width.",
+            Action::ResizeShrink => "Shrink the left pane width.",
+            Action::SearchToggle => "Toggle search mode in palette and project browser.",
+            Action::GoToPath => "Open path editor in the project browser.",
+            Action::OpenEntry => "Open or navigate into the selected entry in the project browser.",
+            Action::AddCurrentDir => "Add the current directory as a project.",
+            Action::Confirm => "Confirm the selected action in a dialog.",
+            Action::ToggleSelection => "Toggle between options in a confirmation dialog.",
+            Action::DeleteProject => "Remove the selected project and its sessions.",
+            Action::RemoveProject => "Remove project from app (keeps files on disk).",
+        }
+    }
+
+    /// Help section name for the help overlay.
+    pub fn help_section(self) -> Option<&'static str> {
+        match self {
+            Action::MoveDown | Action::MoveUp | Action::ToggleProject | Action::NewAgent
+            | Action::FocusAgent | Action::OpenProjectBrowser | Action::CopyPath
+            | Action::CycleProvider | Action::RefreshProject | Action::ReconnectAgent
+            | Action::DeleteSession => Some("Projects pane"),
+            Action::InteractAgent | Action::ExitInteractive | Action::ScrollPageUp
+            | Action::ScrollPageDown => Some("Agent pane"),
+            Action::OpenDiff | Action::StageUnstage | Action::CommitChanges
+            | Action::GenerateCommitMessage | Action::DiscardChanges | Action::EngageCommitInput
+            | Action::PushToRemote | Action::PullFromRemote => Some("Files pane"),
+            Action::ExitCommitInput => Some("Commit input"),
+            Action::FocusNext | Action::FocusPrev | Action::OpenPalette
+            | Action::ToggleResizeMode | Action::ToggleSidebar | Action::ToggleHelp
+            | Action::Quit | Action::CloseOverlay => Some("Global"),
+            Action::ResizeGrow | Action::ResizeShrink => Some("Resize mode"),
+            Action::SearchToggle | Action::GoToPath | Action::OpenEntry
+            | Action::AddCurrentDir | Action::Confirm | Action::ToggleSelection => {
+                Some("Overlays")
             }
-            if k.modifiers.is_empty() {
-                !key.modifiers
-                    .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-            } else {
-                key.modifiers.contains(k.modifiers)
-            }
-        })
+            Action::DeleteProject | Action::RemoveProject => None,
+        }
     }
 }
 
@@ -130,529 +233,952 @@ impl Binding {
 //   - help entry order within each help section
 //
 // Pane bindings come first so their hints appear before global hints
-// (^P, ?) which are appended at the end of every context.
-pub const BINDINGS: &[Binding] = &[
-    // ── Left / Files pane ──────────────────────────────────────────
-    Binding {
+// which are appended at the end of every context.
+pub const BINDING_DEFS: &[BindingDef] = &[
+    // ── Navigation (Left / Files / Palette / Browser) ─────────────
+    BindingDef {
         action: Action::MoveDown,
-        keys: &[KeyCombo::char('j'), KeyCombo::key(KeyCode::Down)],
-        scopes: &[BindingScope::Left, BindingScope::Files],
+        default_keys: &[key!(j), key!(Down)],
+        scopes: &[
+            BindingScope::Left,
+            BindingScope::Files,
+            BindingScope::Palette,
+            BindingScope::Browser,
+        ],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "j/k",
             description: "Move through projects and sessions",
         }),
-        hints: &[
-            (HintContext::LeftProject, "j/k", "Move"),
-            (HintContext::LeftSession, "j/k", "Move"),
-            (HintContext::Files, "j/k", "Move"),
+        hint_contexts: &[
+            (HintContext::LeftProject, "Move"),
+            (HintContext::LeftSession, "Move"),
+            (HintContext::Files, "Move"),
         ],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::MoveUp,
-        keys: &[KeyCombo::char('k'), KeyCombo::key(KeyCode::Up)],
-        scopes: &[BindingScope::Left, BindingScope::Files],
-        help: None, // covered by MoveDown's "j/k" label
-        hints: &[],
+        default_keys: &[key!(k), key!(Up)],
+        scopes: &[
+            BindingScope::Left,
+            BindingScope::Files,
+            BindingScope::Palette,
+            BindingScope::Browser,
+        ],
+        help: None, // covered by MoveDown's combined label
+        hint_contexts: &[],
         palette: None,
-        native: false,
     },
-    Binding {
+    // ── Projects pane ─────────────────────────────────────────────
+    BindingDef {
         action: Action::ToggleProject,
-        keys: &[KeyCombo::char(' ')],
+        default_keys: &[key!(space)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "Space",
             description: "Collapse/expand project",
         }),
-        hints: &[(HintContext::LeftProject, "Space", "Toggle")],
+        hint_contexts: &[(HintContext::LeftProject, "Toggle")],
         palette: Some(PaletteEntry {
             name: "toggle-project",
             description: "Collapse or expand the selected project's agents",
-            shortcut: Some("Space"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::NewAgent,
-        keys: &[KeyCombo::char('n')],
+        default_keys: &[key!(n)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "n",
             description: "New agent session (creates worktree)",
         }),
-        hints: &[(HintContext::LeftProject, "n", "New agent")],
+        hint_contexts: &[(HintContext::LeftProject, "New agent")],
         palette: Some(PaletteEntry {
             name: "new-agent",
             description: "Create a new agent for the selected project",
-            shortcut: Some("n"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::FocusAgent,
-        keys: &[KeyCombo::key(KeyCode::Enter)],
+        default_keys: &[key!(enter)],
         scopes: &[BindingScope::Left],
         help: None,
-        hints: &[(HintContext::LeftSession, "Enter", "Focus")],
+        hint_contexts: &[(HintContext::LeftSession, "Focus")],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::OpenProjectBrowser,
-        keys: &[KeyCombo::char('a')],
+        default_keys: &[key!(a)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "a",
             description: "Open project browser",
         }),
-        hints: &[
-            (HintContext::LeftProject, "a", "Add project"),
-            (HintContext::LeftSession, "a", "Add project"),
+        hint_contexts: &[
+            (HintContext::LeftProject, "Add project"),
+            (HintContext::LeftSession, "Add project"),
         ],
         palette: Some(PaletteEntry {
             name: "add-project",
             description: "Open the project browser",
-            shortcut: Some("a"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::CopyPath,
-        keys: &[KeyCombo::char('y')],
+        default_keys: &[key!(y)],
         scopes: &[BindingScope::Left],
         help: None,
-        hints: &[
-            (HintContext::LeftProject, "y", "Copy path"),
-            (HintContext::LeftSession, "y", "Copy path"),
+        hint_contexts: &[
+            (HintContext::LeftProject, "Copy path"),
+            (HintContext::LeftSession, "Copy path"),
         ],
         palette: Some(PaletteEntry {
             name: "copy-path",
             description: "Copy the selected agent's worktree path",
-            shortcut: Some("y"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::CycleProvider,
-        keys: &[KeyCombo::char('d')],
+        default_keys: &[key!(d)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "d",
             description: "Cycle default provider",
         }),
-        hints: &[(HintContext::LeftProject, "d", "Provider")],
+        hint_contexts: &[(HintContext::LeftProject, "Provider")],
         palette: Some(PaletteEntry {
             name: "provider",
             description: "Toggle the selected project's default provider",
-            shortcut: Some("d"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::RefreshProject,
-        keys: &[KeyCombo::char('u')],
+        default_keys: &[key!(u)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "u",
             description: "Refresh checkout (git pull --ff-only)",
         }),
-        hints: &[(HintContext::LeftProject, "u", "Pull")],
+        hint_contexts: &[(HintContext::LeftProject, "Pull")],
         palette: Some(PaletteEntry {
             name: "refresh-project",
             description: "Git pull the selected project checkout",
-            shortcut: Some("u"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::ReconnectAgent,
-        keys: &[KeyCombo::char('r'), KeyCombo::key(KeyCode::Enter)],
+        default_keys: &[key!(r), key!(enter)],
         scopes: &[BindingScope::Left, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "r",
             description: "Restart agent CLI",
         }),
-        hints: &[(HintContext::LeftSession, "r", "Reconnect")],
+        hint_contexts: &[(HintContext::LeftSession, "Reconnect")],
         palette: Some(PaletteEntry {
             name: "reconnect-agent",
             description: "Restart the CLI for the selected agent",
-            shortcut: None,
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::DeleteSession,
-        keys: &[KeyCombo::ctrl('d')],
+        default_keys: &[key!(ctrl - d)],
         scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
             section: "Projects pane",
-            label: "^D",
             description: "Delete selected session/worktree",
         }),
-        hints: &[(HintContext::LeftSession, "^D", "Delete")],
+        hint_contexts: &[(HintContext::LeftSession, "Delete")],
         palette: Some(PaletteEntry {
             name: "delete-agent",
             description: "Delete the selected agent session",
-            shortcut: None,
         }),
-        native: false,
     },
-    // ── Center pane ────────────────────────────────────────────────
-    Binding {
+    // ── Agent pane ────────────────────────────────────────────────
+    BindingDef {
         action: Action::InteractAgent,
-        keys: &[KeyCombo::char('i')],
+        default_keys: &[key!(i)],
         scopes: &[BindingScope::Left, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
-            label: "i",
             description: "Start a prompt turn for the agent",
         }),
-        hints: &[(HintContext::Center, "i", "Interact")],
+        hint_contexts: &[(HintContext::Center, "Interact")],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
+        action: Action::ExitInteractive,
+        default_keys: &[key!(ctrl - g)],
+        scopes: &[BindingScope::Interactive],
+        help: Some(HelpEntry {
+            section: "Agent pane",
+            description: "Exit interactive mode",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
         action: Action::ScrollPageUp,
-        keys: &[KeyCombo::ctrl('b'), KeyCombo::key(KeyCode::PageUp)],
+        default_keys: &[key!(ctrl - b), key!(pageup)],
         scopes: &[BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
-            label: "^B/PgUp",
             description: "Scroll up one page",
         }),
-        hints: &[],
+        hint_contexts: &[],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::ScrollPageDown,
-        keys: &[KeyCombo::ctrl('f'), KeyCombo::key(KeyCode::PageDown)],
+        default_keys: &[key!(ctrl - f), key!(pagedown)],
         scopes: &[BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
-            label: "^F/PgDn",
             description: "Scroll down one page",
         }),
-        hints: &[],
+        hint_contexts: &[],
         palette: None,
-        native: false,
     },
-    // ── Files pane ─────────────────────────────────────────────────
-    Binding {
+    // ── Files pane (git staging) ──────────────────────────────────
+    BindingDef {
         action: Action::OpenDiff,
-        keys: &[KeyCombo::key(KeyCode::Enter)],
+        default_keys: &[key!(enter)],
         scopes: &[BindingScope::Files],
         help: Some(HelpEntry {
             section: "Files pane",
-            label: "Enter",
             description: "Open selected file diff",
         }),
-        hints: &[(HintContext::Files, "Enter", "Diff")],
+        hint_contexts: &[(HintContext::Files, "Diff")],
         palette: None,
-        native: false,
     },
-    // ── Global ─────────────────────────────────────────────────────
-    // (placed after pane bindings so ^P / ? appear last in hints)
-    Binding {
+    BindingDef {
+        action: Action::StageUnstage,
+        default_keys: &[key!(space)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Stage or unstage selected file",
+        }),
+        hint_contexts: &[(HintContext::Files, "Stage/Unstage")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::CommitChanges,
+        default_keys: &[key!(c)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Commit staged changes",
+        }),
+        hint_contexts: &[(HintContext::Files, "Commit")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::GenerateCommitMessage,
+        default_keys: &[key!(ctrl - g)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Generate AI commit message",
+        }),
+        hint_contexts: &[(HintContext::Files, "AI msg")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::DiscardChanges,
+        default_keys: &[key!(ctrl - d)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Discard changes to selected file",
+        }),
+        hint_contexts: &[(HintContext::Files, "Discard")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::EngageCommitInput,
+        default_keys: &[key!(i)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Write a commit message",
+        }),
+        hint_contexts: &[(HintContext::Files, "Commit msg")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::PushToRemote,
+        default_keys: &[key!(u)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Push to remote",
+        }),
+        hint_contexts: &[(HintContext::Files, "Push")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::PullFromRemote,
+        default_keys: &[key!(p)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Pull from remote",
+        }),
+        hint_contexts: &[(HintContext::Files, "Pull")],
+        palette: None,
+    },
+    // ── Commit message editor ─────────────────────────────────────
+    BindingDef {
+        action: Action::ExitCommitInput,
+        default_keys: &[key!(ctrl - g), key!(esc)],
+        scopes: &[BindingScope::CommitInput],
+        help: Some(HelpEntry {
+            section: "Commit input",
+            description: "Exit commit input",
+        }),
+        hint_contexts: &[(HintContext::CommitInput, "Exit")],
+        palette: None,
+    },
+    // ── Global ────────────────────────────────────────────────────
+    // (placed after pane bindings so palette / help appear last in hints)
+    BindingDef {
         action: Action::FocusNext,
-        keys: &[KeyCombo::key(KeyCode::Tab)],
+        default_keys: &[key!(tab)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "Tab",
             description: "Focus next pane",
         }),
-        hints: &[
-            (HintContext::Center, "Tab", "Next"),
-            (HintContext::Files, "Tab", "Next"),
+        hint_contexts: &[
+            (HintContext::Center, "Next"),
+            (HintContext::Files, "Next"),
         ],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::FocusPrev,
-        keys: &[KeyCombo::key(KeyCode::BackTab)],
+        default_keys: &[key!(shift - tab)],
         scopes: &[BindingScope::Global],
         help: None,
-        hints: &[],
+        hint_contexts: &[],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::OpenPalette,
-        keys: &[KeyCombo::ctrl('p')],
+        default_keys: &[key!(ctrl - p)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "^P",
             description: "Open command palette",
         }),
-        hints: &[
-            (HintContext::LeftProject, "^P", "Palette"),
-            (HintContext::LeftSession, "^P", "Palette"),
-            (HintContext::Center, "^P", "Palette"),
-            (HintContext::Files, "^P", "Palette"),
+        hint_contexts: &[
+            (HintContext::LeftProject, "Palette"),
+            (HintContext::LeftSession, "Palette"),
+            (HintContext::Center, "Palette"),
+            (HintContext::Files, "Palette"),
         ],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::ToggleResizeMode,
-        keys: &[KeyCombo::ctrl('w')],
+        default_keys: &[key!(ctrl - w)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "^W",
             description: "Resize mode (h/l side panes)",
         }),
-        hints: &[],
+        hint_contexts: &[],
         palette: None,
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::ToggleSidebar,
-        keys: &[KeyCombo::char('[')],
+        default_keys: &[KeyCombination::one_key(KeyCode::Char('['), KeyModifiers::NONE)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "[",
             description: "Toggle sidebar",
         }),
-        hints: &[],
+        hint_contexts: &[],
         palette: Some(PaletteEntry {
             name: "toggle-sidebar",
             description: "Collapse or expand the projects sidebar",
-            shortcut: Some("["),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::ToggleHelp,
-        keys: &[KeyCombo::char('?')],
+        default_keys: &[KeyCombination::one_key(KeyCode::Char('?'), KeyModifiers::NONE)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "?",
             description: "Toggle help",
         }),
-        hints: &[
-            (HintContext::LeftProject, "?", "Help"),
-            (HintContext::LeftSession, "?", "Help"),
-            (HintContext::Center, "?", "Help"),
-            (HintContext::Files, "?", "Help"),
+        hint_contexts: &[
+            (HintContext::LeftProject, "Help"),
+            (HintContext::LeftSession, "Help"),
+            (HintContext::Center, "Help"),
+            (HintContext::Files, "Help"),
         ],
         palette: Some(PaletteEntry {
             name: "help",
             description: "Open the help overlay",
-            shortcut: Some("?"),
         }),
-        native: false,
     },
-    Binding {
+    BindingDef {
         action: Action::Quit,
-        keys: &[KeyCombo::char('q'), KeyCombo::ctrl('c')],
+        default_keys: &[key!(q), key!(ctrl - c)],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
-            label: "q",
             description: "Quit",
         }),
-        hints: &[],
+        hint_contexts: &[],
         palette: None,
-        native: false,
+    },
+    BindingDef {
+        action: Action::CloseOverlay,
+        default_keys: &[key!(esc)],
+        scopes: &[BindingScope::Global, BindingScope::Palette, BindingScope::Browser, BindingScope::Dialog],
+        help: Some(HelpEntry {
+            section: "Global",
+            description: "Close the current overlay or dialog",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    // ── Resize mode ───────────────────────────────────────────────
+    BindingDef {
+        action: Action::ResizeGrow,
+        default_keys: &[key!(l), key!(Right)],
+        scopes: &[BindingScope::Resize],
+        help: Some(HelpEntry {
+            section: "Resize mode",
+            description: "Grow the left pane width",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ResizeShrink,
+        default_keys: &[key!(h), key!(Left)],
+        scopes: &[BindingScope::Resize],
+        help: Some(HelpEntry {
+            section: "Resize mode",
+            description: "Shrink the left pane width",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    // ── Overlays and dialogs ──────────────────────────────────────
+    BindingDef {
+        action: Action::SearchToggle,
+        default_keys: &[KeyCombination::one_key(KeyCode::Char('/'), KeyModifiers::NONE)],
+        scopes: &[BindingScope::Palette, BindingScope::Browser],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Toggle search mode",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::GoToPath,
+        default_keys: &[key!(g)],
+        scopes: &[BindingScope::Browser],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Open path editor in the project browser",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::OpenEntry,
+        default_keys: &[key!(enter), key!(Right), key!(l)],
+        scopes: &[BindingScope::Browser],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Open or navigate into the selected entry",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::AddCurrentDir,
+        default_keys: &[key!(o)],
+        scopes: &[BindingScope::Browser],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Add the current directory as a project",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::Confirm,
+        default_keys: &[key!(enter)],
+        scopes: &[BindingScope::Dialog, BindingScope::Palette],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Confirm the selected action",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ToggleSelection,
+        default_keys: &[key!(h), key!(l), key!(Left), key!(Right), key!(tab)],
+        scopes: &[BindingScope::Dialog],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Toggle between options in a confirmation dialog",
+        }),
+        hint_contexts: &[],
+        palette: None,
     },
     // ── Palette-only (no direct keybinding) ────────────────────────
-    Binding {
+    BindingDef {
         action: Action::DeleteProject,
-        keys: &[],
+        default_keys: &[],
         scopes: &[],
         help: None,
-        hints: &[],
+        hint_contexts: &[],
         palette: Some(PaletteEntry {
             name: "delete-project",
             description: "Remove the selected project and its sessions",
-            shortcut: None,
         }),
-        native: false,
     },
-    // ── Files pane (native — handled directly in handle_files_key) ──────
-    Binding {
-        action: Action::ToggleProject, // reused: Space in files = stage/unstage
-        keys: &[KeyCombo::char(' ')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Files pane",
-            label: "Space",
-            description: "Stage or unstage selected file",
-        }),
-        hints: &[(HintContext::Files, "Space", "Stage/Unstage")],
-        palette: None,
-        native: true,
-    },
-    Binding {
-        action: Action::CommitChanges,
-        keys: &[KeyCombo::char('c')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Files pane",
-            label: "c",
-            description: "Commit staged changes",
-        }),
-        hints: &[(HintContext::Files, "c", "Commit")],
-        palette: None,
-        native: true,
-    },
-    Binding {
-        action: Action::GenerateCommitMessage,
-        keys: &[KeyCombo::ctrl('g')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Files pane",
-            label: "^G",
-            description: "Generate AI commit message",
-        }),
-        hints: &[(HintContext::Files, "^G", "AI msg")],
-        palette: None,
-        native: true,
-    },
-    Binding {
-        action: Action::DeleteSession, // reused: ^D in files = discard
-        keys: &[KeyCombo::ctrl('d')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Files pane",
-            label: "^D",
-            description: "Discard changes to selected file",
-        }),
-        hints: &[(HintContext::Files, "^D", "Discard")],
-        palette: None,
-        native: true,
-    },
-    Binding {
-        action: Action::InteractAgent, // reused: i in files = engage commit input
-        keys: &[KeyCombo::char('i')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Files pane",
-            label: "i",
-            description: "Write a commit message",
-        }),
-        hints: &[(HintContext::Files, "i", "Commit msg")],
-        palette: None,
-        native: true,
-    },
-    // ── Commit input (native keybindings — handled directly, not via lookup) ──
-    Binding {
-        action: Action::GenerateCommitMessage, // ^G exits commit input
-        keys: &[KeyCombo::ctrl('g')],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Commit input",
-            label: "^G",
-            description: "Exit commit input",
-        }),
-        hints: &[], // works but not shown in hint bar
-        palette: None,
-        native: true,
-    },
-    Binding {
-        action: Action::InsertNewline,
-        keys: &[KeyCombo::key(KeyCode::Esc)],
-        scopes: &[],
-        help: Some(HelpEntry {
-            section: "Commit input",
-            label: "Esc",
-            description: "Exit commit input",
-        }),
-        hints: &[(HintContext::CommitInput, "Esc", "Exit")],
-        palette: None,
-        native: true,
-    },
-    Binding {
+    BindingDef {
         action: Action::RemoveProject,
-        keys: &[],
+        default_keys: &[],
         scopes: &[],
         help: None,
-        hints: &[],
+        hint_contexts: &[],
         palette: Some(PaletteEntry {
             name: "remove-project",
             description: "Remove project from app (keeps files on disk)",
-            shortcut: None,
         }),
-        native: false,
     },
 ];
 
-const HELP_SECTION_ORDER: &[&str] = &["Global", "Projects pane", "Agent pane", "Files pane", "Commit input"];
+const HELP_SECTION_ORDER: &[&str] = &[
+    "Global",
+    "Projects pane",
+    "Agent pane",
+    "Files pane",
+    "Commit input",
+    "Resize mode",
+    "Overlays",
+];
 
-/// Find the action for a key event in the given scope.
-pub fn lookup(key: &KeyEvent, scope: BindingScope) -> Option<Action> {
-    BINDINGS
-        .iter()
-        .filter(|b| b.scopes.contains(&scope))
-        .find(|b| b.matches(key))
-        .map(|b| b.action)
+/// Normalize `BackTab` (sent by crossterm for shift-tab) into `Tab + SHIFT`
+/// so that `key!(shift-tab)` from crokey matches the actual terminal event.
+fn normalize_backtab(kc: KeyCombination) -> KeyCombination {
+    if matches!(kc.codes, crokey::OneToThree::One(KeyCode::BackTab)) {
+        KeyCombination::new(KeyCode::Tab, kc.modifiers | KeyModifiers::SHIFT)
+    } else {
+        kc
+    }
 }
 
-/// Status-bar hints for a given context, in display order.
-pub fn hints_for(ctx: HintContext) -> Vec<(&'static str, &'static str)> {
-    let mut result = Vec::new();
-    for binding in BINDINGS {
-        for &(hint_ctx, label, desc) in binding.hints {
-            if hint_ctx == ctx {
-                result.push((label, desc));
-            }
+/// Returns the shared display format: lowercase modifiers, dash separator.
+/// e.g. `ctrl-p`, `shift-tab`, `space`, `enter`.
+/// Format for UI display: title-case modifiers, natural key names.
+/// e.g. `Ctrl-p`, `Shift-Tab`, `PgDn`, `Enter`.
+pub fn display_format() -> KeyCombinationFormat {
+    KeyCombinationFormat::default()
+}
+
+/// Format a key combo for display in the UI.
+#[cfg(test)]
+pub fn format_key(kc: KeyCombination) -> String {
+    display_format().to_string(kc)
+}
+
+/// Format for config file serialization: all lowercase.
+/// e.g. `ctrl-p`, `shift-tab`, `pgdn`, `enter`.
+fn config_format() -> KeyCombinationFormat {
+    KeyCombinationFormat::default().with_lowercase_modifiers()
+}
+
+/// Format a key combo for config file serialization (all lowercase).
+pub fn format_key_for_config(kc: KeyCombination) -> String {
+    config_format().to_string(kc).to_lowercase()
+}
+
+// ---------------------------------------------------------------------------
+// RuntimeBindings: the runtime-resolved keybinding table built from config.
+// ---------------------------------------------------------------------------
+
+/// A single runtime-resolved binding.
+pub struct RuntimeBinding {
+    pub action: Action,
+    pub keys: Vec<KeyCombination>,
+    pub scopes: &'static [BindingScope],
+    pub help_section: Option<&'static str>,
+    pub help_description: Option<&'static str>,
+    pub hint_contexts: &'static [(HintContext, &'static str)],
+    pub palette_name: Option<&'static str>,
+    pub palette_description: Option<&'static str>,
+}
+
+pub struct RuntimeBindings {
+    bindings: Vec<RuntimeBinding>,
+    #[allow(dead_code)] // Will be used to filter terminal-native hints
+    pub show_terminal_keys: bool,
+    format: KeyCombinationFormat,
+}
+
+impl RuntimeBindings {
+    /// Build runtime bindings from a [`KeysConfig`].
+    /// Parses key strings from the config, falling back to defaults for
+    /// missing or unparseable entries.
+    pub fn from_keys_config(keys: &crate::config::KeysConfig) -> Self {
+        Self::new(
+            |action| {
+                let config_name = action.config_name();
+                match keys.bindings.get(config_name) {
+                    Some(key_strs) => key_strs
+                        .iter()
+                        .filter_map(|s| crokey::parse(s).ok())
+                        .collect(),
+                    None => BINDING_DEFS
+                        .iter()
+                        .find(|d| d.action == action)
+                        .map(|d| d.default_keys.to_vec())
+                        .unwrap_or_default(),
+                }
+            },
+            keys.show_terminal_keys,
+        )
+    }
+
+    /// Build runtime bindings from parsed config keys.
+    /// `keys_for` returns the parsed `KeyCombination`s for a given action.
+    pub fn new(
+        keys_for: impl Fn(Action) -> Vec<KeyCombination>,
+        show_terminal_keys: bool,
+    ) -> Self {
+        let format = display_format();
+        let bindings = BINDING_DEFS
+            .iter()
+            .map(|def| {
+                let keys = keys_for(def.action);
+                RuntimeBinding {
+                    action: def.action,
+                    keys,
+                    scopes: def.scopes,
+                    help_section: def.help.as_ref().map(|h| h.section),
+                    help_description: def.help.as_ref().map(|h| h.description),
+                    hint_contexts: def.hint_contexts,
+                    palette_name: def.palette.as_ref().map(|p| p.name),
+                    palette_description: def.palette.as_ref().map(|p| p.description),
+                }
+            })
+            .collect();
+        Self {
+            bindings,
+            show_terminal_keys,
+            format,
         }
     }
-    result
-}
 
-/// Help overlay sections grouped by section name, in display order.
-pub fn help_sections() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
-    let mut sections: Vec<(&str, Vec<(&str, &str)>)> = HELP_SECTION_ORDER
-        .iter()
-        .map(|&s| (s, Vec::new()))
-        .collect();
-    for binding in BINDINGS {
-        if let Some(ref help) = binding.help {
-            for section in &mut sections {
-                if section.0 == help.section {
-                    section.1.push((help.label, help.description));
-                    break;
+    /// Find the action for a key event in the given scope.
+    /// Plain bindings (no modifiers) reject Ctrl/Alt combos so that e.g.
+    /// Ctrl+D does not accidentally match a plain `d` binding.
+    pub fn lookup(&self, key: &KeyEvent, scope: BindingScope) -> Option<Action> {
+        let incoming = normalize_backtab(KeyCombination::from(*key).normalized());
+        self.bindings
+            .iter()
+            .filter(|b| b.scopes.contains(&scope))
+            .find(|b| {
+                b.keys.iter().any(|k| {
+                    let norm = normalize_backtab(k.normalized());
+                    if norm.codes != incoming.codes {
+                        return false;
+                    }
+                    if norm.modifiers.is_empty() {
+                        // Plain binding: reject if any modifier is pressed
+                        incoming.modifiers.is_empty()
+                    } else {
+                        incoming.modifiers.contains(norm.modifiers)
+                    }
+                })
+            })
+            .map(|b| b.action)
+    }
+
+    /// Display label for the first key combo of an action.
+    /// Uses natural casing (e.g. "PgDn", "shift-Tab") suitable for UI display.
+    pub fn label_for(&self, action: Action) -> String {
+        self.bindings
+            .iter()
+            .find(|b| b.action == action)
+            .and_then(|b| b.keys.first())
+            .map(|k| self.format.to_string(*k))
+            .unwrap_or_default()
+    }
+
+    /// Display labels for all key combos of an action, joined with `/`.
+    /// Uses natural casing (e.g. "ctrl-f/PgDn") suitable for UI display.
+    pub fn labels_for(&self, action: Action) -> String {
+        self.bindings
+            .iter()
+            .find(|b| b.action == action)
+            .map(|b| {
+                b.keys
+                    .iter()
+                    .map(|k| self.format.to_string(*k))
+                    .collect::<Vec<_>>()
+                    .join("/")
+            })
+            .unwrap_or_default()
+    }
+
+    /// Combined label for two related actions (e.g. MoveDown + MoveUp → "j/k").
+    /// Takes the first key from each action.
+    pub fn combined_label(&self, a: Action, b: Action) -> String {
+        let la = self.label_for(a);
+        let lb = self.label_for(b);
+        if la.is_empty() && lb.is_empty() {
+            String::new()
+        } else if la.is_empty() {
+            lb
+        } else if lb.is_empty() {
+            la
+        } else {
+            format!("{la}/{lb}")
+        }
+    }
+
+    /// Status-bar hints for a given context, in display order.
+    pub fn hints_for(&self, ctx: HintContext) -> Vec<(String, &'static str)> {
+        let mut result = Vec::new();
+        for b in &self.bindings {
+            for &(hint_ctx, desc) in b.hint_contexts {
+                if hint_ctx == ctx {
+                    // For MoveDown/MoveUp, show combined "j/k" style label
+                    let label = if b.action == Action::MoveDown {
+                        self.combined_label(Action::MoveDown, Action::MoveUp)
+                    } else {
+                        self.label_for(b.action)
+                    };
+                    result.push((label, desc));
                 }
             }
         }
+        result
     }
-    sections.retain(|(_, entries)| !entries.is_empty());
-    sections
-}
 
-/// All palette-visible bindings matching a filter string.
-pub fn filtered_palette(input: &str) -> Vec<&'static Binding> {
-    let needle = input.trim().to_lowercase();
-    if needle.is_empty() {
-        return BINDINGS.iter().filter(|b| b.palette.is_some()).collect();
-    }
-    let mut name_matches = Vec::new();
-    let mut desc_matches = Vec::new();
-    for b in BINDINGS.iter() {
-        if let Some(ref p) = b.palette {
-            if p.name.contains(&needle) {
-                name_matches.push(b);
-            } else if p.description.to_lowercase().contains(&needle) {
-                desc_matches.push(b);
+    /// Help overlay sections grouped by section name, in display order.
+    pub fn help_sections(&self) -> Vec<(&'static str, Vec<(String, &'static str)>)> {
+        let mut sections: Vec<(&str, Vec<(String, &str)>)> = HELP_SECTION_ORDER
+            .iter()
+            .map(|&s| (s, Vec::new()))
+            .collect();
+        for b in &self.bindings {
+            if let (Some(section), Some(description)) = (b.help_section, b.help_description) {
+                // For MoveDown, show combined "j/k" label
+                let label = if b.action == Action::MoveDown {
+                    self.combined_label(Action::MoveDown, Action::MoveUp)
+                } else {
+                    self.labels_for(b.action)
+                };
+                if label.is_empty() {
+                    continue;
+                }
+                for sec in &mut sections {
+                    if sec.0 == section {
+                        sec.1.push((label, description));
+                        break;
+                    }
+                }
             }
         }
+        sections.retain(|(_, entries)| !entries.is_empty());
+        sections
     }
-    name_matches.extend(desc_matches);
-    name_matches
+
+    /// All palette-visible bindings matching a filter string.
+    pub fn filtered_palette(&self, input: &str) -> Vec<&RuntimeBinding> {
+        let needle = input.trim().to_lowercase();
+        if needle.is_empty() {
+            return self
+                .bindings
+                .iter()
+                .filter(|b| b.palette_name.is_some())
+                .collect();
+        }
+        let mut name_matches = Vec::new();
+        let mut desc_matches = Vec::new();
+        for b in &self.bindings {
+            if let Some(name) = b.palette_name {
+                if name.contains(&needle) {
+                    name_matches.push(b);
+                } else if let Some(desc) = b.palette_description {
+                    if desc.to_lowercase().contains(&needle) {
+                        desc_matches.push(b);
+                    }
+                }
+            }
+        }
+        name_matches.extend(desc_matches);
+        name_matches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_bindings() -> RuntimeBindings {
+        RuntimeBindings::new(
+            |action| {
+                BINDING_DEFS
+                    .iter()
+                    .find(|d| d.action == action)
+                    .map(|d| d.default_keys.to_vec())
+                    .unwrap_or_default()
+            },
+            true,
+        )
+    }
+
+    #[test]
+    fn lookup_finds_action_in_correct_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(bindings.lookup(&key, BindingScope::Left), Some(Action::MoveDown));
+        assert_eq!(bindings.lookup(&key, BindingScope::Center), None);
+    }
+
+    #[test]
+    fn lookup_plain_key_rejects_ctrl_modifier() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL);
+        assert_eq!(bindings.lookup(&key, BindingScope::Left), None);
+    }
+
+    #[test]
+    fn lookup_ctrl_combo_matches() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Global),
+            Some(Action::OpenPalette)
+        );
+    }
+
+    #[test]
+    fn label_for_returns_display_label() {
+        let bindings = default_bindings();
+        let label = bindings.label_for(Action::OpenPalette);
+        assert_eq!(label, "Ctrl-p");
+    }
+
+    #[test]
+    fn labels_for_joins_multiple_keys() {
+        let bindings = default_bindings();
+        let labels = bindings.labels_for(Action::Quit);
+        assert_eq!(labels, "q/Ctrl-c");
+    }
+
+    #[test]
+    fn combined_label_for_move() {
+        let bindings = default_bindings();
+        let label = bindings.combined_label(Action::MoveDown, Action::MoveUp);
+        assert_eq!(label, "j/k");
+    }
+
+    #[test]
+    fn hints_for_returns_dynamic_labels() {
+        let bindings = default_bindings();
+        let hints = bindings.hints_for(HintContext::LeftProject);
+        assert!(!hints.is_empty());
+        // MoveDown hint should show combined j/k label
+        let move_hint = hints.iter().find(|(_, desc)| *desc == "Move");
+        assert!(move_hint.is_some());
+        assert_eq!(move_hint.unwrap().0, "j/k");
+    }
+
+    #[test]
+    fn help_sections_produces_valid_sections() {
+        let bindings = default_bindings();
+        let sections = bindings.help_sections();
+        assert!(!sections.is_empty());
+        let section_names: Vec<_> = sections.iter().map(|(n, _)| *n).collect();
+        assert!(section_names.contains(&"Global"));
+        assert!(section_names.contains(&"Projects pane"));
+    }
+
+    #[test]
+    fn filtered_palette_returns_all_when_empty() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("");
+        assert!(results.len() >= 2); // at least delete-project and remove-project
+    }
+
+    #[test]
+    fn filtered_palette_filters_by_name() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("toggle");
+        assert!(results
+            .iter()
+            .all(|b| b.palette_name.unwrap().contains("toggle")
+                || b.palette_description
+                    .unwrap()
+                    .to_lowercase()
+                    .contains("toggle")));
+    }
+
+    #[test]
+    fn every_action_has_config_name() {
+        // Ensure no action panics when asked for config_name
+        for def in BINDING_DEFS {
+            let name = def.action.config_name();
+            assert!(!name.is_empty());
+        }
+    }
+
+    #[test]
+    fn format_key_display_uses_title_case_modifiers() {
+        let kc = key!(ctrl - p);
+        assert_eq!(format_key(kc), "Ctrl-p");
+
+        let kc2 = key!(enter);
+        assert_eq!(format_key(kc2), "Enter");
+
+        let kc3 = key!(space);
+        assert_eq!(format_key(kc3), "Space");
+    }
+
+    #[test]
+    fn format_key_for_config_is_all_lowercase() {
+        assert_eq!(format_key_for_config(key!(ctrl - p)), "ctrl-p");
+        assert_eq!(format_key_for_config(key!(shift - tab)), "shift-tab");
+        assert_eq!(format_key_for_config(key!(enter)), "enter");
+    }
+
+    #[test]
+    fn lookup_shift_tab_matches_backtab() {
+        let bindings = default_bindings();
+        // Crossterm sends BackTab with SHIFT for shift-tab
+        let key = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Global),
+            Some(Action::FocusPrev),
+            "shift-tab (BackTab) should match FocusPrev"
+        );
+    }
+
+    #[test]
+    fn new_actions_are_in_binding_defs() {
+        let actions_in_defs: Vec<Action> = BINDING_DEFS.iter().map(|d| d.action).collect();
+        assert!(actions_in_defs.contains(&Action::ExitInteractive));
+        assert!(actions_in_defs.contains(&Action::CloseOverlay));
+        assert!(actions_in_defs.contains(&Action::ResizeGrow));
+        assert!(actions_in_defs.contains(&Action::StageUnstage));
+        assert!(actions_in_defs.contains(&Action::ExitCommitInput));
+        assert!(actions_in_defs.contains(&Action::PushToRemote));
+        assert!(actions_in_defs.contains(&Action::AddCurrentDir));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a `[keys]` section to `config.toml` where every keybinding is materialized and fully rebindable. The config file is the sole source of truth — on first launch all defaults are written out, after that the config is authoritative.
- Migrates key parsing, formatting, and matching to the `crokey` crate, replacing the hand-rolled `KeyCombo` type. UI labels use title-case (`Ctrl-p`, `PgDn`, `Shift-Tab`) while config values are all-lowercase (`ctrl-p`, `pgdn`, `shift-tab`); `crokey::parse` is case-insensitive so any casing works in config input.
- Introduces `RuntimeBindings` with scoped dispatch (10 scopes: Global, Left, Center, Files, Interactive, Resize, Palette, Browser, Dialog, CommitInput) and 42 bindable `Action` variants, replacing all hardcoded `KeyCode` checks in `input.rs`.
- All hint-bar labels, help overlay entries, and command palette listings are generated dynamically from the runtime binding table — no hardcoded label strings remain.
- Adds startup validation (`validate_keys`) that rejects unknown action names and unparseable key strings with a clear error before the TUI launches. Adds `show_terminal_keys` option and removes shortcut badges from the command palette (since palette commands are context-independent). Includes 31 passing tests covering round-trip config serialization, key lookup, label formatting, and validation.

## Test plan
- [x] `cargo test` — all 31 tests pass (27 unit + 4 integration)
- [ ] Launch app, verify all hint bars show title-case key labels
- [ ] Edit `config.toml` `[keys]` section to rebind a key, verify it takes effect
- [ ] Put an invalid key string in config, verify app refuses to start with error message
- [ ] Verify Shift-Tab navigates between panes
- [ ] Open command palette, verify 2-column layout (name + description, no shortcut badges)