### PR TITLE
feat: route all keybinding references through configurable binding system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ When making changes, edit only the relevant submodule. If you need to add a new 
 - Route new modal UI through `PromptState` so `Esc` keeps working uniformly.
 - Prefer command-palette actions over adding many more global hotkeys.
 - Keybinding labels shown to the user must be lowercase (e.g. `ctrl+g`, not `Ctrl+G`) to avoid implying that Shift is required. The `^X` notation (e.g. `^P`) is acceptable in footer hint bars since its meaning is explained in the help overlay.
+- Never hardcode keybinding labels in user-facing strings (config comments, status messages, UI text). All keybindings are user-configurable — always look up the actual binding via `RuntimeBindings::label_for()` so labels stay accurate after rebinding. The only exception is pure text-input contexts (typing characters, backspace, cursor movement in text fields).
 - Keep agent creation and other blocking git/provider work in background workers.
 - The PTY approach is CLI-agnostic: any terminal command can be used as a provider. Keep it generic.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -288,6 +288,9 @@ impl App {
                         self.reconnect_selected_session()?;
                     }
                 }
+                Action::ToggleFullscreen if !in_diff => {
+                    self.fullscreen_agent = !self.fullscreen_agent;
+                }
                 Action::ScrollPageUp => {
                     if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
                         let page = self.last_diff_height.max(1);
@@ -514,14 +517,12 @@ impl App {
         let tx = self.worker_tx.clone();
         self.commit_generating = true;
         self.set_busy("Generating AI commit message from staged diff…");
-        thread::spawn(move || {
-            match prov.run_oneshot(&prompt, &worktree) {
-                Ok(msg) => {
-                    let _ = tx.send(WorkerEvent::CommitMessageGenerated(msg));
-                }
-                Err(e) => {
-                    let _ = tx.send(WorkerEvent::CommitMessageFailed(e.to_string()));
-                }
+        thread::spawn(move || match prov.run_oneshot(&prompt, &worktree) {
+            Ok(msg) => {
+                let _ = tx.send(WorkerEvent::CommitMessageGenerated(msg));
+            }
+            Err(e) => {
+                let _ = tx.send(WorkerEvent::CommitMessageFailed(e.to_string()));
             }
         });
         Ok(())
@@ -613,6 +614,14 @@ impl App {
             return Ok(false);
         }
 
+        // Toggle fullscreen overlay (default: ctrl-e) without leaving interactive mode.
+        if let Some(Action::ToggleFullscreen) =
+            self.bindings.lookup(&key, BindingScope::Interactive)
+        {
+            self.fullscreen_agent = !self.fullscreen_agent;
+            return Ok(false);
+        }
+
         match key.code {
             KeyCode::Esc => {
                 let _ = provider.write_bytes(b"\x1b");
@@ -671,65 +680,75 @@ impl App {
     }
 
     fn handle_prompt_key(&mut self, key: KeyEvent) -> Result<bool> {
-        if let PromptState::Command {
-            input,
-            selected,
-            searching,
-        } = &mut self.prompt
-        {
-            match key.code {
-                KeyCode::Esc => {
-                    if *searching {
-                        *searching = false;
+        if matches!(self.prompt, PromptState::Command { .. }) {
+            // Determine search state and do binding lookup before taking a mutable borrow.
+            let is_searching = matches!(
+                self.prompt,
+                PromptState::Command {
+                    searching: true,
+                    ..
+                }
+            );
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
+            let action = if is_searching && is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::Palette)
+            };
+
+            match action {
+                Some(Action::CloseOverlay) => {
+                    if is_searching {
+                        if let PromptState::Command { searching, .. } = &mut self.prompt {
+                            *searching = false;
+                        }
                     } else {
                         self.prompt = PromptState::None;
                     }
                 }
-                KeyCode::Char('/') if !*searching => {
-                    *searching = true;
-                }
-                KeyCode::Char('j') | KeyCode::Down if !*searching => {
-                    let count = self.bindings.filtered_palette(input).len();
-                    if *selected + 1 < count {
-                        *selected += 1;
+                Some(Action::SearchToggle) if !is_searching => {
+                    if let PromptState::Command { searching, .. } = &mut self.prompt {
+                        *searching = true;
                     }
                 }
-                KeyCode::Char('k') | KeyCode::Up if !*searching => {
-                    if *selected > 0 {
-                        *selected -= 1;
+                Some(Action::MoveDown) => {
+                    if let PromptState::Command {
+                        input, selected, ..
+                    } = &mut self.prompt
+                    {
+                        let count = self.bindings.filtered_palette(input).len();
+                        if *selected + 1 < count {
+                            *selected += 1;
+                        }
                     }
                 }
-                KeyCode::Down if *searching => {
-                    let count = self.bindings.filtered_palette(input).len();
-                    if *selected + 1 < count {
-                        *selected += 1;
+                Some(Action::MoveUp) => {
+                    if let PromptState::Command { selected, .. } = &mut self.prompt {
+                        if *selected > 0 {
+                            *selected -= 1;
+                        }
                     }
                 }
-                KeyCode::Up if *searching => {
-                    if *selected > 0 {
-                        *selected -= 1;
-                    }
-                }
-                KeyCode::Backspace => {
-                    input.pop();
-                    *selected = 0;
-                }
-                KeyCode::Tab => {
-                    if let Some(binding) = self.bindings.filtered_palette(input).get(*selected) {
-                        *input = binding.palette_name.unwrap().to_string();
-                        *selected = 0;
-                    }
-                }
-                KeyCode::Enter => {
-                    if *searching {
-                        *searching = false;
+                Some(Action::Confirm) => {
+                    if is_searching {
+                        if let PromptState::Command { searching, .. } = &mut self.prompt {
+                            *searching = false;
+                        }
                     } else {
-                        let command = if let Some(binding) =
-                            self.bindings.filtered_palette(input).get(*selected)
+                        let command = if let PromptState::Command {
+                            input, selected, ..
+                        } = &self.prompt
                         {
-                            binding.palette_name.unwrap().to_string()
+                            if let Some(binding) =
+                                self.bindings.filtered_palette(input).get(*selected)
+                            {
+                                binding.palette_name.unwrap().to_string()
+                            } else {
+                                input.trim().to_string()
+                            }
                         } else {
-                            input.trim().to_string()
+                            String::new()
                         };
                         self.prompt = PromptState::None;
                         if let Err(e) = self.execute_command(command) {
@@ -737,90 +756,128 @@ impl App {
                         }
                     }
                 }
-                KeyCode::Char(c) => {
-                    if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                        input.push(c);
-                        *selected = 0;
+                _ => {
+                    // Text input fallback: Tab (autocomplete), Backspace, Char.
+                    if let PromptState::Command {
+                        input, selected, ..
+                    } = &mut self.prompt
+                    {
+                        match key.code {
+                            KeyCode::Tab => {
+                                if let Some(binding) =
+                                    self.bindings.filtered_palette(input).get(*selected)
+                                {
+                                    *input = binding.palette_name.unwrap().to_string();
+                                    *selected = 0;
+                                }
+                            }
+                            KeyCode::Backspace => {
+                                input.pop();
+                                *selected = 0;
+                            }
+                            KeyCode::Char(c) if is_plain_char => {
+                                input.push(c);
+                                *selected = 0;
+                            }
+                            _ => {}
+                        }
                     }
                 }
-                _ => {}
             }
             return Ok(false);
         }
 
-        if let PromptState::BrowseProjects {
-            current_dir,
-            entries,
-            loading,
-            selected,
-            filter,
-            searching,
-            editing_path,
-            path_input,
-            tab_completions,
-            tab_index,
-        } = &mut self.prompt
-        {
-            let mut browse_to: Option<PathBuf> = None;
+        if matches!(self.prompt, PromptState::BrowseProjects { .. }) {
+            // Check sub-mode states and do binding lookup before mutable borrow.
+            let is_editing_path = matches!(
+                self.prompt,
+                PromptState::BrowseProjects {
+                    editing_path: true,
+                    ..
+                }
+            );
+            let is_searching = matches!(
+                self.prompt,
+                PromptState::BrowseProjects {
+                    searching: true,
+                    ..
+                }
+            );
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
 
-            if *editing_path {
-                let mut error_msg = None;
-                match key.code {
-                    KeyCode::Esc => {
-                        *editing_path = false;
-                        path_input.clear();
-                        tab_completions.clear();
-                        *tab_index = 0;
-                    }
-                    KeyCode::Backspace => {
-                        path_input.pop();
-                        tab_completions.clear();
-                        *tab_index = 0;
-                    }
-                    KeyCode::Tab | KeyCode::BackTab => {
-                        if tab_completions.is_empty() {
-                            // Build completions from current input
-                            let input_path = PathBuf::from(path_input.as_str());
-                            let (search_dir, prefix) =
-                                if input_path.is_dir() && path_input.ends_with('/') {
-                                    (input_path.clone(), String::new())
-                                } else {
-                                    let parent = input_path
-                                        .parent()
-                                        .unwrap_or_else(|| std::path::Path::new("/"));
-                                    let file_name = input_path
-                                        .file_name()
-                                        .map(|f| f.to_string_lossy().to_string())
-                                        .unwrap_or_default();
-                                    (parent.to_path_buf(), file_name)
-                                };
-                            if let Ok(read) = std::fs::read_dir(&search_dir) {
-                                let prefix_lower = prefix.to_lowercase();
-                                let mut candidates: Vec<String> = read
-                                    .filter_map(|e| e.ok())
-                                    .filter(|e| {
-                                        e.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
-                                    })
-                                    .filter(|e| {
-                                        let name = e.file_name().to_string_lossy().to_lowercase();
-                                        !name.starts_with('.') && name.starts_with(&prefix_lower)
-                                    })
-                                    .map(|e| {
-                                        let mut full = search_dir
-                                            .join(e.file_name())
-                                            .to_string_lossy()
-                                            .to_string();
-                                        full.push('/');
-                                        full
-                                    })
-                                    .collect();
-                                candidates.sort();
-                                *tab_completions = candidates;
-                                *tab_index = 0;
-                            }
-                        } else {
-                            // Cycle through existing completions
-                            if key.code == KeyCode::BackTab {
+            // Path editor is pure text input — keep hardcoded KeyCode matches.
+            if is_editing_path {
+                if let PromptState::BrowseProjects {
+                    current_dir,
+                    entries,
+                    loading,
+                    selected,
+                    filter,
+                    editing_path,
+                    path_input,
+                    tab_completions,
+                    tab_index,
+                    ..
+                } = &mut self.prompt
+                {
+                    let mut browse_to: Option<PathBuf> = None;
+                    let mut error_msg = None;
+                    match key.code {
+                        KeyCode::Esc => {
+                            *editing_path = false;
+                            path_input.clear();
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        KeyCode::Backspace => {
+                            path_input.pop();
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        KeyCode::Tab | KeyCode::BackTab => {
+                            if tab_completions.is_empty() {
+                                let input_path = PathBuf::from(path_input.as_str());
+                                let (search_dir, prefix) =
+                                    if input_path.is_dir() && path_input.ends_with('/') {
+                                        (input_path.clone(), String::new())
+                                    } else {
+                                        let parent = input_path
+                                            .parent()
+                                            .unwrap_or_else(|| std::path::Path::new("/"));
+                                        let file_name = input_path
+                                            .file_name()
+                                            .map(|f| f.to_string_lossy().to_string())
+                                            .unwrap_or_default();
+                                        (parent.to_path_buf(), file_name)
+                                    };
+                                if let Ok(read) = std::fs::read_dir(&search_dir) {
+                                    let prefix_lower = prefix.to_lowercase();
+                                    let mut candidates: Vec<String> = read
+                                        .filter_map(|e| e.ok())
+                                        .filter(|e| {
+                                            e.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
+                                        })
+                                        .filter(|e| {
+                                            let name =
+                                                e.file_name().to_string_lossy().to_lowercase();
+                                            !name.starts_with('.')
+                                                && name.starts_with(&prefix_lower)
+                                        })
+                                        .map(|e| {
+                                            let mut full = search_dir
+                                                .join(e.file_name())
+                                                .to_string_lossy()
+                                                .to_string();
+                                            full.push('/');
+                                            full
+                                        })
+                                        .collect();
+                                    candidates.sort();
+                                    *tab_completions = candidates;
+                                    *tab_index = 0;
+                                }
+                            } else if key.code == KeyCode::BackTab {
                                 if *tab_index == 0 {
                                     *tab_index = tab_completions.len().saturating_sub(1);
                                 } else {
@@ -829,138 +886,187 @@ impl App {
                             } else {
                                 *tab_index = (*tab_index + 1) % tab_completions.len();
                             }
+                            if let Some(completion) = tab_completions.get(*tab_index) {
+                                *path_input = completion.clone();
+                            }
                         }
-                        if let Some(completion) = tab_completions.get(*tab_index) {
-                            *path_input = completion.clone();
+                        KeyCode::Enter => {
+                            let new_dir = PathBuf::from(path_input.trim());
+                            if new_dir.is_dir() {
+                                *current_dir = new_dir.clone();
+                                entries.clear();
+                                *loading = true;
+                                *selected = 0;
+                                filter.clear();
+                                browse_to = Some(new_dir);
+                            } else {
+                                error_msg =
+                                    Some(format!("{} is not a directory.", path_input.trim()));
+                            }
+                            *editing_path = false;
+                            path_input.clear();
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        KeyCode::Char(c) if is_plain_char => {
+                            path_input.push(c);
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        _ => {}
+                    }
+                    if let Some(msg) = error_msg {
+                        self.set_error(msg);
+                    }
+                    if let Some(dir) = browse_to {
+                        self.spawn_browser_entries(&dir);
+                    }
+                }
+                return Ok(false);
+            }
+
+            // Browser normal/search mode — use binding lookup.
+            let action = if is_searching && is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::Browser)
+            };
+
+            let mut browse_to: Option<PathBuf> = None;
+            match action {
+                Some(Action::CloseOverlay) => {
+                    if let PromptState::BrowseProjects {
+                        searching,
+                        filter,
+                        selected,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        if *searching {
+                            *searching = false;
+                        } else if !filter.is_empty() {
+                            filter.clear();
+                            *selected = 0;
+                        } else {
+                            self.prompt = PromptState::None;
                         }
                     }
-                    KeyCode::Enter => {
-                        let new_dir = PathBuf::from(path_input.trim());
-                        if new_dir.is_dir() {
+                }
+                Some(Action::SearchToggle) if !is_searching => {
+                    if let PromptState::BrowseProjects { searching, .. } = &mut self.prompt {
+                        *searching = true;
+                    }
+                }
+                Some(Action::MoveDown) => {
+                    if let PromptState::BrowseProjects {
+                        entries,
+                        selected,
+                        filter,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        let filtered_len = if filter.is_empty() {
+                            entries.len()
+                        } else {
+                            let needle = filter.to_lowercase();
+                            entries
+                                .iter()
+                                .filter(|e| e.label.to_lowercase().contains(&needle))
+                                .count()
+                        };
+                        if *selected + 1 < filtered_len {
+                            *selected += 1;
+                        }
+                    }
+                }
+                Some(Action::MoveUp) => {
+                    if let PromptState::BrowseProjects { selected, .. } = &mut self.prompt {
+                        if *selected > 0 {
+                            *selected -= 1;
+                        }
+                    }
+                }
+                Some(Action::GoToPath) if !is_searching => {
+                    if let PromptState::BrowseProjects {
+                        current_dir,
+                        editing_path,
+                        path_input,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        *editing_path = true;
+                        let mut p = current_dir.to_string_lossy().to_string();
+                        if !p.ends_with('/') {
+                            p.push('/');
+                        }
+                        *path_input = p;
+                    }
+                }
+                Some(Action::Confirm) if is_searching => {
+                    if let PromptState::BrowseProjects { searching, .. } = &mut self.prompt {
+                        *searching = false;
+                    }
+                }
+                Some(Action::OpenEntry) if !is_searching => {
+                    if let PromptState::BrowseProjects {
+                        current_dir,
+                        entries,
+                        loading,
+                        selected,
+                        filter,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        let visible: Vec<_> = if filter.is_empty() {
+                            entries.iter().collect()
+                        } else {
+                            let needle = filter.to_lowercase();
+                            entries
+                                .iter()
+                                .filter(|e| e.label.to_lowercase().contains(&needle))
+                                .collect()
+                        };
+                        if let Some(entry) = visible.get(*selected).cloned() {
+                            let new_dir = entry.path.clone();
                             *current_dir = new_dir.clone();
                             entries.clear();
                             *loading = true;
                             *selected = 0;
                             filter.clear();
                             browse_to = Some(new_dir);
-                        } else {
-                            error_msg = Some(format!("{} is not a directory.", path_input.trim()));
-                        }
-                        *editing_path = false;
-                        path_input.clear();
-                        tab_completions.clear();
-                        *tab_index = 0;
-                    }
-                    KeyCode::Char(c) => {
-                        if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                            path_input.push(c);
-                            tab_completions.clear();
-                            *tab_index = 0;
                         }
                     }
-                    _ => {}
                 }
-                if let Some(msg) = error_msg {
-                    self.set_error(msg);
-                }
-                if let Some(dir) = browse_to {
-                    self.spawn_browser_entries(&dir);
-                }
-                return Ok(false);
-            }
-
-            let filtered_len = if filter.is_empty() {
-                entries.len()
-            } else {
-                let needle = filter.to_lowercase();
-                entries
-                    .iter()
-                    .filter(|e| e.label.to_lowercase().contains(&needle))
-                    .count()
-            };
-            match key.code {
-                KeyCode::Esc => {
-                    if *searching {
-                        *searching = false;
-                    } else if !filter.is_empty() {
-                        filter.clear();
-                        *selected = 0;
-                    } else {
+                Some(Action::AddCurrentDir) if !is_searching => {
+                    if let PromptState::BrowseProjects { current_dir, .. } = &self.prompt {
+                        let path = current_dir.to_string_lossy().to_string();
                         self.prompt = PromptState::None;
+                        if let Err(e) = self.add_project(path, String::new()) {
+                            self.set_error(format!("{e:#}"));
+                        }
                     }
                 }
-                KeyCode::Char('/') if !*searching => {
-                    *searching = true;
-                }
-                KeyCode::Char('j') | KeyCode::Down if !*searching => {
-                    if *selected + 1 < filtered_len {
-                        *selected += 1;
+                _ => {
+                    // Text input fallback for search mode.
+                    if is_searching {
+                        if let PromptState::BrowseProjects {
+                            filter, selected, ..
+                        } = &mut self.prompt
+                        {
+                            match key.code {
+                                KeyCode::Backspace => {
+                                    filter.pop();
+                                    *selected = 0;
+                                }
+                                KeyCode::Char(c) if is_plain_char => {
+                                    filter.push(c);
+                                    *selected = 0;
+                                }
+                                _ => {}
+                            }
+                        }
                     }
                 }
-                KeyCode::Char('k') | KeyCode::Up if !*searching => {
-                    if *selected > 0 {
-                        *selected -= 1;
-                    }
-                }
-                KeyCode::Down if *searching => {
-                    if *selected + 1 < filtered_len {
-                        *selected += 1;
-                    }
-                }
-                KeyCode::Up if *searching => {
-                    if *selected > 0 {
-                        *selected -= 1;
-                    }
-                }
-                KeyCode::Backspace if *searching => {
-                    filter.pop();
-                    *selected = 0;
-                }
-                KeyCode::Char('g') if !*searching => {
-                    *editing_path = true;
-                    let mut p = current_dir.to_string_lossy().to_string();
-                    if !p.ends_with('/') {
-                        p.push('/');
-                    }
-                    *path_input = p;
-                }
-                KeyCode::Enter if *searching => {
-                    *searching = false;
-                }
-                KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') if !*searching => {
-                    let visible: Vec<_> = if filter.is_empty() {
-                        entries.iter().collect()
-                    } else {
-                        let needle = filter.to_lowercase();
-                        entries
-                            .iter()
-                            .filter(|e| e.label.to_lowercase().contains(&needle))
-                            .collect()
-                    };
-                    if let Some(entry) = visible.get(*selected).cloned() {
-                        let new_dir = entry.path.clone();
-                        *current_dir = new_dir.clone();
-                        entries.clear();
-                        *loading = true;
-                        *selected = 0;
-                        filter.clear();
-                        browse_to = Some(new_dir);
-                    }
-                }
-                KeyCode::Char('o') if !*searching => {
-                    let path = current_dir.to_string_lossy().to_string();
-                    self.prompt = PromptState::None;
-                    if let Err(e) = self.add_project(path, String::new()) {
-                        self.set_error(format!("{e:#}"));
-                    }
-                }
-                KeyCode::Char(c) if *searching => {
-                    if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                        filter.push(c);
-                        *selected = 0;
-                    }
-                }
-                _ => {}
             }
             if let Some(dir) = browse_to {
                 self.spawn_browser_entries(&dir);
@@ -974,16 +1080,12 @@ impl App {
             ..
         } = &mut self.prompt
         {
-            match key.code {
-                KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left
-                | KeyCode::Right
-                | KeyCode::Tab
-                | KeyCode::Char('h')
-                | KeyCode::Char('l') => {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
                     *confirm_selected = !*confirm_selected;
                 }
-                KeyCode::Enter => {
+                Some(Action::Confirm) => {
                     if *confirm_selected {
                         let id = session_id.clone();
                         self.prompt = PromptState::None;
@@ -1002,16 +1104,12 @@ impl App {
             confirm_selected, ..
         } = &mut self.prompt
         {
-            match key.code {
-                KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left
-                | KeyCode::Right
-                | KeyCode::Tab
-                | KeyCode::Char('h')
-                | KeyCode::Char('l') => {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
                     *confirm_selected = !*confirm_selected;
                 }
-                KeyCode::Enter => {
+                Some(Action::Confirm) => {
                     if *confirm_selected {
                         return Ok(true);
                     } else {
@@ -1028,16 +1126,12 @@ impl App {
             confirm_selected,
         } = &mut self.prompt
         {
-            match key.code {
-                KeyCode::Esc => self.prompt = PromptState::None,
-                KeyCode::Left
-                | KeyCode::Right
-                | KeyCode::Tab
-                | KeyCode::Char('h')
-                | KeyCode::Char('l') => {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
                     *confirm_selected = !*confirm_selected;
                 }
-                KeyCode::Enter => {
+                Some(Action::Confirm) => {
                     if *confirm_selected {
                         let fp = file_path.clone();
                         let ut = *is_untracked;
@@ -1148,7 +1242,7 @@ impl App {
         {
             self.config.ui.left_width_pct = self.left_width_pct;
             self.config.ui.right_width_pct = self.right_width_pct;
-            let _ = save_config(&self.paths.config_path, &self.config);
+            let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
         }
     }
 
@@ -1156,7 +1250,7 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(_) => {
                 self.set_info(
-                    "Mouse support is available for wheel navigation; resize has a keyboard fallback via Ctrl-w.",
+                    &format!("Mouse support is available for wheel navigation; resize has a keyboard fallback via {}.", self.bindings.label_for(Action::ToggleResizeMode)),
                 );
             }
             MouseEventKind::ScrollDown => match self.focus {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -59,6 +59,7 @@ pub struct App {
     pub(crate) help_scroll: Option<u16>,
     pub(crate) last_help_height: u16,
     pub(crate) last_help_lines: u16,
+    pub(crate) fullscreen_agent: bool,
     pub(crate) status: StatusLine,
     pub(crate) prompt: PromptState,
     pub(crate) input_target: InputTarget,
@@ -295,6 +296,7 @@ impl App {
             help_scroll: None,
             last_help_height: 0,
             last_help_lines: 0,
+            fullscreen_agent: false,
             status: StatusLine::new("Press p to add a project, a to create an agent, ? for help."),
             prompt: PromptState::None,
             input_target: InputTarget::None,
@@ -361,6 +363,12 @@ impl App {
     }
 
     pub(crate) fn close_top_overlay(&mut self) -> bool {
+        if self.fullscreen_agent {
+            self.fullscreen_agent = false;
+            let key = self.bindings.label_for(Action::ToggleFullscreen);
+            self.set_info(format!("Exited fullscreen. Press {key} to re-enter."));
+            return true;
+        }
         if !matches!(self.prompt, PromptState::None) {
             self.prompt = PromptState::None;
             self.set_info("Closed overlay.");

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -459,6 +459,7 @@ impl App {
         if hint_area.height > 0 {
             // Pre-compute all key labels so they outlive the Span borrows.
             let exit_key = self.bindings.label_for(Action::ExitInteractive);
+            let fullscreen_key = self.bindings.label_for(Action::ToggleFullscreen);
             let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
             let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
             let interact = self.bindings.labels_for(Action::InteractAgent);
@@ -480,7 +481,9 @@ impl App {
                     desc_style,
                 ));
                 spans.extend(self.theme.dim_key_badge(&exit_key, Color::Reset));
-                spans.push(Span::styled(" to bring the focus back.", desc_style));
+                spans.push(Span::styled(" to bring the focus back. ", desc_style));
+                spans.extend(self.theme.dim_key_badge(&fullscreen_key, Color::Reset));
+                spans.push(Span::styled(" fullscreen.", desc_style));
                 Line::from(spans)
             } else if scrollback_offset > 0 {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
@@ -500,6 +503,8 @@ impl App {
                 if session_active {
                     spans.extend(self.theme.dim_key_badge(&interact, Color::Reset));
                     spans.push(Span::styled(" to interact. ", desc_style));
+                    spans.extend(self.theme.dim_key_badge(&fullscreen_key, Color::Reset));
+                    spans.push(Span::styled(" fullscreen. ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                     spans.push(Span::styled(" ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
@@ -721,11 +726,8 @@ impl App {
                 .render(text_area, frame.buffer_mut());
 
             if focused {
-                let (cursor_row, cursor_col) = cursor_pos_in_wrapped(
-                    &self.commit_input,
-                    self.commit_input_cursor,
-                    text_w,
-                );
+                let (cursor_row, cursor_col) =
+                    cursor_pos_in_wrapped(&self.commit_input, self.commit_input_cursor, text_w);
                 let screen_row = cursor_row.saturating_sub(self.commit_scroll);
                 let cx = text_area.x + cursor_col as u16;
                 let cy = text_area.y + screen_row;
@@ -1061,35 +1063,39 @@ impl App {
                 } else {
                     "Command Palette"
                 };
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let search_key = self.bindings.label_for(Action::SearchToggle);
                 let mut bottom_spans = vec![Span::raw(" ")];
                 if *searching {
-                    bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&confirm_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " done  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " clear",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
                 } else {
-                    bottom_spans.extend(self.theme.key_badge("/", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&search_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " search  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&confirm_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " run  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
+                    // Tab autocomplete is text-input behavior, not a rebindable action.
                     bottom_spans.extend(self.theme.key_badge("Tab", Color::Reset));
                     bottom_spans.push(Span::styled(
                         " complete  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " cancel",
                         Style::default().fg(self.theme.hint_desc_fg),
@@ -1205,8 +1211,14 @@ impl App {
                     Paragraph::new(input_text)
                         .block(self.themed_overlay_block(&title))
                         .render(filter_area, frame.buffer_mut());
+                    let confirm_key = self.bindings.label_for(Action::Confirm);
+                    let close_key = self.bindings.label_for(Action::CloseOverlay);
+                    let search_key = self.bindings.label_for(Action::SearchToggle);
+                    let open_key = self.bindings.label_for(Action::OpenEntry);
+                    let goto_key = self.bindings.label_for(Action::GoToPath);
                     let mut bottom_spans = vec![Span::raw(" ")];
                     if *editing_path {
+                        // Path editor: Tab/Enter/Esc are text-input controls, not rebindable.
                         bottom_spans.extend(self.theme.key_badge("Tab", Color::Reset));
                         bottom_spans.push(Span::styled(
                             " complete  ",
@@ -1223,33 +1235,33 @@ impl App {
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
                     } else if *searching {
-                        bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&confirm_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " done  ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
-                        bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " clear",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
                     } else {
-                        bottom_spans.extend(self.theme.key_badge("/", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&search_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " search  ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
-                        bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&open_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " open  ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
-                        bottom_spans.extend(self.theme.key_badge("g", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&goto_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " go to  ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
-                        bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
+                        bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
                         bottom_spans.push(Span::styled(
                             " cancel",
                             Style::default().fg(self.theme.hint_desc_fg),
@@ -1269,28 +1281,33 @@ impl App {
                         &mut state,
                     );
                 } else {
+                    let search_key = self.bindings.label_for(Action::SearchToggle);
+                    let open_key = self.bindings.label_for(Action::OpenEntry);
+                    let add_key = self.bindings.label_for(Action::AddCurrentDir);
+                    let goto_key = self.bindings.label_for(Action::GoToPath);
+                    let close_key = self.bindings.label_for(Action::CloseOverlay);
                     let mut bottom_spans = vec![Span::raw(" ")];
-                    bottom_spans.extend(self.theme.key_badge("/", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&search_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " search  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("Enter", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&open_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " open  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("o", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&add_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " add current  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("g", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&goto_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " go to  ",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
-                    bottom_spans.extend(self.theme.key_badge("Esc", Color::Reset));
+                    bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
                     bottom_spans.push(Span::styled(
                         " cancel",
                         Style::default().fg(self.theme.hint_desc_fg),
@@ -1617,9 +1634,7 @@ impl App {
                 )
                 .render(discard_area, frame.buffer_mut());
             }
-            PromptState::RenameSession {
-                input, cursor, ..
-            } => {
+            PromptState::RenameSession { input, cursor, .. } => {
                 self.render_dim_overlay(frame);
                 let area = centered_rect(56, 14, frame.area());
                 Clear.render(area, frame.buffer_mut());
@@ -1653,21 +1668,14 @@ impl App {
                         Span::raw(format!(" {before}")),
                         Span::styled(
                             cursor_char.to_string(),
-                            Style::default()
-                                .fg(Color::Black)
-                                .bg(Color::White),
+                            Style::default().fg(Color::Black).bg(Color::White),
                         ),
                         Span::raw(rest.to_string()),
                     ])
                 } else {
                     Line::from(vec![
                         Span::raw(format!(" {input}")),
-                        Span::styled(
-                            " ",
-                            Style::default()
-                                .fg(Color::Black)
-                                .bg(Color::White),
-                        ),
+                        Span::styled(" ", Style::default().fg(Color::Black).bg(Color::White)),
                     ])
                 };
                 Paragraph::new(display)
@@ -1679,13 +1687,15 @@ impl App {
                     )
                     .render(input_area, frame.buffer_mut());
 
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
                 let mut hints = vec![Span::raw(" ")];
-                hints.extend(self.theme.key_badge("Enter", Color::Reset));
+                hints.extend(self.theme.key_badge(&confirm_key, Color::Reset));
                 hints.push(Span::styled(
                     " confirm  ",
                     Style::default().fg(self.theme.hint_desc_fg),
                 ));
-                hints.extend(self.theme.key_badge("Esc", Color::Reset));
+                hints.extend(self.theme.key_badge(&close_key, Color::Reset));
                 hints.push(Span::styled(
                     " cancel",
                     Style::default().fg(self.theme.hint_desc_fg),
@@ -1697,6 +1707,10 @@ impl App {
     }
 
     fn render_overlay(&mut self, frame: &mut Frame) {
+        if self.fullscreen_agent {
+            self.render_fullscreen_agent(frame);
+            return;
+        }
         if !matches!(self.prompt, PromptState::None) {
             self.render_prompt(frame);
             return;
@@ -1704,6 +1718,13 @@ impl App {
         if self.help_scroll.is_some() {
             self.render_help(frame);
         }
+    }
+
+    fn render_fullscreen_agent(&mut self, frame: &mut Frame) {
+        self.render_dim_overlay(frame);
+        let area = centered_rect(96, 94, frame.area());
+        Clear.render(area, frame.buffer_mut());
+        self.render_agent_terminal(frame, area, " Agent (fullscreen) ", true);
     }
 
     fn themed_block<'a>(&self, title: &'a str, focused: bool) -> Block<'a> {
@@ -1854,7 +1875,7 @@ fn cursor_pos_in_wrapped(text: &str, cursor: usize, width: usize) -> (u16, usize
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui::{backend::TestBackend, Terminal};
+    use ratatui::{Terminal, backend::TestBackend};
 
     // ── Unit tests for wrap_text_at_width ──────────────────────────
 
@@ -1881,27 +1902,18 @@ mod tests {
 
     #[test]
     fn wrap_multiple_lines() {
-        assert_eq!(
-            wrap_text_at_width("abcdefghij", 3),
-            "abc\ndef\nghi\nj"
-        );
+        assert_eq!(wrap_text_at_width("abcdefghij", 3), "abc\ndef\nghi\nj");
     }
 
     #[test]
     fn wrap_preserves_existing_newlines() {
-        assert_eq!(
-            wrap_text_at_width("ab\ncdefgh", 5),
-            "ab\ncdefg\nh"
-        );
+        assert_eq!(wrap_text_at_width("ab\ncdefgh", 5), "ab\ncdefg\nh");
     }
 
     #[test]
     fn wrap_newline_resets_column() {
         // "abcde" fills width 5, then "\n" resets, then "fg" fits.
-        assert_eq!(
-            wrap_text_at_width("abcde\nfg", 5),
-            "abcde\n\nfg"
-        );
+        assert_eq!(wrap_text_at_width("abcde\nfg", 5), "abcde\n\nfg");
     }
 
     #[test]
@@ -2064,7 +2076,8 @@ mod tests {
             let cell = buf.cell((ccol as u16, crow as u16)).unwrap();
             let expected = &text[cursor..cursor + 1];
             assert_eq!(
-                cell.symbol(), expected,
+                cell.symbol(),
+                expected,
                 "cursor={cursor} at ({crow},{ccol}): buffer has {:?}, expected {expected:?}",
                 cell.symbol()
             );

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -29,9 +29,15 @@ impl App {
             tab_index: 0,
         };
         self.spawn_browser_entries(&start_dir);
-        self.set_info(
-            "Project browser: Enter opens folders, o adds current dir, / to search, g to go to a path.",
-        );
+        {
+            let open = self.bindings.label_for(Action::OpenEntry);
+            let add = self.bindings.label_for(Action::AddCurrentDir);
+            let search = self.bindings.label_for(Action::SearchToggle);
+            let goto = self.bindings.label_for(Action::GoToPath);
+            self.set_info(format!(
+                "Project browser: {open} opens folders, {add} adds current dir, {search} to search, {goto} to go to a path.",
+            ));
+        }
         Ok(())
     }
 
@@ -73,7 +79,7 @@ impl App {
             default_provider: None,
             commit_prompt: None,
         });
-        save_config(&self.paths.config_path, &self.config)?;
+        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
         self.projects.push(Project {
             id: project_id,
             name: display_name.clone(),
@@ -248,7 +254,7 @@ impl App {
         {
             project_config.default_provider = Some(next.as_str().to_string());
         }
-        save_config(&self.paths.config_path, &self.config)?;
+        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
         for session in self
             .sessions
             .iter_mut()
@@ -275,7 +281,7 @@ impl App {
         self.config
             .projects
             .retain(|p| Path::new(&p.path) != Path::new(&project.path));
-        save_config(&self.paths.config_path, &self.config)?;
+        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
         self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.set_info(format!("Removed project \"{}\" from app", project.name));
@@ -314,7 +320,7 @@ impl App {
         self.config
             .projects
             .retain(|candidate| Path::new(&candidate.path) != Path::new(&project.path));
-        save_config(&self.paths.config_path, &self.config)?;
+        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
         self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -51,16 +51,23 @@ impl App {
                     self.commit_input_cursor = self.commit_input.len();
                     self.commit_generating = false;
                     self.input_target = InputTarget::CommitMessage;
-                    self.set_info(
-                        "AI commit message generated. Press Esc to exit, then c to commit.",
-                    );
+                    {
+                        let exit_key = self.bindings.label_for(Action::ExitCommitInput);
+                        let commit_key = self.bindings.label_for(Action::CommitChanges);
+                        self.set_info(format!(
+                            "AI commit message generated. Press {exit_key} to exit, then {commit_key} to commit.",
+                        ));
+                    }
                 }
                 WorkerEvent::CommitMessageFailed(err) => {
                     self.commit_generating = false;
-                    self.set_error(format!(
-                        "Failed to generate AI commit message: {err}. \
-                         You can write one manually or retry with ^G.",
-                    ));
+                    {
+                        let gen_key = self.bindings.label_for(Action::GenerateCommitMessage);
+                        self.set_error(format!(
+                            "Failed to generate AI commit message: {err}. \
+                             You can write one manually or retry with {gen_key}.",
+                        ));
+                    }
                 }
                 WorkerEvent::PushCompleted(result) => match result {
                     Ok(()) => self.set_info(

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,7 +272,8 @@ pub fn ensure_config(paths: &DuxPaths) -> Result<Config> {
     let mut config: Config = toml::from_str(&raw)
         .with_context(|| format!("failed to parse {}", paths.config_path.display()))?;
     config.providers.ensure_defaults();
-    let _ = save_config(&paths.config_path, &config);
+    let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
+    let _ = save_config(&paths.config_path, &config, &bindings);
     Ok(config)
 }
 
@@ -290,6 +291,12 @@ enum FieldValue {
     MultilineStr(Option<String>),
 }
 
+/// A comment source: static string or dynamically built.
+enum CommentSource {
+    Static(&'static str),
+    Dynamic(String),
+}
+
 /// One entry in the config file layout.
 enum ConfigEntry {
     /// A comment line (must include the leading `#`).
@@ -301,7 +308,7 @@ enum ConfigEntry {
     /// A key = value line with an optional comment above it.
     Field {
         key: &'static str,
-        comment: Option<&'static str>,
+        comment: Option<CommentSource>,
         value_fn: fn(&Config) -> FieldValue,
     },
     /// Renders all `[providers.*]` sub-tables dynamically.
@@ -312,7 +319,7 @@ enum ConfigEntry {
     Keys,
 }
 
-fn config_schema() -> Vec<ConfigEntry> {
+fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
     vec![
         ConfigEntry::Comment("# dux configuration"),
         ConfigEntry::Comment(
@@ -322,22 +329,26 @@ fn config_schema() -> Vec<ConfigEntry> {
         ConfigEntry::Section("defaults"),
         ConfigEntry::Field {
             key: "provider",
-            comment: Some("# Which provider new sessions use unless a project overrides it."),
+            comment: Some(CommentSource::Static(
+                "# Which provider new sessions use unless a project overrides it.",
+            )),
             value_fn: |c| FieldValue::Str(c.defaults.provider.clone()),
         },
         ConfigEntry::Field {
             key: "start_directory",
-            comment: Some("# Starting directory for the project browser."),
+            comment: Some(CommentSource::Static(
+                "# Starting directory for the project browser.",
+            )),
             value_fn: |c| FieldValue::OptStr(c.defaults.start_directory.clone()),
         },
         ConfigEntry::Blank,
         ConfigEntry::Field {
             key: "commit_prompt",
-            comment: Some(
-                "# Prompt sent to the AI provider when generating commit messages (Ctrl+G).\n\
+            comment: Some(CommentSource::Dynamic(format!(
+                "# Prompt sent to the AI provider when generating commit messages ({generate_commit_key}).\n\
                  # The provider will inspect the staged diff on its own.\n\
                  # Override per-project by adding commit_prompt in a [[projects]] entry.",
-            ),
+            ))),
             value_fn: |c| FieldValue::MultilineStr(c.defaults.commit_prompt.clone()),
         },
         ConfigEntry::Blank,
@@ -345,21 +356,25 @@ fn config_schema() -> Vec<ConfigEntry> {
         ConfigEntry::Section("logging"),
         ConfigEntry::Field {
             key: "level",
-            comment: Some("# Log level can be error, info, or debug."),
+            comment: Some(CommentSource::Static(
+                "# Log level can be error, info, or debug.",
+            )),
             value_fn: |c| FieldValue::Str(c.logging.level.clone()),
         },
         ConfigEntry::Field {
             key: "path",
-            comment: Some("# Relative paths are resolved from the dux config directory."),
+            comment: Some(CommentSource::Static(
+                "# Relative paths are resolved from the dux config directory.",
+            )),
             value_fn: |c| FieldValue::Str(c.logging.path.clone()),
         },
         ConfigEntry::Blank,
         ConfigEntry::Section("ui"),
         ConfigEntry::Field {
             key: "left_width_pct",
-            comment: Some(
+            comment: Some(CommentSource::Static(
                 "# Initial pane sizing percentages. They can still be resized at runtime.",
-            ),
+            )),
             value_fn: |c| FieldValue::U16(c.ui.left_width_pct),
         },
         ConfigEntry::Field {
@@ -374,9 +389,9 @@ fn config_schema() -> Vec<ConfigEntry> {
     ]
 }
 
-fn render_config(config: &Config) -> String {
+fn render_config(config: &Config, generate_commit_key: &str) -> String {
     let mut out = String::new();
-    for entry in config_schema() {
+    for entry in config_schema(generate_commit_key) {
         match entry {
             ConfigEntry::Comment(text) => {
                 out.push_str(text);
@@ -392,7 +407,10 @@ fn render_config(config: &Config) -> String {
                 value_fn,
             } => {
                 if let Some(c) = comment {
-                    out.push_str(c);
+                    match c {
+                        CommentSource::Static(s) => out.push_str(s),
+                        CommentSource::Dynamic(s) => out.push_str(&s),
+                    }
                     out.push('\n');
                 }
                 match value_fn(config) {
@@ -409,7 +427,8 @@ fn render_config(config: &Config) -> String {
                         let _ = writeln!(out, "{key} = {n}");
                     }
                     FieldValue::MultilineStr(Some(s)) => {
-                        let _ = writeln!(out, "{key} = \"\"\"\n{s}\"\"\"");
+                        let escaped = escape_toml_multiline(&s);
+                        let _ = writeln!(out, "{key} = \"\"\"\n{escaped}\"\"\"");
                     }
                     FieldValue::MultilineStr(None) => {
                         let _ = writeln!(out, "{key} = \"\"");
@@ -425,11 +444,18 @@ fn render_config(config: &Config) -> String {
 }
 
 pub fn render_default_config() -> String {
-    render_config(&Config::default())
+    let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&KeysConfig::default());
+    let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
+    render_config(&Config::default(), &key)
 }
 
-pub fn save_config(config_path: &Path, config: &Config) -> Result<()> {
-    let body = render_config(config);
+pub fn save_config(
+    config_path: &Path,
+    config: &Config,
+    bindings: &crate::keybindings::RuntimeBindings,
+) -> Result<()> {
+    let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
+    let body = render_config(config, &key);
     fs::write(config_path, body)
         .with_context(|| format!("failed to write {}", config_path.display()))?;
     Ok(())
@@ -505,11 +531,19 @@ fn render_projects(out: &mut String, projects: &[ProjectConfig]) {
                 );
             }
             if let Some(prompt) = &project.commit_prompt {
-                let _ = writeln!(out, "commit_prompt = \"\"\"\n{prompt}\"\"\"");
+                let escaped = escape_toml_multiline(prompt);
+                let _ = writeln!(out, "commit_prompt = \"\"\"\n{escaped}\"\"\"");
             }
             out.push('\n');
         }
     }
+}
+
+/// Escape triple-quotes in a TOML multiline basic string.
+/// Per the TOML spec, `"""` inside `"""..."""` can be included by escaping
+/// at least one quote: `""\"`.
+fn escape_toml_multiline(value: &str) -> String {
+    value.replace("\"\"\"", "\"\"\\\"")
 }
 
 fn escape_toml_string(value: &str) -> String {
@@ -667,6 +701,14 @@ fn discover_root(home: &Path, xdg_config_home: Option<std::ffi::OsString>) -> Pa
 mod tests {
     use super::*;
 
+    /// Render config using default keybinding labels (for tests that don't need custom bindings).
+    fn render_config_default(config: &Config) -> String {
+        let bindings =
+            crate::keybindings::RuntimeBindings::from_keys_config(&KeysConfig::default());
+        let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
+        render_config(config, &key)
+    }
+
     #[test]
     fn default_config_is_commented_and_complete() {
         let rendered = render_default_config();
@@ -721,7 +763,7 @@ mod tests {
             default_provider: None,
             commit_prompt: None,
         });
-        let rendered = render_config(&config);
+        let rendered = render_config_default(&config);
         let parsed: Config = toml::from_str(&rendered).expect("should parse back");
         assert_eq!(parsed.projects[0].path, config.projects[0].path);
         assert_eq!(parsed.projects[0].name, config.projects[0].name);
@@ -737,7 +779,7 @@ mod tests {
             default_provider: None,
             commit_prompt: None,
         });
-        let rendered = render_config(&config);
+        let rendered = render_config_default(&config);
         let parsed: Config = toml::from_str(&rendered).expect("should parse back");
         assert_eq!(parsed.projects[0].path, config.projects[0].path);
         assert_eq!(parsed.projects[0].name, config.projects[0].name);
@@ -747,7 +789,7 @@ mod tests {
     fn default_config_round_trips_through_toml() {
         let rendered = render_default_config();
         let parsed: Config = toml::from_str(&rendered).expect("default config should parse");
-        let re_rendered = render_config(&parsed);
+        let re_rendered = render_config_default(&parsed);
         assert_eq!(
             rendered, re_rendered,
             "render → parse → render should be stable"
@@ -834,6 +876,33 @@ mod tests {
         assert_eq!(
             config.commit_prompt_for_project("/any/project"),
             DEFAULT_COMMIT_PROMPT
+        );
+    }
+
+    #[test]
+    fn multiline_string_with_triple_quotes_roundtrips() {
+        let mut config = Config::default();
+        config.defaults.commit_prompt =
+            Some("Use triple \"\"\" quotes in your prompt.".to_string());
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("should parse back");
+        assert_eq!(
+            parsed.defaults.commit_prompt.as_deref(),
+            Some("Use triple \"\"\" quotes in your prompt."),
+        );
+    }
+
+    #[test]
+    fn config_comment_uses_dynamic_keybinding_label() {
+        let rendered = render_default_config();
+        // The default binding for GenerateCommitMessage is Ctrl-g.
+        assert!(
+            rendered.contains("(Ctrl-g)"),
+            "config comment should include the dynamic keybinding label"
+        );
+        assert!(
+            !rendered.contains("(Ctrl+G)"),
+            "config comment should NOT contain hardcoded Ctrl+G"
         );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -471,7 +471,16 @@ mod tests {
             );
         };
         run(&["init", "-b", "main"]);
-        run(&["-c", "user.name=test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "init"]);
+        run(&[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ]);
         dir
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -20,6 +20,7 @@ pub enum Action {
     // Agent pane
     InteractAgent,
     ExitInteractive,
+    ToggleFullscreen,
     ScrollPageUp,
     ScrollPageDown,
     // Files pane (git staging)
@@ -123,6 +124,7 @@ impl Action {
             Action::DeleteSession => "delete_session",
             Action::InteractAgent => "interact_agent",
             Action::ExitInteractive => "exit_interactive",
+            Action::ToggleFullscreen => "toggle_fullscreen",
             Action::ScrollPageUp => "scroll_page_up",
             Action::ScrollPageDown => "scroll_page_down",
             Action::OpenDiff => "open_diff",
@@ -172,6 +174,7 @@ impl Action {
             Action::DeleteSession => "Delete the selected session and worktree.",
             Action::InteractAgent => "Start a prompt turn for the agent.",
             Action::ExitInteractive => "Exit interactive mode (stop forwarding keys to agent).",
+            Action::ToggleFullscreen => "Toggle fullscreen overlay for the agent terminal.",
             Action::ScrollPageUp => "Scroll up one page in the agent output.",
             Action::ScrollPageDown => "Scroll down one page in the agent output.",
             Action::OpenDiff => "Open the selected file's diff.",
@@ -221,6 +224,7 @@ impl Action {
             | Action::DeleteSession => Some("Projects pane"),
             Action::InteractAgent
             | Action::ExitInteractive
+            | Action::ToggleFullscreen
             | Action::ScrollPageUp
             | Action::ScrollPageDown => Some("Agent pane"),
             Action::OpenDiff
@@ -444,6 +448,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             description: "Exit interactive mode",
         }),
         hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ToggleFullscreen,
+        default_keys: &[key!(ctrl - e)],
+        scopes: &[BindingScope::Interactive, BindingScope::Center],
+        help: Some(HelpEntry {
+            section: "Agent pane",
+            description: "Toggle fullscreen agent overlay",
+        }),
+        hint_contexts: &[(HintContext::Center, "Fullscreen")],
         palette: None,
     },
     BindingDef {


### PR DESCRIPTION
## Summary

- Rewrites `handle_prompt_key()` so the command palette, project browser, and confirmation dialogs use `bindings.lookup()` instead of hardcoded `KeyCode::` matches — all overlay actions are now user-configurable via `[keys]` in config.toml
- Replaces ~20 hardcoded `key_badge("Enter"/"Esc"/"/"/"g"/"o")` calls in render.rs overlay footers with dynamic `label_for()` lookups, and fixes hardcoded key labels in status messages across workers.rs, sessions.rs, input.rs, and mod.rs
- Makes `render_config`/`save_config` accept `RuntimeBindings` so the commit_prompt config comment dynamically reflects the actual keybinding (was hardcoded `Ctrl+G`)
- Adds fullscreen agent overlay toggle (`ctrl-e`) with `ToggleFullscreen` action, makes commit message prompt configurable per-project with project → defaults → hardcoded fallback resolution, and fixes TOML multiline string `"""` escaping
- Adds CLAUDE.md rule: never hardcode keybinding labels in user-facing strings; always use `RuntimeBindings::label_for()`

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo test` — 72 tests pass, including new tests for triple-quote round-trip and dynamic config comment label
- [ ] Manual: open command palette, project browser, confirm dialogs — verify footer badges reflect configured keys
- [ ] Manual: rebind a key in `[keys]` config, restart, verify labels update everywhere
- [ ] Manual: toggle fullscreen with ctrl-e, verify Esc exits and status message shows re-enter key