### PR TITLE
feat: PgUp/PgDn scroll buffer in fullscreen interactive mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -628,6 +628,23 @@ impl App {
             return Ok(false);
         }
 
+        // PgUp/PgDn scroll the scrollback buffer even in interactive mode.
+        match key.code {
+            KeyCode::PageUp => {
+                if self.last_pty_size.0 > 0 {
+                    self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+                }
+                return Ok(false);
+            }
+            KeyCode::PageDown => {
+                if self.last_pty_size.0 > 0 {
+                    self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+                }
+                return Ok(false);
+            }
+            _ => {}
+        }
+
         match key.code {
             KeyCode::Esc => {
                 let _ = provider.write_bytes(b"\x1b");
@@ -673,12 +690,6 @@ impl App {
             }
             KeyCode::Delete => {
                 let _ = provider.write_bytes(b"\x1b[3~");
-            }
-            KeyCode::PageUp => {
-                let _ = provider.write_bytes(b"\x1b[5~");
-            }
-            KeyCode::PageDown => {
-                let _ = provider.write_bytes(b"\x1b[6~");
             }
             _ => {}
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -463,6 +463,24 @@ impl App {
                         }
                     }
 
+                    // Floating scroll indicator in top-right corner.
+                    if scrollback_offset > 0 {
+                        let label = format!(" ↑ {scrollback_offset} lines ");
+                        let label_len = label.chars().count() as u16;
+                        if label_len < term_area.width {
+                            let x_start = term_area.x + term_area.width - label_len;
+                            let y = term_area.y;
+                            let style = Style::default()
+                                .fg(self.theme.scroll_indicator_fg)
+                                .bg(self.theme.scroll_indicator_bg);
+                            for (i, ch) in label.chars().enumerate() {
+                                let cell = &mut buf[(x_start + i as u16, y)];
+                                cell.set_symbol(&ch.to_string());
+                                cell.set_style(style);
+                            }
+                        }
+                    }
+
                     // Render cursor if in input mode.
                     if is_input && !screen.hide_cursor() {
                         let (cursor_row, cursor_col) = screen.cursor_position();

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -507,7 +507,9 @@ impl App {
                     desc_style,
                 ));
                 spans.extend(self.theme.dim_key_badge(&exit_key, Color::Reset));
-                spans.push(Span::styled(" to return to the app.", desc_style));
+                spans.push(Span::styled(" to return to the app. ", desc_style));
+                spans.extend(self.theme.dim_key_badge("PgUp/PgDn", Color::Reset));
+                spans.push(Span::styled(" to scroll.", desc_style));
                 Line::from(spans)
             } else if scrollback_offset > 0 {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -209,14 +209,19 @@ impl PtyClient {
             } else {
                 current.saturating_sub(amount)
             };
-            p.set_scrollback(new_offset);
+            // vt100's visible_rows() subtracts the scrollback offset from
+            // the row count, so the offset must never exceed the number of
+            // terminal rows to avoid an underflow panic.
+            let max_offset = p.screen().size().0 as usize;
+            p.set_scrollback(new_offset.min(max_offset));
         }
     }
 
     /// Set the scrollback offset (0 = normal view, positive = scrolled back).
     pub fn set_scrollback(&self, rows: usize) {
         if let Ok(mut p) = self.parser.lock() {
-            p.set_scrollback(rows);
+            let max_offset = p.screen().size().0 as usize;
+            p.set_scrollback(rows.min(max_offset));
         }
     }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -192,7 +192,15 @@ impl PtyClient {
     /// offset in a single lock acquisition, avoiding race conditions with the
     /// background reader thread.
     pub fn screen_and_scrollback(&self) -> (vt100::Screen, usize) {
-        let p = self.parser.lock().expect("parser mutex poisoned");
+        let mut p = self.parser.lock().expect("parser mutex poisoned");
+        // vt100's scroll_up() can increment scrollback_offset beyond the
+        // terminal row count, which causes visible_rows() to panic with an
+        // underflow. Re-clamp before cloning to ensure the snapshot is safe.
+        let offset = p.screen().scrollback();
+        let max_offset = p.screen().size().0 as usize;
+        if offset > max_offset {
+            p.set_scrollback(max_offset);
+        }
         let screen = p.screen().clone();
         let offset = screen.scrollback();
         (screen, offset)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -48,6 +48,8 @@ pub struct Theme {
     pub button_active_fg: Color,
     pub button_confirm_border: Color,
     pub button_danger_border: Color,
+    pub scroll_indicator_fg: Color,
+    pub scroll_indicator_bg: Color,
 }
 
 impl Theme {
@@ -97,6 +99,8 @@ impl Theme {
             button_active_fg: Color::White,
             button_confirm_border: Color::Cyan,
             button_danger_border: Color::Red,
+            scroll_indicator_fg: Color::White,
+            scroll_indicator_bg: Color::Rgb(60, 60, 60),
         }
     }
 


### PR DESCRIPTION
## Summary
- PgUp/PgDn now scroll the terminal scrollback buffer in fullscreen interactive mode, instead of being forwarded to the PTY as escape sequences.
- The fullscreen modal hint bar now shows "PgUp/PgDn to scroll" alongside the existing exit-key hint.
- Ctrl+B/Ctrl+F are intentionally left untouched since agents may bind those keys.

## Test plan
- Enter fullscreen interactive mode and press PgUp/PgDn to verify scrollback works
- Verify the hint bar shows the new PgUp/PgDn label
- Confirm Ctrl+B/Ctrl+F still forward to the agent PTY