### PR TITLE
fix: move selection to parent project on tree collapse

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -461,9 +461,17 @@ impl App {
             if self.collapsed_projects.contains(&id) {
                 self.collapsed_projects.remove(&id);
             } else {
-                self.collapsed_projects.insert(id);
+                self.collapsed_projects.insert(id.clone());
             }
             self.rebuild_left_items();
+
+            // Move selection to the toggled project so collapsing from a
+            // child session leaves the cursor on the parent header.
+            if let Some(new_index) = self.left_items().iter().position(|item| {
+                matches!(item, LeftItem::Project(pi) if self.projects[*pi].id == id)
+            }) {
+                self.selected_left = new_index;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- When pressing space on an agent in the Projects pane to collapse its parent project, the selection index (`selected_left`) was not updated after rebuilding the flattened item list. This left the cursor on whatever item happened to occupy the old index, requiring the user to press "up" before they could re-expand the tree.
- After rebuilding the left items cache, the toggled project's new position is now located and `selected_left` is set to it, so the cursor lands on the parent project header as expected.

## Test plan

- [x] `cargo test` — all 89 tests pass
- [ ] Manual: expand a project, select an agent, press space → cursor should land on the parent project
- [ ] Manual: press space again → project re-expands immediately
- [ ] Manual: select a project directly, press space → collapse/expand still works normally