### PR TITLE
feat: rename agent session with git branch rename

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -188,6 +188,7 @@ impl App {
                 Action::NewAgent => self.create_agent_for_selected_project()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
+                Action::RenameSession => self.open_rename_session()?,
                 Action::CycleProvider => self.cycle_selected_project_provider()?,
                 Action::ReconnectAgent => self.reconnect_selected_session()?,
                 Action::CopyPath => self.copy_selected_path()?,
@@ -1026,6 +1027,58 @@ impl App {
                     } else {
                         self.prompt = PromptState::None;
                     }
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
+        if let PromptState::RenameSession {
+            session_id,
+            input,
+            cursor,
+        } = &mut self.prompt
+        {
+            match key.code {
+                KeyCode::Esc => {
+                    self.prompt = PromptState::None;
+                }
+                KeyCode::Enter => {
+                    let id = session_id.clone();
+                    let new_name = input.clone();
+                    self.prompt = PromptState::None;
+                    self.apply_rename_session(&id, new_name);
+                }
+                KeyCode::Backspace => {
+                    if *cursor > 0 {
+                        input.remove(*cursor - 1);
+                        *cursor -= 1;
+                    }
+                }
+                KeyCode::Delete => {
+                    if *cursor < input.len() {
+                        input.remove(*cursor);
+                    }
+                }
+                KeyCode::Left => {
+                    if *cursor > 0 {
+                        *cursor -= 1;
+                    }
+                }
+                KeyCode::Right => {
+                    if *cursor < input.len() {
+                        *cursor += 1;
+                    }
+                }
+                KeyCode::Home => {
+                    *cursor = 0;
+                }
+                KeyCode::End => {
+                    *cursor = input.len();
+                }
+                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    input.insert(*cursor, c);
+                    *cursor += 1;
                 }
                 _ => {}
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -184,6 +184,11 @@ pub(crate) enum PromptState {
         is_untracked: bool,
         confirm_selected: bool, // false = Cancel (default), true = Discard
     },
+    RenameSession {
+        session_id: String,
+        input: String,
+        cursor: usize,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -392,6 +397,7 @@ impl App {
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),
             "delete-agent" => self.confirm_delete_selected_session(),
+            "rename-agent" => self.open_rename_session(),
             "reconnect-agent" => self.reconnect_selected_session(),
             "add-project" => self.open_project_browser(),
             "copy-path" => self.copy_selected_path(),
@@ -516,6 +522,59 @@ impl App {
         } else if self.files_index >= len {
             self.files_index = len.saturating_sub(1);
         }
+    }
+
+    pub(crate) fn open_rename_session(&mut self) -> Result<()> {
+        if let Some(session) = self.selected_session() {
+            let current_name = session
+                .title
+                .clone()
+                .unwrap_or_else(|| session.branch_name.clone());
+            let cursor = current_name.len();
+            self.prompt = PromptState::RenameSession {
+                session_id: session.id.clone(),
+                input: current_name,
+                cursor,
+            };
+        } else {
+            self.set_error("No agent session selected.");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn apply_rename_session(&mut self, session_id: &str, new_name: String) {
+        let name = new_name.trim().to_string();
+        if name.is_empty() {
+            self.set_error("Name cannot be empty.");
+            return;
+        }
+
+        // Gather session info we need before mutating.
+        let Some(session) = self.sessions.iter().find(|s| s.id == session_id) else {
+            return;
+        };
+        let old_branch = session.branch_name.clone();
+        let worktree = session.worktree_path.clone();
+
+        // Skip the git rename if the branch name is unchanged.
+        if name != old_branch {
+            if let Err(e) = git::rename_branch(Path::new(&worktree), &old_branch, &name) {
+                self.set_error(format!("Rename failed: {e}"));
+                return;
+            }
+        }
+
+        // Git rename succeeded — update the session.
+        if let Some(session) = self.sessions.iter_mut().find(|s| s.id == session_id) {
+            session.branch_name = name.clone();
+            session.title = Some(name.clone());
+            session.updated_at = Utc::now();
+        }
+        if let Some(session) = self.sessions.iter().find(|s| s.id == session_id) {
+            let _ = self.session_store.upsert_session(session);
+        }
+        self.set_info(format!("Renamed agent to \"{name}\" (branch updated)."));
+        self.rebuild_left_items();
     }
 
     pub(crate) fn mark_session_status(&mut self, session_id: &str, status: SessionStatus) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1568,6 +1568,81 @@ impl App {
                 )
                 .render(discard_area, frame.buffer_mut());
             }
+            PromptState::RenameSession {
+                input, cursor, ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(56, 14, frame.area());
+                Clear.render(area, frame.buffer_mut());
+
+                let outer = self.themed_overlay_block("Rename Agent");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [label_area, _, input_area, _, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                        Constraint::Length(1),
+                        Constraint::Min(1),
+                    ])
+                    .areas(inner);
+
+                Paragraph::new(Line::from(Span::styled(
+                    " Enter a new name (empty to reset):",
+                    Style::default().fg(Color::White),
+                )))
+                .render(label_area, frame.buffer_mut());
+
+                // Show the input with a cursor indicator.
+                let display = if *cursor < input.len() {
+                    let (before, after) = input.split_at(*cursor);
+                    let (cursor_char, rest) = after.split_at(1);
+                    Line::from(vec![
+                        Span::raw(format!(" {before}")),
+                        Span::styled(
+                            cursor_char.to_string(),
+                            Style::default()
+                                .fg(Color::Black)
+                                .bg(Color::White),
+                        ),
+                        Span::raw(rest.to_string()),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::raw(format!(" {input}")),
+                        Span::styled(
+                            " ",
+                            Style::default()
+                                .fg(Color::Black)
+                                .bg(Color::White),
+                        ),
+                    ])
+                };
+                Paragraph::new(display)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_set(border::ROUNDED)
+                            .border_style(Style::default().fg(Color::Cyan)),
+                    )
+                    .render(input_area, frame.buffer_mut());
+
+                let mut hints = vec![Span::raw(" ")];
+                hints.extend(self.theme.key_badge("Enter", Color::Reset));
+                hints.push(Span::styled(
+                    " confirm  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                hints.extend(self.theme.key_badge("Esc", Color::Reset));
+                hints.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+            }
             PromptState::None => {}
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -449,4 +449,126 @@ mod tests {
     fn docker_name_uses_dash() {
         assert!(docker_style_name().contains('-'));
     }
+
+    // ── Helpers for git-backed tests ─────────────────────────────
+
+    /// Create a temporary bare-ish git repo with an initial commit so
+    /// worktrees and branches can be created from it.
+    fn init_test_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path();
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(p)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-b", "main"]);
+        run(&["-c", "user.name=test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "init"]);
+        dir
+    }
+
+    /// Create a worktree + branch from the test repo. Returns the worktree path.
+    fn add_worktree(repo: &Path, branch: &str) -> PathBuf {
+        let wt = repo.join(format!("wt-{branch}"));
+        let out = Command::new("git")
+            .args([
+                "-C",
+                repo.to_string_lossy().as_ref(),
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                wt.to_string_lossy().as_ref(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "worktree add failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        wt
+    }
+
+    // ── rename_branch tests ──────────────────────────────────────
+
+    #[test]
+    fn rename_branch_succeeds() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "old-name");
+
+        rename_branch(&wt, "old-name", "new-name").unwrap();
+
+        let branch = current_branch(&wt).unwrap();
+        assert_eq!(branch, "new-name");
+    }
+
+    #[test]
+    fn rename_branch_fails_on_conflict() {
+        let repo = init_test_repo();
+        // Create two worktrees with different branches.
+        let wt1 = add_worktree(repo.path(), "branch-a");
+        let _wt2 = add_worktree(repo.path(), "branch-b");
+
+        // Trying to rename branch-a to branch-b should fail because
+        // branch-b already exists.
+        let result = rename_branch(&wt1, "branch-a", "branch-b");
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("rename failed"),
+            "error should mention rename failure"
+        );
+
+        // The original branch should be unchanged.
+        let branch = current_branch(&wt1).unwrap();
+        assert_eq!(branch, "branch-a");
+    }
+
+    #[test]
+    fn rename_branch_fails_on_invalid_name() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "valid-name");
+
+        // Git rejects branch names with spaces and other invalid characters.
+        let result = rename_branch(&wt, "valid-name", "has spaces");
+        assert!(result.is_err());
+
+        // Original branch should still be intact.
+        let branch = current_branch(&wt).unwrap();
+        assert_eq!(branch, "valid-name");
+    }
+
+    #[test]
+    fn rename_branch_fails_when_old_name_wrong() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "real-branch");
+
+        // Renaming a nonexistent branch should fail.
+        let result = rename_branch(&wt, "nonexistent", "new-name");
+        assert!(result.is_err());
+
+        // The real branch should be unaffected.
+        let branch = current_branch(&wt).unwrap();
+        assert_eq!(branch, "real-branch");
+    }
+
+    #[test]
+    fn rename_branch_noop_same_name() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "same-name");
+
+        // Renaming to the same name should succeed (git allows this).
+        rename_branch(&wt, "same-name", "same-name").unwrap();
+
+        let branch = current_branch(&wt).unwrap();
+        assert_eq!(branch, "same-name");
+    }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -388,6 +388,28 @@ pub fn ellipsize_middle(input: &str, max_width: usize) -> String {
     format!("{start}...{end}")
 }
 
