### PR TITLE
Make AI providers fully declarative and config-driven

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
  "crokey",
  "crossterm 0.29.0",
  "home",
+ "indexmap",
  "petname",
  "portable-pty",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ petname = { version = "2.0.2", default-features = false, features = ["default-rn
 similar = "2"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-onig"] }
 crokey = "1.4.0"
+indexmap = { version = "2.13.0", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -486,7 +486,7 @@ impl App {
             diff
         };
         let cfg = provider_config(&self.config, &session.provider);
-        let prov = provider::create_provider(&session.provider, cfg);
+        let prov = provider::create_provider(session.provider.as_str(), cfg);
         let tx = self.worker_tx.clone();
         self.commit_generating = true;
         self.set_busy("Generating AI commit message from staged diff…");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -561,6 +561,6 @@ pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> Provi
         .cloned()
         .unwrap_or_else(|| ProviderCommandConfig {
             command: provider.as_str().to_string(),
-            args: Vec::new(),
+            ..Default::default()
         })
 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -220,10 +220,18 @@ impl App {
             self.set_error("Select a project first.");
             return Ok(());
         };
-        let next = match project.default_provider {
-            ProviderKind::Claude => ProviderKind::Codex,
-            ProviderKind::Codex => ProviderKind::Claude,
-        };
+        let provider_names: Vec<&String> = self.config.providers.commands.keys().collect();
+        if provider_names.is_empty() {
+            self.set_error("No providers configured.");
+            return Ok(());
+        }
+        let current = project.default_provider.as_str();
+        let current_idx = provider_names
+            .iter()
+            .position(|n| n.as_str() == current)
+            .unwrap_or(0);
+        let next_idx = (current_idx + 1) % provider_names.len();
+        let next = ProviderKind::new(provider_names[next_idx].clone());
         if let Some(existing) = self
             .projects
             .iter_mut()

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -211,7 +211,7 @@ pub(crate) fn run_create_agent_job(
         updated_at: Utc::now(),
     };
     let provider_cfg = provider_config(&config, &session.provider);
-    if let Err(hint) = check_provider_available(session.provider.as_str(), &provider_cfg.command) {
+    if let Err(hint) = check_provider_available(&provider_cfg) {
         logger::error(&format!("provider not found for {}: {hint}", session.id));
         let _ = git::remove_worktree(
             &repo_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -41,7 +42,7 @@ pub struct Defaults {
 #[serde(default)]
 pub struct ProvidersConfig {
     #[serde(flatten)]
-    pub commands: BTreeMap<String, ProviderCommandConfig>,
+    pub commands: IndexMap<String, ProviderCommandConfig>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -52,10 +53,20 @@ pub struct LoggingConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OneshotOutput {
+    Stdout,
+    Tempfile,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ProviderCommandConfig {
     pub command: String,
     pub args: Vec<String>,
+    pub oneshot_args: Vec<String>,
+    pub oneshot_output: OneshotOutput,
+    pub install_hint: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -143,6 +154,9 @@ impl Default for ProviderCommandConfig {
         Self {
             command: String::new(),
             args: Vec::new(),
+            oneshot_args: Vec::new(),
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
         }
     }
 }
@@ -483,6 +497,11 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
             ProviderCommandConfig {
                 command: "claude".to_string(),
                 args: Vec::new(),
+                oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+                oneshot_output: OneshotOutput::Stdout,
+                install_hint: Some(
+                    "npm install -g @anthropic-ai/claude-code".to_string(),
+                ),
             },
         ),
         (
@@ -490,21 +509,21 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
             ProviderCommandConfig {
                 command: "codex".to_string(),
                 args: Vec::new(),
+                oneshot_args: vec![
+                    "exec".to_string(),
+                    "-o".to_string(),
+                    "{tempfile}".to_string(),
+                    "{prompt}".to_string(),
+                ],
+                oneshot_output: OneshotOutput::Tempfile,
+                install_hint: Some("npm install -g @openai/codex".to_string()),
             },
         ),
     ]
 }
 
 fn render_provider_configs(out: &mut String, providers: &ProvidersConfig) {
-    for name in ["claude", "codex"] {
-        if let Some(config) = providers.get(name) {
-            render_provider_config(out, name, config);
-        }
-    }
     for (name, config) in &providers.commands {
-        if matches!(name.as_str(), "claude" | "codex") {
-            continue;
-        }
         render_provider_config(out, name, config);
     }
 }
@@ -512,16 +531,29 @@ fn render_provider_configs(out: &mut String, providers: &ProvidersConfig) {
 fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommandConfig) {
     out.push_str(&format!("[providers.{name}]\n"));
     out.push_str(&format!("# CLI command for {name} sessions.\n"));
-    if name == "claude" {
-        out.push_str("# Example: command = \"claude\"\n");
-    } else if name == "codex" {
-        out.push_str("# Example: command = \"codex\"\n");
-    }
     out.push_str(&format!(
         "command = \"{}\"\n",
         escape_toml_string(&config.command)
     ));
-    out.push_str(&format!("args = {}\n\n", render_string_list(&config.args)));
+    out.push_str(&format!("args = {}\n", render_string_list(&config.args)));
+    out.push_str("# Oneshot args for non-interactive use (e.g. AI commit messages).\n");
+    out.push_str("# Placeholders: {prompt} = the prompt text, {tempfile} = temp file path.\n");
+    out.push_str(&format!(
+        "oneshot_args = {}\n",
+        render_string_list(&config.oneshot_args)
+    ));
+    let output_str = match config.oneshot_output {
+        OneshotOutput::Stdout => "stdout",
+        OneshotOutput::Tempfile => "tempfile",
+    };
+    out.push_str(&format!("oneshot_output = \"{output_str}\"\n"));
+    if let Some(hint) = &config.install_hint {
+        out.push_str(&format!(
+            "install_hint = \"{}\"\n",
+            escape_toml_string(hint)
+        ));
+    }
+    out.push('\n');
 }
 
 /// Validate all key bindings in the config. Returns a descriptive error on failure.
@@ -545,26 +577,24 @@ pub fn validate_keys(keys: &KeysConfig) -> Result<(), String> {
 /// Check whether a provider command is available on PATH.
 /// Returns `Ok(())` if found, or `Err(message)` with a user-friendly install hint.
 pub fn check_provider_available(
-    provider_name: &str,
-    command: &str,
+    config: &ProviderCommandConfig,
 ) -> std::result::Result<(), String> {
     use std::process::Command as StdCommand;
-    match StdCommand::new("which").arg(command).output() {
+    match StdCommand::new("which").arg(&config.command).output() {
         Ok(output) if output.status.success() => Ok(()),
         _ => {
-            let hint = install_hint(provider_name, command);
-            Err(format!("CLI tool '{command}' not found on PATH. {hint}"))
+            let hint = config
+                .install_hint
+                .as_ref()
+                .map(|h| format!("Install with: {h}"))
+                .unwrap_or_else(|| {
+                    format!("Make sure '{}' is installed and on your PATH.", config.command)
+                });
+            Err(format!(
+                "CLI tool '{}' not found on PATH. {hint}",
+                config.command
+            ))
         }
-    }
-}
-
-fn install_hint(provider_name: &str, command: &str) -> String {
-    match provider_name {
-        "claude" if command == "claude" => {
-            "Install with: npm install -g @anthropic-ai/claude-code".to_string()
-        }
-        "codex" if command == "codex" => "Install with: npm install -g @openai/codex".to_string(),
-        _ => format!("Make sure '{command}' is installed and on your PATH."),
     }
 }
 
@@ -597,6 +627,8 @@ mod tests {
         assert!(rendered.contains("[defaults]"));
         assert!(rendered.contains("[providers.claude]"));
         assert!(rendered.contains("[providers.codex]"));
+        assert!(rendered.contains("oneshot_args = "));
+        assert!(rendered.contains("oneshot_output = "));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("[keys]"));
         assert!(rendered.contains("show_terminal_keys = true"));

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,24 +1,19 @@
 use chrono::{DateTime, Utc};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ProviderKind {
-    Claude,
-    Codex,
-}
+pub struct ProviderKind(String);
 
 impl ProviderKind {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Claude => "claude",
-            Self::Codex => "codex",
-        }
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 
     pub fn from_str(value: &str) -> Self {
-        match value {
-            "claude" => Self::Claude,
-            _ => Self::Codex,
-        }
+        Self(value.to_string())
     }
 }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,22 +3,50 @@ use std::process::Command;
 
 use anyhow::Result;
 
-use crate::config::ProviderCommandConfig;
-use crate::model::ProviderKind;
+use crate::config::{OneshotOutput, ProviderCommandConfig};
 
-/// Trait abstracting CLI provider capabilities beyond interactive PTY sessions.
-pub trait Provider: Send {
-    /// The provider kind (Claude, Codex).
-    fn kind(&self) -> ProviderKind;
+/// A config-driven provider that builds oneshot commands from templates.
+pub struct GenericProvider {
+    pub name: String,
+    pub config: ProviderCommandConfig,
+}
 
-    /// The CLI command name (e.g. "claude", "codex").
-    fn command(&self) -> &str;
+impl GenericProvider {
+    pub fn command(&self) -> &str {
+        &self.config.command
+    }
 
     /// Build a [`Command`] for a non-interactive one-shot prompt.
-    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>);
+    ///
+    /// Substitutes `{prompt}` and `{tempfile}` placeholders in `oneshot_args`.
+    pub fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>) {
+        let unique: u64 = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        let tmpfile = std::env::temp_dir().join(format!(
+            "dux-{}-{}-{}.txt",
+            self.name,
+            std::process::id(),
+            unique
+        ));
+        let mut cmd = Command::new(&self.config.command);
+        cmd.current_dir(cwd);
+        for arg_template in &self.config.oneshot_args {
+            let arg = arg_template
+                .replace("{prompt}", prompt)
+                .replace("{tempfile}", &tmpfile.to_string_lossy());
+            cmd.arg(arg);
+        }
+        let tmpfile_option = match self.config.oneshot_output {
+            OneshotOutput::Tempfile => Some(tmpfile),
+            OneshotOutput::Stdout => None,
+        };
+        (cmd, tmpfile_option)
+    }
 
     /// Run a non-interactive prompt and return the response text.
-    fn run_oneshot(&self, prompt: &str, cwd: &Path) -> Result<String> {
+    pub fn run_oneshot(&self, prompt: &str, cwd: &Path) -> Result<String> {
         let (mut cmd, tmpfile) = self.build_oneshot_command(prompt, cwd);
         let output = cmd.output()?;
         if !output.status.success() {
@@ -38,57 +66,139 @@ pub trait Provider: Send {
     }
 }
 
-pub struct ClaudeProvider {
-    pub config: ProviderCommandConfig,
-}
-
-impl Provider for ClaudeProvider {
-    fn kind(&self) -> ProviderKind {
-        ProviderKind::Claude
-    }
-
-    fn command(&self) -> &str {
-        &self.config.command
-    }
-
-    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>) {
-        let mut cmd = Command::new(&self.config.command);
-        cmd.current_dir(cwd);
-        cmd.args(["-p", prompt]);
-        (cmd, None)
+/// Create a [`GenericProvider`] from a provider name and its config.
+pub fn create_provider(name: &str, config: ProviderCommandConfig) -> GenericProvider {
+    GenericProvider {
+        name: name.to_string(),
+        config,
     }
 }
 
-pub struct CodexProvider {
-    pub config: ProviderCommandConfig,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-impl Provider for CodexProvider {
-    fn kind(&self) -> ProviderKind {
-        ProviderKind::Codex
+    fn claude_like_config() -> ProviderCommandConfig {
+        ProviderCommandConfig {
+            command: "echo".to_string(),
+            args: Vec::new(),
+            oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
+        }
     }
 
-    fn command(&self) -> &str {
-        &self.config.command
+    fn codex_like_config() -> ProviderCommandConfig {
+        ProviderCommandConfig {
+            command: "bash".to_string(),
+            args: Vec::new(),
+            oneshot_args: vec![
+                "-c".to_string(),
+                "echo {prompt} > {tempfile}".to_string(),
+            ],
+            oneshot_output: OneshotOutput::Tempfile,
+            install_hint: None,
+        }
     }
 
-    fn build_oneshot_command(&self, prompt: &str, cwd: &Path) -> (Command, Option<PathBuf>) {
-        let tmpfile =
-            std::env::temp_dir().join(format!("dux-codex-{}.txt", std::process::id()));
-        let mut cmd = Command::new(&self.config.command);
-        cmd.current_dir(cwd);
-        cmd.args(["exec", "-o", &tmpfile.to_string_lossy(), prompt]);
-        (cmd, Some(tmpfile))
+    #[test]
+    fn claude_style_stdout_build_command() {
+        let prov = create_provider("claude", claude_like_config());
+        let cwd = std::env::temp_dir();
+        let (cmd, tmpfile) = prov.build_oneshot_command("hello world", &cwd);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        assert_eq!(args, vec!["-p", "hello world"]);
+        assert!(tmpfile.is_none(), "stdout mode should not produce a tempfile");
     }
-}
 
-/// Create a boxed [`Provider`] from a [`ProviderKind`] and its config.
-pub fn create_provider(
-    kind: &ProviderKind,
-    config: ProviderCommandConfig,
-) -> Box<dyn Provider> {
-    match kind {
-        ProviderKind::Claude => Box::new(ClaudeProvider { config }),
-        ProviderKind::Codex => Box::new(CodexProvider { config }),
+    #[test]
+    fn codex_style_tempfile_build_command() {
+        let prov = create_provider("codex", codex_like_config());
+        let cwd = std::env::temp_dir();
+        let (cmd, tmpfile) = prov.build_oneshot_command("hello world", &cwd);
+        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        assert!(tmpfile.is_some(), "tempfile mode should produce a tempfile path");
+        let tf = tmpfile.unwrap();
+        assert_eq!(args[0], "-c");
+        assert!(args[1].contains("hello world"), "prompt should be substituted");
+        assert!(
+            args[1].contains(&tf.to_string_lossy().to_string()),
+            "tempfile path should be substituted"
+        );
+    }
+
+    #[test]
+    fn claude_style_run_oneshot() {
+        let prov = create_provider("claude", claude_like_config());
+        let cwd = std::env::temp_dir();
+        let result = prov.run_oneshot("hello world", &cwd).unwrap();
+        // echo prints: -p hello world
+        assert_eq!(result, "-p hello world");
+    }
+
+    #[test]
+    fn codex_style_run_oneshot_via_tempfile() {
+        let prov = create_provider("codex", codex_like_config());
+        let cwd = std::env::temp_dir();
+        let result = prov.run_oneshot("hello world", &cwd).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn run_oneshot_reports_failure() {
+        let config = ProviderCommandConfig {
+            command: "false".to_string(),
+            args: Vec::new(),
+            oneshot_args: Vec::new(),
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
+        };
+        let prov = create_provider("bad", config);
+        let cwd = std::env::temp_dir();
+        let result = prov.run_oneshot("anything", &cwd);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("failed"));
+    }
+
+    #[test]
+    fn custom_provider_with_extra_args() {
+        let config = ProviderCommandConfig {
+            command: "echo".to_string(),
+            args: Vec::new(),
+            oneshot_args: vec![
+                "--format".to_string(),
+                "plain".to_string(),
+                "{prompt}".to_string(),
+            ],
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
+        };
+        let prov = create_provider("custom", config);
+        let cwd = std::env::temp_dir();
+        let result = prov.run_oneshot("test prompt", &cwd).unwrap();
+        assert_eq!(result, "--format plain test prompt");
+    }
+
+    #[test]
+    fn tempfile_cleaned_up_after_read() {
+        let prov = create_provider("cleanup-test", codex_like_config());
+        let cwd = std::env::temp_dir();
+        // run_oneshot should create a tempfile, read it, then delete it.
+        // Check that no dux-cleanup-test-* files remain afterward.
+        let _ = prov.run_oneshot("check cleanup", &cwd).unwrap();
+        let leftover: Vec<_> = std::fs::read_dir(std::env::temp_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with("dux-cleanup-test-")
+            })
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "tempfile should be cleaned up after run_oneshot, found: {:?}",
+            leftover
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `ProviderKind` enum (Claude/Codex only) with a string-based newtype, so arbitrary providers can be added in `config.toml` without code changes.
- Each provider now declares `oneshot_args` (with `{prompt}`/`{tempfile}` placeholders), `oneshot_output` mode, and an optional `install_hint` — making AI commit message generation work for any CLI tool.
- Replaces the `Provider` trait and per-provider structs with a single `GenericProvider` that uses config-driven template substitution.
- Provider cycling now rotates through all configured providers (N-way) instead of toggling between two. Uses `IndexMap` to preserve TOML declaration order.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] All 38 tests pass (`cargo test`), including 7 new provider tests
- [ ] Run dux, verify default `config.toml` renders with `oneshot_args`/`oneshot_output` for claude and codex
- [ ] Add a custom provider in config, verify it appears in provider cycling
- [ ] Test AI commit message generation with a configured provider