### PR TITLE
feat: fullscreen is intrinsic to interactive mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2,6 +2,13 @@ use super::*;
 
 impl App {
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
+        // Interactive mode: ALL keys go to the PTY except Ctrl-G
+        // (ExitInteractive, handled inside handle_agent_input). This must be
+        // the very first check so that no global binding — including
+        // CloseOverlay / Escape — intercepts keys during interactive mode.
+        if self.input_target == InputTarget::Agent {
+            return self.handle_agent_input(key);
+        }
         if self.bindings.lookup(&key, BindingScope::Global) == Some(Action::CloseOverlay)
             && self.close_top_overlay()
         {
@@ -36,12 +43,6 @@ impl App {
         }
         if !matches!(self.prompt, PromptState::None) {
             return self.handle_prompt_key(key);
-        }
-        // In interactive mode, ALL keys go to the PTY except ctrl+g (handled
-        // inside handle_agent_input). This must be checked before quit / help /
-        // palette so that typing 'q', ctrl+c, '?', ctrl+p etc. reaches the CLI.
-        if self.input_target == InputTarget::Agent {
-            return self.handle_agent_input(key);
         }
         // When typing a commit message, route all keys to the commit input
         // handler so that q, ?, [ etc. are typed instead of triggering
@@ -98,6 +99,7 @@ impl App {
                         }
                     }
                     self.input_target = InputTarget::None;
+                    self.fullscreen_agent = false;
                 }
                 Action::FocusPrev => {
                     let has_staged = !self.staged_files.is_empty();
@@ -119,6 +121,7 @@ impl App {
                         }
                     }
                     self.input_target = InputTarget::None;
