### PR TITLE
fix: replace hardcoded keybinding labels with dynamic lookups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ When making changes, edit only the relevant submodule. If you need to add a new 
 - Code must be production ready and modular to allow future Open Source contributors to integrate new features with ease. Do not take shortcuts.
 - Route new modal UI through `PromptState` so `Esc` keeps working uniformly.
 - Prefer command-palette actions over adding many more global hotkeys.
-- Keybinding labels shown to the user must be lowercase (e.g. `ctrl+g`, not `Ctrl+G`) to avoid implying that Shift is required. The `^X` notation (e.g. `^P`) is acceptable in footer hint bars since its meaning is explained in the help overlay.
+- Keybinding labels shown to the user should use proper casing (e.g. `Ctrl-g`, not `ctrl-g` or `CTRL-G`). Title-case modifiers (`Ctrl`, `Shift`, `Alt`) distinguish them visually from the key itself. The `^X` notation (e.g. `^P`) is acceptable in footer hint bars since its meaning is explained in the help overlay.
+- Keybinding parsing from config is case-insensitive for modifiers and control keys — `CTRL-g`, `Ctrl-g`, and `ctrl-g` all parse identically (crokey lowercases the input). Letter keys are also lowercased during parsing, so `P` and `p` are the same binding; to bind uppercase P the user must write `shift-p`.
 - Never hardcode keybinding labels in user-facing strings (config comments, status messages, UI text). All keybindings are user-configurable — always look up the actual binding via `RuntimeBindings::label_for()` so labels stay accurate after rebinding. The only exception is pure text-input contexts (typing characters, backspace, cursor movement in text fields).
 - Keep agent creation and other blocking git/provider work in background workers.
 - The PTY approach is CLI-agnostic: any terminal command can be used as a provider. Keep it generic.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -271,6 +271,12 @@ impl App {
         let sessions = session_store.load_sessions()?;
         let (worker_tx, worker_rx) = mpsc::channel();
         let watched_worktree: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
+        let initial_status = format!(
+            "Press {} to add a project, {} to create an agent, {} for help.",
+            bindings.label_for(Action::OpenProjectBrowser),
+            bindings.label_for(Action::NewAgent),
+            bindings.label_for(Action::ToggleHelp),
+        );
         let mut app = Self {
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
@@ -297,7 +303,7 @@ impl App {
             last_help_height: 0,
             last_help_lines: 0,
             fullscreen_agent: false,
-            status: StatusLine::new("Press p to add a project, a to create an agent, ? for help."),
+            status: StatusLine::new(initial_status),
             prompt: PromptState::None,
             input_target: InputTarget::None,
             worker_tx,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -119,7 +119,10 @@ impl App {
                 if exited.contains(&current.id) {
                     self.input_target = InputTarget::None;
                     self.focus = FocusPane::Left;
-                    self.set_info("Agent CLI process has exited. Press \"r\" to relaunch.");
+                    let key = self.bindings.label_for(Action::ReconnectAgent);
+                    self.set_info(format!(
+                        "Agent CLI process has exited. Press \"{key}\" to relaunch."
+                    ));
                 }
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -389,9 +389,10 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
     ]
 }
 
-fn render_config(config: &Config, generate_commit_key: &str) -> String {
+fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings) -> String {
+    let generate_commit_key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
     let mut out = String::new();
-    for entry in config_schema(generate_commit_key) {
+    for entry in config_schema(&generate_commit_key) {
         match entry {
             ConfigEntry::Comment(text) => {
                 out.push_str(text);
@@ -437,7 +438,7 @@ fn render_config(config: &Config, generate_commit_key: &str) -> String {
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
             ConfigEntry::Projects => render_projects(&mut out, &config.projects),
-            ConfigEntry::Keys => render_keys_config(&mut out, &config.keys),
+            ConfigEntry::Keys => render_keys_config(&mut out, &config.keys, bindings),
         }
     }
     out
@@ -445,8 +446,7 @@ fn render_config(config: &Config, generate_commit_key: &str) -> String {
 
 pub fn render_default_config() -> String {
     let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&KeysConfig::default());
-    let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
-    render_config(&Config::default(), &key)
+    render_config(&Config::default(), &bindings)
 }
 
 pub fn save_config(
@@ -454,14 +454,17 @@ pub fn save_config(
     config: &Config,
     bindings: &crate::keybindings::RuntimeBindings,
 ) -> Result<()> {
-    let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
-    let body = render_config(config, &key);
+    let body = render_config(config, bindings);
     fs::write(config_path, body)
         .with_context(|| format!("failed to write {}", config_path.display()))?;
     Ok(())
 }
 
-fn render_keys_config(out: &mut String, keys: &KeysConfig) {
+fn render_keys_config(
+    out: &mut String,
+    keys: &KeysConfig,
+    bindings: &crate::keybindings::RuntimeBindings,
+) {
     out.push_str("[keys]\n");
     out.push_str("# Keybindings configuration. Each action maps to one or more key combos.\n");
     out.push_str(
@@ -493,8 +496,19 @@ fn render_keys_config(out: &mut String, keys: &KeysConfig) {
             last_section = Some(section);
         }
 
-        // Description comment.
-        let _ = writeln!(out, "# {}", def.action.config_description());
+        // Description comment — dynamic override for actions that reference other keys.
+        let desc = if def.action == keybindings::Action::ToggleResizeMode {
+            format!(
+                "Enter resize mode ({} to resize side panes).",
+                bindings.combined_label(
+                    keybindings::Action::ResizeGrow,
+                    keybindings::Action::ResizeShrink,
+                ),
+            )
+        } else {
+            def.action.config_description().to_string()
+        };
+        let _ = writeln!(out, "# {desc}");
 
         // Value from config (or defaults if missing).
         let key_strs = keys.bindings.get(config_name).cloned().unwrap_or_else(|| {
@@ -705,8 +719,7 @@ mod tests {
     fn render_config_default(config: &Config) -> String {
         let bindings =
             crate::keybindings::RuntimeBindings::from_keys_config(&KeysConfig::default());
-        let key = bindings.label_for(crate::keybindings::Action::GenerateCommitMessage);
-        render_config(config, &key)
+        render_config(config, &bindings)
     }
 
     #[test]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -189,7 +189,7 @@ impl Action {
             Action::FocusNext => "Focus the next pane.",
             Action::FocusPrev => "Focus the previous pane.",
             Action::OpenPalette => "Open the command palette.",
-            Action::ToggleResizeMode => "Enter resize mode (h/l to resize side panes).",
+            Action::ToggleResizeMode => "Enter resize mode to resize side panes.",
             Action::ToggleSidebar => "Toggle the projects sidebar.",
             Action::ToggleHelp => "Toggle the help overlay.",
             Action::Quit => "Quit the application.",


### PR DESCRIPTION
## Summary

- Audited the entire codebase for hardcoded keybinding labels that bypass the `RuntimeBindings` system.
- Fixed three violations: the initial status message (`p`, `a`, `?`), agent exit message (`r`), and `ToggleResizeMode` config comment (`h/l`) now all resolve labels dynamically via `label_for()` / `combined_label()`.
- Threaded `&RuntimeBindings` through the config rendering pipeline (`render_config` → `render_keys_config`) so TOML config comments can reference actual bound keys instead of hardcoded defaults.
- Updated CLAUDE.md to clarify keybinding label casing conventions and document case-insensitive parsing behavior.

## Test plan
- [x] `cargo fmt` — no formatting issues
- [x] `cargo test` — all 72 tests pass
- [ ] Delete `~/.dux/config.toml`, re-run app, verify `toggle_resize_mode` comment shows dynamic keys
- [ ] Verify initial status bar shows correct key labels
- [ ] Rebind a key in config, restart, confirm status/config comments update accordingly