+/// Rename a git branch inside a worktree. Runs `git branch -m <old> <new>`
+/// from within the worktree directory.
+pub fn rename_branch(worktree_path: &Path, old_name: &str, new_name: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            worktree_path.to_string_lossy().as_ref(),
+            "branch",
+            "-m",
+            old_name,
+            new_name,
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git branch rename failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 pub fn docker_style_name() -> String {
     use petname::{Generator, Petnames};
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -53,6 +53,7 @@ pub enum Action {
     Confirm,
     ToggleSelection,
     // Palette-only (no direct keybinding)
+    RenameSession,
     DeleteProject,
     RemoveProject,
 }
@@ -149,6 +150,7 @@ impl Action {
             Action::AddCurrentDir => "add_current_dir",
             Action::Confirm => "confirm",
             Action::ToggleSelection => "toggle_selection",
+            Action::RenameSession => "rename_session",
             Action::DeleteProject => "delete_project",
             Action::RemoveProject => "remove_project",
         }
@@ -197,6 +199,7 @@ impl Action {
             Action::AddCurrentDir => "Add the current directory as a project.",
             Action::Confirm => "Confirm the selected action in a dialog.",
             Action::ToggleSelection => "Toggle between options in a confirmation dialog.",
+            Action::RenameSession => "Rename the selected agent session.",
             Action::DeleteProject => "Remove the selected project and its sessions.",
             Action::RemoveProject => "Remove project from app (keeps files on disk).",
         }
@@ -244,7 +247,7 @@ impl Action {
             | Action::AddCurrentDir
             | Action::Confirm
             | Action::ToggleSelection => Some("Overlays"),
-            Action::DeleteProject | Action::RemoveProject => None,
+            Action::RenameSession | Action::DeleteProject | Action::RemoveProject => None,
         }
     }
 }