+                    self.fullscreen_agent = false;
                 }
                 Action::ToggleSidebar => {
                     self.left_collapsed = !self.left_collapsed;
@@ -193,6 +196,7 @@ impl App {
                                         .unwrap_or(false)
                                     {
                                         self.input_target = InputTarget::Agent;
+                                        self.fullscreen_agent = true;
                                     } else if self.selected_session().is_some() {
                                         self.reconnect_selected_session()?;
                                     }
@@ -211,6 +215,7 @@ impl App {
                             .unwrap_or(false)
                         {
                             self.input_target = InputTarget::Agent;
+                            self.fullscreen_agent = true;
                         } else if self.selected_session().is_some() {
                             self.reconnect_selected_session()?;
                         }
@@ -237,6 +242,7 @@ impl App {
                         self.focus = FocusPane::Center;
                         self.center_mode = CenterMode::Agent;
                         self.input_target = InputTarget::Agent;
+                        self.fullscreen_agent = true;
                         let exit_key = self.bindings.label_for(Action::ExitInteractive);
                         self.set_info(format!(
                             "Interactive mode. Keys forwarded to agent. {exit_key} exits."
@@ -259,7 +265,7 @@ impl App {
         let in_diff = matches!(self.center_mode, CenterMode::Diff { .. });
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Center) {
             match action {
-                Action::InteractAgent if !in_diff => {
+                Action::FocusAgent if !in_diff => {
                     if self.selected_session().is_some()
                         && self
                             .selected_session()
@@ -268,16 +274,18 @@ impl App {
                     {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
+                        self.fullscreen_agent = true;
                         let exit_key = self.bindings.label_for(Action::ExitInteractive);
                         self.set_info(format!(
                             "Interactive mode. Keys forwarded to agent. {exit_key} exits."
                         ));
+                    } else if self.selected_session().is_some() {
+                        self.reconnect_selected_session()?;
                     } else {
-                        let r = self.bindings.label_for(Action::ReconnectAgent);
                         let n = self.bindings.label_for(Action::NewAgent);
-                        self.set_error(
-                            format!("No active agent. Press \"{r}\" to restart or \"{n}\" to create a new one."),
-                        );
+                        self.set_error(format!(
+                            "No agent selected. Press \"{n}\" to create a new one."
+                        ));
                     }
                 }
                 Action::ReconnectAgent if !in_diff => {
@@ -290,12 +298,10 @@ impl App {
                     if has_provider {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
+                        self.fullscreen_agent = true;
                     } else if self.selected_session().is_some() {
                         self.reconnect_selected_session()?;
                     }
-                }
-                Action::ToggleFullscreen if !in_diff => {
-                    self.fullscreen_agent = !self.fullscreen_agent;
                 }
                 Action::ScrollPageUp => {
                     if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
@@ -614,15 +620,11 @@ impl App {
         if let Some(Action::ExitInteractive) = self.bindings.lookup(&key, BindingScope::Interactive)
         {
             self.input_target = InputTarget::None;
-            self.set_info("Exited interactive mode.");
-            return Ok(false);
-        }
-
-        // Toggle fullscreen overlay (default: ctrl-e) without leaving interactive mode.
-        if let Some(Action::ToggleFullscreen) =
-            self.bindings.lookup(&key, BindingScope::Interactive)
-        {
-            self.fullscreen_agent = !self.fullscreen_agent;
+            self.fullscreen_agent = false;
+            let reenter_key = self.bindings.label_for(Action::FocusAgent);
+            self.set_info(format!(
+                "Exited interactive mode. Press {reenter_key} to re-enter."
+            ));
             return Ok(false);
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -371,12 +371,6 @@ impl App {
     }
 
     pub(crate) fn close_top_overlay(&mut self) -> bool {
-        if self.fullscreen_agent {
-            self.fullscreen_agent = false;
-            let key = self.bindings.label_for(Action::ToggleFullscreen);
-            self.set_info(format!("Exited fullscreen. Press {key} to re-enter."));
-            return true;
-        }
         if !matches!(self.prompt, PromptState::None) {
             self.prompt = PromptState::None;
             self.set_info("Closed overlay.");

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -213,6 +213,13 @@ impl App {
             CenterMode::Diff { .. } => {
                 self.render_diff(frame, area, focused);
             }
+            CenterMode::Agent if self.fullscreen_agent => {
+                // Skip agent rendering here — fullscreen overlay handles it.
+                // Rendering in both places causes the PTY to be resized twice
+                // per frame (once to the small pane, once to the overlay).
+                self.themed_block("Agent", focused)
+                    .render(area, frame.buffer_mut());
+            }
             CenterMode::Agent => {
                 self.render_agent_terminal(frame, area, "Agent", focused);
             }
@@ -479,10 +486,9 @@ impl App {
         if hint_area.height > 0 {
             // Pre-compute all key labels so they outlive the Span borrows.
             let exit_key = self.bindings.label_for(Action::ExitInteractive);
-            let fullscreen_key = self.bindings.label_for(Action::ToggleFullscreen);
             let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
             let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
-            let interact = self.bindings.labels_for(Action::InteractAgent);
+            let focus_agent = self.bindings.labels_for(Action::FocusAgent);
             let reconnect = self.bindings.labels_for(Action::ReconnectAgent);
 
             let hint_line = if is_input {
@@ -501,9 +507,7 @@ impl App {
                     desc_style,
                 ));
                 spans.extend(self.theme.dim_key_badge(&exit_key, Color::Reset));
-                spans.push(Span::styled(" to bring the focus back. ", desc_style));
-                spans.extend(self.theme.dim_key_badge(&fullscreen_key, Color::Reset));
-                spans.push(Span::styled(" fullscreen.", desc_style));
+                spans.push(Span::styled(" to return to the app.", desc_style));
                 Line::from(spans)
             } else if scrollback_offset > 0 {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
@@ -521,10 +525,8 @@ impl App {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
                 if session_active {
-                    spans.extend(self.theme.dim_key_badge(&interact, Color::Reset));
+                    spans.extend(self.theme.dim_key_badge(&focus_agent, Color::Reset));
                     spans.push(Span::styled(" to interact. ", desc_style));
-                    spans.extend(self.theme.dim_key_badge(&fullscreen_key, Color::Reset));
-                    spans.push(Span::styled(" fullscreen. ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                     spans.push(Span::styled(" ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
@@ -532,7 +534,9 @@ impl App {
                 } else if session_id.is_some() {
                     spans.push(Span::styled("Agent CLI exited. Press ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&reconnect, Color::Reset));
-                    spans.push(Span::styled(" to relaunch.", desc_style));
+                    spans.push(Span::styled(" to relaunch or ", desc_style));
+                    spans.extend(self.theme.dim_key_badge(&focus_agent, Color::Reset));
+                    spans.push(Span::styled(" to interact.", desc_style));
                 } else {
                     spans.push(Span::styled("No agent selected.", desc_style));
                 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -358,6 +358,7 @@ impl App {
                 self.focus = FocusPane::Center;
                 self.center_mode = CenterMode::Agent;
                 self.input_target = InputTarget::Agent;
+                self.fullscreen_agent = true;
                 let proj_name = self.project_name_for_session(&session);
                 self.set_info(format!(
                     "Relaunched {} agent \"{}\" in project \"{}\"",

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -29,6 +29,7 @@ impl App {
                     self.focus = FocusPane::Center;
                     self.center_mode = CenterMode::Agent;
                     self.input_target = InputTarget::Agent;
+                    self.fullscreen_agent = true;
                     let proj_name = self.project_name_for_session(&session);
                     self.set_info(format!(
                         "Created {} agent \"{}\" in project \"{}\"",
@@ -118,6 +119,7 @@ impl App {
             if let Some(current) = self.selected_session() {
                 if exited.contains(&current.id) {
                     self.input_target = InputTarget::None;
+                    self.fullscreen_agent = false;
                     self.focus = FocusPane::Left;
                     let key = self.bindings.label_for(Action::ReconnectAgent);
                     self.set_info(format!(

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -238,10 +238,10 @@ impl Action {
             | Action::CopyPath
             | Action::CycleProvider
             | Action::RefreshProject
+            | Action::InteractAgent
             | Action::ReconnectAgent
             | Action::DeleteSession => Some("Projects pane"),
-            Action::InteractAgent
-            | Action::ExitInteractive
+            Action::ExitInteractive
             | Action::ToggleFullscreen
             | Action::ScrollPageUp
             | Action::ScrollPageDown => Some("Agent pane"),
@@ -371,12 +371,15 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::FocusAgent,
         default_keys: &[key!(enter)],
-        scopes: &[BindingScope::Left],
+        scopes: &[BindingScope::Left, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Projects pane",
             description: "Focus the selected agent",
         }),
-        hint_contexts: &[(HintContext::LeftSession, "Focus")],
+        hint_contexts: &[
+            (HintContext::LeftSession, "Focus"),
+            (HintContext::Center, "Interact"),
+        ],
         palette: None,
     },
     BindingDef {
@@ -473,12 +476,12 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::InteractAgent,
         default_keys: &[key!(i)],
-        scopes: &[BindingScope::Left, BindingScope::Center],
+        scopes: &[BindingScope::Left],
         help: Some(HelpEntry {
-            section: "Agent pane",
-            description: "Start a prompt turn for the agent",
+            section: "Projects pane",
+            description: "Enter interactive mode for the selected agent",
         }),
-        hint_contexts: &[(HintContext::Center, "Interact")],
+        hint_contexts: &[],
         palette: None,
     },
     BindingDef {
@@ -494,13 +497,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     },
     BindingDef {
         action: Action::ToggleFullscreen,
-        default_keys: &[key!(ctrl - e)],
-        scopes: &[BindingScope::Interactive, BindingScope::Center],
-        help: Some(HelpEntry {
-            section: "Agent pane",
-            description: "Toggle fullscreen agent overlay",
-        }),
-        hint_contexts: &[(HintContext::Center, "Fullscreen")],
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
         palette: None,
     },
     BindingDef {


### PR DESCRIPTION
## Summary

- Entering interactive mode now always activates the fullscreen agent overlay; exiting interactive mode (Ctrl-g, Tab, Shift-Tab, or PTY exit) dismisses it. This applies to all seven entry points: FocusAgent, InteractAgent, ReconnectAgent, CreateAgentReady, and reconnect_selected_session.
- Removed the standalone ToggleFullscreen action (Ctrl-e) since fullscreen is no longer an independent toggle — it's tied to interactive mode.
- Replaced `i` (InteractAgent) with `Enter` (FocusAgent) as the keybinding to enter interactive mode from the center pane, unifying the interaction model across panes.
- Fixed a PTY double-resize bug: when fullscreen was active, the center pane and the fullscreen overlay both called `render_agent_terminal`, causing the PTY to resize twice per frame. The center pane now renders an empty block when fullscreen is active.
- Updated hint bars and status messages to reflect the new keybindings and simplified interaction model.

## Test plan

- [x] `cargo fmt && cargo test` — 89 tests pass
- [ ] Create a new agent → enters fullscreen + interactive automatically
- [ ] Press Enter on a running session from left pane → fullscreen + interactive
- [ ] Press `i` from left pane → fullscreen + interactive
- [ ] Press Enter from center pane → fullscreen + interactive
- [ ] Press `r` from center pane on exited agent → reconnects and enters fullscreen
- [ ] Reconnect a stopped agent → fullscreen + interactive
- [ ] Ctrl-g → exits interactive AND fullscreen
- [ ] Tab / Shift-Tab → exits interactive AND fullscreen
- [ ] Agent process exits → exits interactive AND fullscreen
- [ ] No rendering glitches in fullscreen (PTY resized only once per frame)