### PR TITLE
feat: show all keybindings in scrollable help popup

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -7,6 +7,30 @@ impl App {
         {
             return Ok(false);
         }
+        if let Some(ref mut scroll) = self.help_scroll {
+            // Help overlay is open — consume all keys, only scroll keys do anything.
+            if let Some(action) = self.bindings.lookup(&key, BindingScope::Left) {
+                match action {
+                    Action::MoveDown => *scroll = scroll.saturating_add(1),
+                    Action::MoveUp => *scroll = scroll.saturating_sub(1),
+                    _ => {}
+                }
+            }
+            if let Some(action) = self.bindings.lookup(&key, BindingScope::Global) {
+                match action {
+                    Action::ScrollPageDown => {
+                        let page = self.last_help_height.max(1);
+                        *scroll = (*scroll + page).min(self.last_help_lines.saturating_sub(1));
+                    }
+                    Action::ScrollPageUp => {
+                        let page = self.last_help_height.max(1);
+                        *scroll = scroll.saturating_sub(page);
+                    }
+                    _ => {}
+                }
+            }
+            return Ok(false);
+        }
         if !matches!(self.prompt, PromptState::None) {
             return self.handle_prompt_key(key);
         }
@@ -37,7 +61,11 @@ impl App {
                     return Ok(true);
                 }
                 Action::ToggleHelp => {
-                    self.help_overlay = !self.help_overlay;
+                    self.help_scroll = if self.help_scroll.is_some() {
+                        None
+                    } else {
+                        Some(0)
+                    };
                 }
                 Action::OpenPalette => {
                     self.prompt = PromptState::Command {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -56,7 +56,9 @@ pub struct App {
     pub(crate) center_mode: CenterMode,
     pub(crate) left_collapsed: bool,
     pub(crate) resize_mode: bool,
-    pub(crate) help_overlay: bool,
+    pub(crate) help_scroll: Option<u16>,
+    pub(crate) last_help_height: u16,
+    pub(crate) last_help_lines: u16,
     pub(crate) status: StatusLine,
     pub(crate) prompt: PromptState,
     pub(crate) input_target: InputTarget,
@@ -285,7 +287,9 @@ impl App {
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             resize_mode: false,
-            help_overlay: false,
+            help_scroll: None,
+            last_help_height: 0,
+            last_help_lines: 0,
             status: StatusLine::new("Press p to add a project, a to create an agent, ? for help."),
             prompt: PromptState::None,
             input_target: InputTarget::None,
@@ -357,8 +361,8 @@ impl App {
             self.set_info("Closed overlay.");
             return true;
         }
-        if self.help_overlay {
-            self.help_overlay = false;
+        if self.help_scroll.is_some() {
+            self.help_scroll = None;
             self.set_info("Closed overlay.");
             return true;
         }
@@ -404,7 +408,7 @@ impl App {
                 Ok(())
             }
             "help" => {
-                self.help_overlay = true;
+                self.help_scroll = Some(0);
                 Ok(())
             }
             "" => Ok(()),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -867,16 +867,45 @@ impl App {
             .render(status_area, frame.buffer_mut());
     }
 
-    fn render_help(&self, frame: &mut Frame) {
+    fn render_help(&mut self, frame: &mut Frame) {
         self.render_dim_overlay(frame);
         let area = centered_rect(72, 70, frame.area());
         Clear.render(area, frame.buffer_mut());
-        let help_bindings = self.bindings.help_sections();
+
+        let outer_block = self.themed_overlay_block("Help");
+        let inner = outer_block.inner(area);
+        outer_block.render(area, frame.buffer_mut());
+
+        if inner.height < 3 || inner.width < 4 {
+            return;
+        }
+
+        let hint_height = 2;
+        let [content_area, hint_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(hint_height)])
+            .areas(inner);
+
+        // Build help content lines.
         let mut lines: Vec<Line> = Vec::new();
-        for (section_idx, (section, bindings)) in help_bindings.iter().enumerate() {
-            if section_idx > 0 {
-                lines.push(Line::from(""));
-            }
+
+        // Config banner
+        lines.push(Line::from(vec![
+            Span::styled(
+                "All keybindings are configurable. See ",
+                Style::default().fg(self.theme.hint_desc_fg),
+            ),
+            Span::styled(
+                self.paths.config_path.display().to_string(),
+                Style::default()
+                    .fg(self.theme.hint_key_fg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+
+        let help_bindings = self.bindings.help_sections();
+        for (section, bindings) in &help_bindings {
+            lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 section.to_string(),
                 Style::default()
@@ -948,10 +977,56 @@ impl App {
                 ),
             ]));
         }
+
+        // Track content size for scroll clamping in input handler.
+        let total_lines = lines.len() as u16;
+        self.last_help_lines = total_lines;
+        self.last_help_height = content_area.height;
+
+        // Clamp scroll offset.
+        let max_scroll = total_lines.saturating_sub(content_area.height);
+        let scroll = self.help_scroll.unwrap_or(0).min(max_scroll);
+
         Paragraph::new(lines)
-            .block(self.themed_overlay_block("Help"))
             .wrap(Wrap { trim: false })
-            .render(area, frame.buffer_mut());
+            .scroll((scroll, 0))
+            .render(content_area, frame.buffer_mut());
+
+        // Hint bar with top border (same pattern as diff view).
+        if hint_area.height > 0 {
+            let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+            let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
+            let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
+            let move_down = self.bindings.label_for(Action::MoveDown);
+            let move_up = self.bindings.label_for(Action::MoveUp);
+            let close = self.bindings.label_for(Action::CloseOverlay);
+            let mut spans: Vec<Span> = Vec::new();
+
+            if scroll > 0 {
+                spans.push(Span::styled(
+                    format!("Scrolled back {scroll} lines. "),
+                    Style::default().fg(self.theme.hint_key_fg),
+                ));
+            }
+            spans.extend(self.theme.dim_key_badge(&move_down, Color::Reset));
+            spans.push(Span::styled(" ", desc_style));
+            spans.extend(self.theme.dim_key_badge(&move_up, Color::Reset));
+            spans.push(Span::styled(" scroll, ", desc_style));
+            spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
+            spans.push(Span::styled(" ", desc_style));
+            spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
+            spans.push(Span::styled(" page. ", desc_style));
+            spans.extend(self.theme.dim_key_badge(&close, Color::Reset));
+            spans.push(Span::styled(" close.", desc_style));
+
+            Paragraph::new(Line::from(spans))
+                .block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_style(Style::default().fg(self.theme.border_normal)),
+                )
+                .render(hint_area, frame.buffer_mut());
+        }
     }
 
     fn render_prompt(&self, frame: &mut Frame) {
@@ -1572,12 +1647,12 @@ impl App {
         }
     }
 
-    fn render_overlay(&self, frame: &mut Frame) {
+    fn render_overlay(&mut self, frame: &mut Frame) {
         if !matches!(self.prompt, PromptState::None) {
             self.render_prompt(frame);
             return;
         }
-        if self.help_overlay {
+        if self.help_scroll.is_some() {
             self.render_help(frame);
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -323,7 +323,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         action: Action::FocusAgent,
         default_keys: &[key!(enter)],
         scopes: &[BindingScope::Left],
-        help: None,
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Focus the selected agent",
+        }),
         hint_contexts: &[(HintContext::LeftSession, "Focus")],
         palette: None,
     },
@@ -348,7 +351,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         action: Action::CopyPath,
         default_keys: &[key!(y)],
         scopes: &[BindingScope::Left],
-        help: None,
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Copy agent worktree path",
+        }),
         hint_contexts: &[
             (HintContext::LeftProject, "Copy path"),
             (HintContext::LeftSession, "Copy path"),
@@ -577,7 +583,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         action: Action::FocusPrev,
         default_keys: &[key!(shift - tab)],
         scopes: &[BindingScope::Global],
-        help: None,
+        help: Some(HelpEntry {
+            section: "Global",
+            description: "Focus previous pane",
+        }),
         hint_contexts: &[],
         palette: None,
     },

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1222,4 +1222,21 @@ mod tests {
         assert!(actions_in_defs.contains(&Action::PushToRemote));
         assert!(actions_in_defs.contains(&Action::AddCurrentDir));
     }
+
+    #[test]
+    fn every_keyed_binding_has_help_entry() {
+        // Every BindingDef that has keys assigned should have a help entry,
+        // so it appears in the help overlay. MoveUp is the sole exception
+        // because it's shown via MoveDown's combined "j/k" label.
+        for def in BINDING_DEFS {
+            if def.default_keys.is_empty() || def.action == Action::MoveUp {
+                continue;
+            }
+            assert!(
+                def.help.is_some(),
+                "Action {:?} has keys but no help entry — add help: Some(HelpEntry {{ ... }})",
+                def.action,
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Display all centralized keybindings in the help overlay, adding three that were missing: `Enter` (focus agent), `y` (copy path), and `Shift-Tab` (focus previous pane)
- Make the help popup scrollable with `j`/`k` (line) and `PgUp`/`PgDn` (page), following the same scroll pattern as the diff view, with a hint bar at the bottom
- Add a config banner at the top of the help overlay pointing to the user's config file path
- When help is open, all keys are consumed except scroll and close — no accidental actions

## Test plan
- [ ] Press `?` to open help — verify all keybindings are listed, grouped by section
- [ ] Verify config banner appears at top with correct path
- [ ] Scroll with `j`/`k` and `PgUp`/`PgDn` — verify hint bar updates with "Scrolled back N lines"
- [ ] Press other keys while help is open — verify they are ignored
- [ ] Press `Esc` to close