@@ -768,6 +771,20 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: None,
     },
     // ── Palette-only (no direct keybinding) ────────────────────────
+    BindingDef {
+        action: Action::RenameSession,
+        default_keys: &[key!(e)],
+        scopes: &[BindingScope::Left],
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Rename the selected agent session",
+        }),
+        hint_contexts: &[(HintContext::LeftSession, "Rename")],
+        palette: Some(PaletteEntry {
+            name: "rename-agent",
+            description: "Rename the selected agent session",
+        }),
+    },
     BindingDef {
         action: Action::DeleteProject,
         default_keys: &[],


### PR DESCRIPTION
## Summary

- Adds a "rename-agent" command to the command palette (`ctrl+p`) and a direct `e` keybinding in the left pane to rename agent sessions
- Renaming first runs `git branch -m` to rename the actual git branch; if it fails the operation is aborted with an error
- On success, updates both `branch_name` and `title` in the session model and persists to SQLite
- The worktree path remains unchanged since it's stored independently from the branch name
- The keybinding is customizable via `rename_session` in the `[keys]` config section

## Test plan

- [ ] Select an agent session in the left pane and press `e` to open the rename dialog
- [ ] Enter a new name and confirm — verify the git branch is renamed and the sidebar label updates
- [ ] Try renaming to a name that already exists as a branch — verify the error is shown and nothing changes
- [ ] Open the command palette and run `rename-agent` — verify it works the same as pressing `e`
- [ ] Delete a renamed agent — verify the worktree and new branch name are cleaned up correctly