### PR TITLE
Fix all clippy warnings, enforce formatting, add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run fmt fmt-check lint lint-fix
+
+run:
+	cargo run
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt --check
+
+lint:
+	cargo clippy --all-targets --all-features
+
+lint-fix:
+	cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -97,7 +97,9 @@ impl App {
                     if self.resize_mode {
                         let grow = self.bindings.labels_for(Action::ResizeGrow);
                         let shrink = self.bindings.labels_for(Action::ResizeShrink);
-                        self.set_info(format!("Resize mode on: {shrink}/{grow} resize side panes."));
+                        self.set_info(format!(
+                            "Resize mode on: {shrink}/{grow} resize side panes."
+                        ));
                     } else {
                         self.persist_pane_widths();
                         self.set_info("Resize mode off.");
@@ -201,7 +203,9 @@ impl App {
                         self.center_mode = CenterMode::Agent;
                         self.input_target = InputTarget::Agent;
                         let exit_key = self.bindings.label_for(Action::ExitInteractive);
-                        self.set_info(format!("Interactive mode. Keys forwarded to agent. {exit_key} exits."));
+                        self.set_info(format!(
+                            "Interactive mode. Keys forwarded to agent. {exit_key} exits."
+                        ));
                     } else {
                         let r = self.bindings.label_for(Action::ReconnectAgent);
                         let n = self.bindings.label_for(Action::NewAgent);
@@ -230,7 +234,9 @@ impl App {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
                         let exit_key = self.bindings.label_for(Action::ExitInteractive);
-                        self.set_info(format!("Interactive mode. Keys forwarded to agent. {exit_key} exits."));
+                        self.set_info(format!(
+                            "Interactive mode. Keys forwarded to agent. {exit_key} exits."
+                        ));
                     } else {
                         let r = self.bindings.label_for(Action::ReconnectAgent);
                         let n = self.bindings.label_for(Action::NewAgent);
@@ -313,10 +319,8 @@ impl App {
                     }
                 }
                 Action::MoveUp => {
-                    if self.right_section != RightSection::CommitInput {
-                        if self.files_index > 0 {
-                            self.files_index -= 1;
-                        }
+                    if self.right_section != RightSection::CommitInput && self.files_index > 0 {
+                        self.files_index -= 1;
                     }
                 }
                 Action::StageUnstage => {
@@ -361,8 +365,7 @@ impl App {
 
     fn handle_commit_input_key(&mut self, key: KeyEvent) -> Result<()> {
         // Exit actions are dispatched via bindings; text input stays hardcoded.
-        if let Some(Action::ExitCommitInput) =
-            self.bindings.lookup(&key, BindingScope::CommitInput)
+        if let Some(Action::ExitCommitInput) = self.bindings.lookup(&key, BindingScope::CommitInput)
         {
             self.input_target = InputTarget::None;
             return Ok(());
@@ -504,8 +507,12 @@ impl App {
                  Diff:\n{diff}"
             );
             match prov.run_oneshot(&prompt, &worktree) {
-                Ok(msg) => { let _ = tx.send(WorkerEvent::CommitMessageGenerated(msg)); }
-                Err(e) => { let _ = tx.send(WorkerEvent::CommitMessageFailed(e.to_string())); }
+                Ok(msg) => {
+                    let _ = tx.send(WorkerEvent::CommitMessageGenerated(msg));
+                }
+                Err(e) => {
+                    let _ = tx.send(WorkerEvent::CommitMessageFailed(e.to_string()));
+                }
             }
         });
         Ok(())
@@ -564,7 +571,9 @@ impl App {
         let tx = self.worker_tx.clone();
         self.set_busy("Pulling latest changes from remote…");
         thread::spawn(move || {
-            let result = git::pull_current_branch(&worktree).map(|_| ()).map_err(|e| e.to_string());
+            let result = git::pull_current_branch(&worktree)
+                .map(|_| ())
+                .map_err(|e| e.to_string());
             let _ = tx.send(WorkerEvent::PullCompleted(result));
         });
         Ok(())
@@ -588,8 +597,7 @@ impl App {
         };
 
         // Exit interactive mode via configured binding (default: ctrl-g).
-        if let Some(Action::ExitInteractive) =
-            self.bindings.lookup(&key, BindingScope::Interactive)
+        if let Some(Action::ExitInteractive) = self.bindings.lookup(&key, BindingScope::Interactive)
         {
             self.input_target = InputTarget::None;
             self.set_info("Exited interactive mode.");
@@ -1013,7 +1021,11 @@ impl App {
         {
             match key.code {
                 KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left | KeyCode::Right | KeyCode::Tab | KeyCode::Char('h') | KeyCode::Char('l') => {
+                KeyCode::Left
+                | KeyCode::Right
+                | KeyCode::Tab
+                | KeyCode::Char('h')
+                | KeyCode::Char('l') => {
                     *confirm_selected = !*confirm_selected;
                 }
                 KeyCode::Enter => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,8 +27,8 @@ use crate::config::{
 use crate::git;
 use crate::keybindings::{Action, BindingScope, HintContext, RuntimeBindings};
 use crate::logger;
-use crate::provider;
 use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
+use crate::provider;
 use crate::pty::PtyClient;
 use crate::statusline::{StatusLine, StatusTone};
 use crate::storage::SessionStore;
@@ -212,13 +212,15 @@ pub(crate) enum LeftItem {
     Session(usize),
 }
 
+pub(crate) struct AgentReadyData {
+    pub session: AgentSession,
+    pub client: PtyClient,
+    pub pty_size: (u16, u16), // (rows, cols) the PTY was spawned with
+}
+
 pub(crate) enum WorkerEvent {
     CreateAgentProgress(String),
-    CreateAgentReady {
-        session: AgentSession,
-        client: PtyClient,
-        pty_size: (u16, u16), // (rows, cols) the PTY was spawned with
-    },
+    CreateAgentReady(Box<AgentReadyData>),
     CreateAgentFailed(String),
     ChangedFilesReady {
         staged: Vec<ChangedFile>,
@@ -248,7 +250,10 @@ impl App {
 
         // Validate and build runtime keybindings from config.
         if let Err(msg) = validate_keys(&config.keys) {
-            eprintln!("Configuration error in {}: {msg}", paths.config_path.display());
+            eprintln!(
+                "Configuration error in {}: {msg}",
+                paths.config_path.display()
+            );
             std::process::exit(1);
         }
         let bindings = RuntimeBindings::from_keys_config(&config.keys);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -979,7 +979,7 @@ impl App {
                         .iter()
                         .map(|binding| {
                             let name = binding.palette_name.unwrap();
-                            let name_padded = format!("{:width$}", name, width = name_col);
+                            let name_padded = format!("{name:name_col$}");
                             let mut spans = vec![Span::styled(
                                 name_padded,
                                 Style::default()
@@ -991,7 +991,7 @@ impl App {
                             let desc_display = if desc.len() > desc_avail && desc_avail > 1 {
                                 format!("  {}\u{2026}", &desc[..desc_avail - 1])
                             } else {
-                                format!("  {:width$}", desc, width = desc_avail)
+                                format!("  {desc:desc_avail$}")
                             };
                             spans.push(Span::styled(
                                 desc_display,
@@ -1047,7 +1047,7 @@ impl App {
                     ));
                 }
                 let prompt_prefix = if *searching { "/ " } else { "> " };
-                Paragraph::new(format!("{}{}", prompt_prefix, input))
+                Paragraph::new(format!("{prompt_prefix}{input}"))
                     .block(
                         self.themed_overlay_block(title)
                             .title_bottom(Line::from(bottom_spans)),
@@ -1149,9 +1149,9 @@ impl App {
                 if let Some(filter_area) = top_areas {
                     let title = format!("Add Project: {}", current_dir.display());
                     let input_text = if *editing_path {
-                        format!("go: {}█", path_input)
+                        format!("go: {path_input}█")
                     } else {
-                        format!("/ {}", filter)
+                        format!("/ {filter}")
                     };
                     Paragraph::new(input_text)
                         .block(self.themed_overlay_block(&title))
@@ -1529,7 +1529,10 @@ impl App {
                 };
 
                 let (cancel_border, cancel_fg) = if !confirm_selected {
-                    (self.theme.button_confirm_border, self.theme.button_active_fg)
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
                 } else {
                     (self.theme.border_normal, self.theme.hint_desc_fg)
                 };

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -82,7 +82,7 @@ impl App {
         });
         self.rebuild_left_items();
         logger::info(&format!("registered project {}", path.display()));
-        self.set_info(format!("Added project \"{}\" to workspace", display_name));
+        self.set_info(format!("Added project \"{display_name}\" to workspace"));
         Ok(())
     }
 

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -5,11 +5,8 @@ impl App {
         while let Ok(event) = self.worker_rx.try_recv() {
             match event {
                 WorkerEvent::CreateAgentProgress(message) => self.set_busy(message),
-                WorkerEvent::CreateAgentReady {
-                    session,
-                    client,
-                    pty_size,
-                } => {
+                WorkerEvent::CreateAgentReady(boxed) => {
+                    let AgentReadyData { session, client, pty_size } = *boxed;
                     self.create_agent_in_flight = false;
                     self.last_pty_size = pty_size;
                     if let Err(err) = self.session_store.upsert_session(&session) {
@@ -156,7 +153,10 @@ impl App {
                 let path = watched.lock().ok().and_then(|guard| guard.clone());
                 if let Some(worktree_path) = path {
                     if let Ok((staged, unstaged)) = git::changed_files(&worktree_path) {
-                        if tx.send(WorkerEvent::ChangedFilesReady { staged, unstaged }).is_err() {
+                        if tx
+                            .send(WorkerEvent::ChangedFilesReady { staged, unstaged })
+                            .is_err()
+                        {
                             break; // receiver dropped, app is shutting down
                         }
                     }
@@ -250,11 +250,11 @@ pub(crate) fn run_create_agent_job(
         }
     };
     logger::info(&format!("PTY session started for {}", session.id));
-    let _ = worker_tx.send(WorkerEvent::CreateAgentReady {
+    let _ = worker_tx.send(WorkerEvent::CreateAgentReady(Box::new(AgentReadyData {
         session,
         client,
         pty_size: (rows, cols),
-    });
+    })));
 }
 
 pub(crate) fn browser_entries(dir: &Path) -> Vec<BrowserEntry> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -388,16 +388,16 @@ pub fn save_config(config_path: &Path, config: &Config) -> Result<()> {
 fn render_keys_config(out: &mut String, keys: &KeysConfig) {
     out.push_str("[keys]\n");
     out.push_str("# Keybindings configuration. Each action maps to one or more key combos.\n");
-    out.push_str("# Key format: single chars (\"j\"), special names (\"up\", \"enter\", \"space\",\n");
-    out.push_str("# \"tab\", \"shift-tab\", \"pageup\", \"esc\"), or modifier combos (\"ctrl-d\").\n");
+    out.push_str(
+        "# Key format: single chars (\"j\"), special names (\"up\", \"enter\", \"space\",\n",
+    );
+    out.push_str(
+        "# \"tab\", \"shift-tab\", \"pageup\", \"esc\"), or modifier combos (\"ctrl-d\").\n",
+    );
     out.push_str("#\n");
     out.push_str("# Some keys shown in hints are terminal conventions (e.g. ctrl-j for newline)\n");
     out.push_str("# that dux documents but does not control. Set this to false to hide them.\n");
-    let _ = writeln!(
-        out,
-        "show_terminal_keys = {}",
-        keys.show_terminal_keys
-    );
+    let _ = writeln!(out, "show_terminal_keys = {}", keys.show_terminal_keys);
     out.push('\n');
 
     let mut last_section: Option<&str> = None;
@@ -421,16 +421,12 @@ fn render_keys_config(out: &mut String, keys: &KeysConfig) {
         let _ = writeln!(out, "# {}", def.action.config_description());
 
         // Value from config (or defaults if missing).
-        let key_strs = keys
-            .bindings
-            .get(config_name)
-            .cloned()
-            .unwrap_or_else(|| {
-                def.default_keys
-                    .iter()
-                    .map(|k| keybindings::format_key_for_config(*k))
-                    .collect()
-            });
+        let key_strs = keys.bindings.get(config_name).cloned().unwrap_or_else(|| {
+            def.default_keys
+                .iter()
+                .map(|k| keybindings::format_key_for_config(*k))
+                .collect()
+        });
         let _ = writeln!(out, "{config_name} = {}", render_string_list(&key_strs));
     }
     out.push('\n');
@@ -499,9 +495,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
                 args: Vec::new(),
                 oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
                 oneshot_output: OneshotOutput::Stdout,
-                install_hint: Some(
-                    "npm install -g @anthropic-ai/claude-code".to_string(),
-                ),
+                install_hint: Some("npm install -g @anthropic-ai/claude-code".to_string()),
             },
         ),
         (
@@ -566,9 +560,8 @@ pub fn validate_keys(keys: &KeysConfig) -> Result<(), String> {
             return Err(format!("[keys] unknown action: \"{name}\""));
         }
         for s in key_strs {
-            crokey::parse(s).map_err(|_| {
-                format!("[keys] invalid key \"{s}\" for action \"{name}\"")
-            })?;
+            crokey::parse(s)
+                .map_err(|_| format!("[keys] invalid key \"{s}\" for action \"{name}\""))?;
         }
     }
     Ok(())
@@ -576,9 +569,7 @@ pub fn validate_keys(keys: &KeysConfig) -> Result<(), String> {
 
 /// Check whether a provider command is available on PATH.
 /// Returns `Ok(())` if found, or `Err(message)` with a user-friendly install hint.
-pub fn check_provider_available(
-    config: &ProviderCommandConfig,
-) -> std::result::Result<(), String> {
+pub fn check_provider_available(config: &ProviderCommandConfig) -> std::result::Result<(), String> {
     use std::process::Command as StdCommand;
     match StdCommand::new("which").arg(&config.command).output() {
         Ok(output) if output.status.success() => Ok(()),
@@ -588,7 +579,10 @@ pub fn check_provider_available(
                 .as_ref()
                 .map(|h| format!("Install with: {h}"))
                 .unwrap_or_else(|| {
-                    format!("Make sure '{}' is installed and on your PATH.", config.command)
+                    format!(
+                        "Make sure '{}' is installed and on your PATH.",
+                        config.command
+                    )
                 });
             Err(format!(
                 "CLI tool '{}' not found on PATH. {hint}",
@@ -602,7 +596,7 @@ fn discover_root(home: &Path, xdg_config_home: Option<std::ffi::OsString>) -> Pa
     #[cfg(target_os = "macos")]
     {
         let _ = xdg_config_home;
-        return home.join(".dux");
+        home.join(".dux")
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -645,10 +639,8 @@ mod tests {
     #[test]
     fn validate_keys_rejects_bad_key() {
         let mut keys = KeysConfig::default();
-        keys.bindings.insert(
-            "quit".to_string(),
-            vec!["badkey!!!".to_string()],
-        );
+        keys.bindings
+            .insert("quit".to_string(), vec!["badkey!!!".to_string()]);
         let result = validate_keys(&keys);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("badkey!!!"));

--- a/src/git.rs
+++ b/src/git.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, anyhow};
 
-use crate::model::{ChangedFile, FileStage};
+use crate::model::ChangedFile;
 
 pub fn current_branch(repo_path: &Path) -> Result<String> {
     let output = Command::new("git")
@@ -191,7 +191,6 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path,
                 additions: 0,
                 deletions: 0,
-                stage: FileStage::Unstaged,
             });
             continue;
         }
@@ -202,7 +201,6 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path: path.clone(),
                 additions: 0,
                 deletions: 0,
-                stage: FileStage::Staged,
             });
         }
 
@@ -212,7 +210,6 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path: path.clone(),
                 additions: 0,
                 deletions: 0,
-                stage: FileStage::Unstaged,
             });
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,4 +1,4 @@
-use crokey::{key, KeyCombination, KeyCombinationFormat};
+use crokey::{KeyCombination, KeyCombinationFormat, key};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 /// Unique identifier for every bindable action.
@@ -205,24 +205,45 @@ impl Action {
     /// Help section name for the help overlay.
     pub fn help_section(self) -> Option<&'static str> {
         match self {
-            Action::MoveDown | Action::MoveUp | Action::ToggleProject | Action::NewAgent
-            | Action::FocusAgent | Action::OpenProjectBrowser | Action::CopyPath
-            | Action::CycleProvider | Action::RefreshProject | Action::ReconnectAgent
+            Action::MoveDown
+            | Action::MoveUp
+            | Action::ToggleProject
+            | Action::NewAgent
+            | Action::FocusAgent
+            | Action::OpenProjectBrowser
+            | Action::CopyPath
+            | Action::CycleProvider
+            | Action::RefreshProject
+            | Action::ReconnectAgent
             | Action::DeleteSession => Some("Projects pane"),
-            Action::InteractAgent | Action::ExitInteractive | Action::ScrollPageUp
+            Action::InteractAgent
+            | Action::ExitInteractive
+            | Action::ScrollPageUp
             | Action::ScrollPageDown => Some("Agent pane"),
-            Action::OpenDiff | Action::StageUnstage | Action::CommitChanges
-            | Action::GenerateCommitMessage | Action::DiscardChanges | Action::EngageCommitInput
-            | Action::PushToRemote | Action::PullFromRemote => Some("Files pane"),
+            Action::OpenDiff
+            | Action::StageUnstage
+            | Action::CommitChanges
+            | Action::GenerateCommitMessage
+            | Action::DiscardChanges
+            | Action::EngageCommitInput
+            | Action::PushToRemote
+            | Action::PullFromRemote => Some("Files pane"),
             Action::ExitCommitInput => Some("Commit input"),
-            Action::FocusNext | Action::FocusPrev | Action::OpenPalette
-            | Action::ToggleResizeMode | Action::ToggleSidebar | Action::ToggleHelp
-            | Action::Quit | Action::CloseOverlay => Some("Global"),
+            Action::FocusNext
+            | Action::FocusPrev
+            | Action::OpenPalette
+            | Action::ToggleResizeMode
+            | Action::ToggleSidebar
+            | Action::ToggleHelp
+            | Action::Quit
+            | Action::CloseOverlay => Some("Global"),
             Action::ResizeGrow | Action::ResizeShrink => Some("Resize mode"),
-            Action::SearchToggle | Action::GoToPath | Action::OpenEntry
-            | Action::AddCurrentDir | Action::Confirm | Action::ToggleSelection => {
-                Some("Overlays")
-            }
+            Action::SearchToggle
+            | Action::GoToPath
+            | Action::OpenEntry
+            | Action::AddCurrentDir
+            | Action::Confirm
+            | Action::ToggleSelection => Some("Overlays"),
             Action::DeleteProject | Action::RemoveProject => None,
         }
     }
@@ -549,10 +570,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             section: "Global",
             description: "Focus next pane",
         }),
-        hint_contexts: &[
-            (HintContext::Center, "Next"),
-            (HintContext::Files, "Next"),
-        ],
+        hint_contexts: &[(HintContext::Center, "Next"), (HintContext::Files, "Next")],
         palette: None,
     },
     BindingDef {
@@ -592,7 +610,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     },
     BindingDef {
         action: Action::ToggleSidebar,
-        default_keys: &[KeyCombination::one_key(KeyCode::Char('['), KeyModifiers::NONE)],
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char('['),
+            KeyModifiers::NONE,
+        )],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
@@ -606,7 +627,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     },
     BindingDef {
         action: Action::ToggleHelp,
-        default_keys: &[KeyCombination::one_key(KeyCode::Char('?'), KeyModifiers::NONE)],
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char('?'),
+            KeyModifiers::NONE,
+        )],
         scopes: &[BindingScope::Global],
         help: Some(HelpEntry {
             section: "Global",
@@ -637,7 +661,12 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::CloseOverlay,
         default_keys: &[key!(esc)],
-        scopes: &[BindingScope::Global, BindingScope::Palette, BindingScope::Browser, BindingScope::Dialog],
+        scopes: &[
+            BindingScope::Global,
+            BindingScope::Palette,
+            BindingScope::Browser,
+            BindingScope::Dialog,
+        ],
         help: Some(HelpEntry {
             section: "Global",
             description: "Close the current overlay or dialog",
@@ -671,7 +700,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     // ── Overlays and dialogs ──────────────────────────────────────
     BindingDef {
         action: Action::SearchToggle,
-        default_keys: &[KeyCombination::one_key(KeyCode::Char('/'), KeyModifiers::NONE)],
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char('/'),
+            KeyModifiers::NONE,
+        )],
         scopes: &[BindingScope::Palette, BindingScope::Browser],
         help: Some(HelpEntry {
             section: "Overlays",
@@ -854,10 +886,7 @@ impl RuntimeBindings {
 
     /// Build runtime bindings from parsed config keys.
     /// `keys_for` returns the parsed `KeyCombination`s for a given action.
-    pub fn new(
-        keys_for: impl Fn(Action) -> Vec<KeyCombination>,
-        show_terminal_keys: bool,
-    ) -> Self {
+    pub fn new(keys_for: impl Fn(Action) -> Vec<KeyCombination>, show_terminal_keys: bool) -> Self {
         let format = display_format();
         let bindings = BINDING_DEFS
             .iter()
@@ -1047,7 +1076,10 @@ mod tests {
     fn lookup_finds_action_in_correct_scope() {
         let bindings = default_bindings();
         let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
-        assert_eq!(bindings.lookup(&key, BindingScope::Left), Some(Action::MoveDown));
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Left),
+            Some(Action::MoveDown)
+        );
         assert_eq!(bindings.lookup(&key, BindingScope::Center), None);
     }
 
@@ -1121,13 +1153,13 @@ mod tests {
     fn filtered_palette_filters_by_name() {
         let bindings = default_bindings();
         let results = bindings.filtered_palette("toggle");
-        assert!(results
-            .iter()
-            .all(|b| b.palette_name.unwrap().contains("toggle")
+        assert!(results.iter().all(|b| {
+            b.palette_name.unwrap().contains("toggle")
                 || b.palette_description
                     .unwrap()
                     .to_lowercase()
-                    .contains("toggle")));
+                    .contains("toggle")
+        }));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -66,17 +66,10 @@ pub struct AgentSession {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FileStage {
-    Staged,
-    Unstaged,
-}
-
 #[derive(Clone, Debug)]
 pub struct ChangedFile {
     pub status: String,
     pub path: String,
     pub additions: usize,
     pub deletions: usize,
-    pub stage: FileStage,
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -92,10 +92,7 @@ mod tests {
         ProviderCommandConfig {
             command: "bash".to_string(),
             args: Vec::new(),
-            oneshot_args: vec![
-                "-c".to_string(),
-                "echo {prompt} > {tempfile}".to_string(),
-            ],
+            oneshot_args: vec!["-c".to_string(), "echo {prompt} > {tempfile}".to_string()],
             oneshot_output: OneshotOutput::Tempfile,
             install_hint: None,
         }
@@ -106,9 +103,15 @@ mod tests {
         let prov = create_provider("claude", claude_like_config());
         let cwd = std::env::temp_dir();
         let (cmd, tmpfile) = prov.build_oneshot_command("hello world", &cwd);
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
         assert_eq!(args, vec!["-p", "hello world"]);
-        assert!(tmpfile.is_none(), "stdout mode should not produce a tempfile");
+        assert!(
+            tmpfile.is_none(),
+            "stdout mode should not produce a tempfile"
+        );
     }
 
     #[test]
@@ -116,11 +119,20 @@ mod tests {
         let prov = create_provider("codex", codex_like_config());
         let cwd = std::env::temp_dir();
         let (cmd, tmpfile) = prov.build_oneshot_command("hello world", &cwd);
-        let args: Vec<_> = cmd.get_args().map(|a| a.to_string_lossy().to_string()).collect();
-        assert!(tmpfile.is_some(), "tempfile mode should produce a tempfile path");
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            tmpfile.is_some(),
+            "tempfile mode should produce a tempfile path"
+        );
         let tf = tmpfile.unwrap();
         assert_eq!(args[0], "-c");
-        assert!(args[1].contains("hello world"), "prompt should be substituted");
+        assert!(
+            args[1].contains("hello world"),
+            "prompt should be substituted"
+        );
         assert!(
             args[1].contains(&tf.to_string_lossy().to_string()),
             "tempfile path should be substituted"
@@ -197,8 +209,7 @@ mod tests {
             .collect();
         assert!(
             leftover.is_empty(),
-            "tempfile should be cleaned up after run_oneshot, found: {:?}",
-            leftover
+            "tempfile should be cleaned up after run_oneshot, found: {leftover:?}",
         );
     }
 }


### PR DESCRIPTION
## Summary

- Resolve all 11 clippy warnings: remove dead `FileStage` enum and unused `stage` field, inline format string variables, collapse nested `if`, remove unneeded `return`, and box the large `CreateAgentReady` enum variant to reduce size disparity.
- Run `cargo fmt` to fix all pre-existing formatting issues across the codebase.
- Add a `Makefile` with targets for `run`, `fmt`, `fmt-check`, `lint`, and `lint-fix` for use in CI/CD pipelines.

## Test plan
- [x] `cargo clippy --all-targets --all-features` reports zero warnings
- [x] `cargo fmt --check` passes cleanly
- [x] `cargo test --no-run` compiles successfully