### PR TITLE
fix: prevent projects key from leaking into TOML keys section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 ### Quality
 
 - **Prove your work with tests.** Every change should include unit tests. When feasible and low-lift, add integration tests as well.
+- When debugging a problem, before fixing it, **aim to prove your findings with a unit test**.
 
 ## Project Summary
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -514,7 +514,8 @@ fn render_projects(out: &mut String, projects: &[ProjectConfig]) {
     );
     out.push_str("# default_provider can override the global default for one project.\n");
     if projects.is_empty() {
-        out.push_str("projects = []\n");
+        out.push_str("# [[projects]]\n");
+        out.push_str("# path = \"/path/to/your/repo\"\n");
     } else {
         for project in projects {
             out.push_str("[[projects]]\n");
@@ -808,6 +809,13 @@ mod tests {
     fn config_root_uses_xdg_config_home_when_absolute() {
         let root = discover_root(Path::new("/example/home"), Some("/tmp/xdg".into()));
         assert_eq!(root, PathBuf::from("/tmp/xdg/dux"));
+    }
+
+    #[test]
+    fn default_config_keys_valid_after_round_trip() {
+        let rendered = render_default_config();
+        let parsed: Config = toml::from_str(&rendered).expect("default config should parse");
+        validate_keys(&parsed.keys).expect("round-tripped keys should be valid");
     }
 
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## Summary

- On a fresh setup with no projects, `render_projects()` emitted `projects = []` after the `[keys]` header with no intervening TOML section header, so the TOML parser treated `projects` as a keybinding action inside `[keys]`. Since `KeysConfig` uses `#[serde(flatten)]`, the stray key was captured into the bindings map and rejected by `validate_keys()` with `unknown action: "projects"`.
- Replaced the bare `projects = []` with commented-out documentation (`# [[projects]]` / `# path = ...`) that is inert to the parser while still documenting the feature in the config file.
- Added a round-trip test that renders the default config, parses it back, and validates all keybindings to prevent similar TOML scoping regressions.
- Updated CLAUDE.md with a debugging tenet about proving findings with a failing test before fixing.

## Test plan

- [x] New `default_config_keys_valid_after_round_trip` test fails on old code, passes after fix
- [x] Full `cargo test` passes (73 tests)
- [x] `cargo run` on a fresh setup no longer errors