### PR TITLE
feat: add editor picker for opening agent worktrees

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -239,6 +239,8 @@ impl App {
                 Action::RenameSession => self.open_rename_session()?,
                 Action::CycleProvider => self.cycle_selected_project_provider()?,
                 Action::CopyPath => self.copy_selected_path()?,
+                Action::OpenWorktreeInEditor => self.open_selected_worktree_in_default_editor()?,
+                Action::ChooseWorktreeEditor => self.open_worktree_editor_picker()?,
                 Action::ToggleProject => self.toggle_collapse_selected_project(),
                 Action::InteractAgent => {
                     if self.selected_session().is_some()
@@ -1104,6 +1106,41 @@ impl App {
             }
             if let Some(dir) = browse_to {
                 self.spawn_browser_entries(&dir);
+            }
+            return Ok(false);
+        }
+
+        if let PromptState::PickEditor {
+            session_label,
+            worktree_path,
+            editors,
+            selected,
+        } = &mut self.prompt
+        {
+            match self.bindings.lookup(&key, BindingScope::Palette) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::MoveDown) => {
+                    if *selected + 1 < editors.len() {
+                        *selected += 1;
+                    }
+                }
+                Some(Action::MoveUp) => {
+                    if *selected > 0 {
+                        *selected -= 1;
+                    }
+                }
+                Some(Action::Confirm) => {
+                    let editor = editors.get(*selected).cloned();
+                    let worktree = worktree_path.clone();
+                    let label = session_label.clone();
+                    self.prompt = PromptState::None;
+                    if let Some(editor) = editor {
+                        if let Err(e) = self.open_worktree_in_editor(&worktree, &label, &editor) {
+                            self.set_error(format!("{e:#}"));
+                        }
+                    }
+                }
+                _ => {}
             }
             return Ok(false);
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,7 @@ use crate::config::{
     Config, DuxPaths, ProjectConfig, ProviderCommandConfig, check_provider_available,
     ensure_config, save_config, validate_keys,
 };
+use crate::editor::DetectedEditor;
 use crate::git;
 use crate::keybindings::{Action, BindingScope, HintContext, RuntimeBindings};
 use crate::logger;
@@ -192,6 +193,12 @@ pub(crate) enum PromptState {
         session_id: String,
         input: String,
         cursor: usize,
+    },
+    PickEditor {
+        session_label: String,
+        worktree_path: String,
+        editors: Vec<DetectedEditor>,
+        selected: usize,
     },
 }
 
@@ -415,6 +422,8 @@ impl App {
             "reconnect-agent" => self.reconnect_selected_session(),
             "add-project" => self.open_project_browser(),
             "copy-path" => self.copy_selected_path(),
+            "open-worktree" => self.open_selected_worktree_in_default_editor(),
+            "open-worktree-with" => self.open_worktree_editor_picker(),
             "toggle-project" => {
                 self.toggle_collapse_selected_project();
                 Ok(())
@@ -467,9 +476,9 @@ impl App {
 
             // Move selection to the toggled project so collapsing from a
             // child session leaves the cursor on the parent header.
-            if let Some(new_index) = self.left_items().iter().position(|item| {
-                matches!(item, LeftItem::Project(pi) if self.projects[*pi].id == id)
-            }) {
+            if let Some(new_index) = self.left_items().iter().position(
+                |item| matches!(item, LeftItem::Project(pi) if self.projects[*pi].id == id),
+            ) {
                 self.selected_left = new_index;
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1438,6 +1438,105 @@ impl App {
                     );
                 }
             }
+            PromptState::PickEditor {
+                session_label,
+                worktree_path,
+                editors,
+                selected,
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(64, 34, frame.area());
+                Clear.render(area, frame.buffer_mut());
+
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let move_down = self.bindings.label_for(Action::MoveDown);
+                let move_up = self.bindings.label_for(Action::MoveUp);
+                let mut bottom_spans = vec![Span::raw(" ")];
+                bottom_spans.extend(self.theme.key_badge(&move_down, Color::Reset));
+                bottom_spans.push(Span::styled(
+                    " down  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge(&move_up, Color::Reset));
+                bottom_spans.push(Span::styled(
+                    " up  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge(&confirm_key, Color::Reset));
+                bottom_spans.push(Span::styled(
+                    " open  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge(&close_key, Color::Reset));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let [details_area, list_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(4), Constraint::Min(4)])
+                    .areas(area);
+
+                let detail_lines = vec![
+                    Line::from(vec![
+                        Span::styled(" Agent: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::styled(
+                            session_label.as_str(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled(" Path: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::raw(worktree_path.as_str()),
+                    ]),
+                ];
+                Paragraph::new(detail_lines)
+                    .block(
+                        self.themed_overlay_block("Open Worktree In")
+                            .title_bottom(Line::from(bottom_spans)),
+                    )
+                    .render(details_area, frame.buffer_mut());
+
+                let configured_default = self.config.editor.default.trim();
+                let items = editors
+                    .iter()
+                    .map(|editor| {
+                        let mut spans = vec![Span::styled(
+                            format!("{:<14}", editor.label),
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD),
+                        )];
+                        spans.push(Span::styled(
+                            format!(" {}", editor.command),
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ));
+                        if crate::editor::matches_configured_editor(editor, configured_default) {
+                            spans.push(Span::styled(
+                                "  default",
+                                Style::default().fg(self.theme.branch_fg),
+                            ));
+                        }
+                        ListItem::new(Line::from(spans))
+                    })
+                    .collect::<Vec<_>>();
+                let mut state = ListState::default()
+                    .with_selected(Some((*selected).min(editors.len().saturating_sub(1))));
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(
+                            Block::default()
+                                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                                .border_style(Style::default().fg(self.theme.overlay_border)),
+                        )
+                        .highlight_style(self.theme.selection_style()),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+            }
             PromptState::ConfirmDeleteAgent {
                 branch_name,
                 confirm_selected,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::editor;
 
 impl App {
     pub(crate) fn open_project_browser(&mut self) -> Result<()> {
@@ -419,5 +420,87 @@ impl App {
                 Ok(())
             }
         }
+    }
+
+    pub(crate) fn open_selected_worktree_in_default_editor(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent session first.");
+            return Ok(());
+        };
+        let editors = editor::detect_installed_editors();
+        let Some(selected_editor) = editor::preferred_editor(&editors, &self.config.editor.default)
+        else {
+            self.set_error(
+                "No supported editor CLI found on PATH. Install cursor, code, zed, or antigravity.",
+            );
+            return Ok(());
+        };
+
+        let session_label = self.session_label(&session);
+        let configured_default = self.config.editor.default.trim().to_string();
+        self.open_worktree_in_editor(&session.worktree_path, &session_label, &selected_editor)?;
+
+        if !configured_default.is_empty()
+            && !editor::matches_configured_editor(&selected_editor, &configured_default)
+        {
+            self.set_info(format!(
+                "Opened agent \"{session_label}\" in {} via {} (configured default \"{}\" was not found on PATH).",
+                selected_editor.label, selected_editor.command, configured_default
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn open_worktree_editor_picker(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent session first.");
+            return Ok(());
+        };
+        let editors = editor::detect_installed_editors();
+        if editors.is_empty() {
+            self.set_error(
+                "No supported editor CLI found on PATH. Install cursor, code, zed, or antigravity.",
+            );
+            return Ok(());
+        }
+
+        let selected = editor::preferred_editor(&editors, &self.config.editor.default)
+            .and_then(|preferred| {
+                editors
+                    .iter()
+                    .position(|editor| editor.command == preferred.command)
+            })
+            .unwrap_or(0);
+        let session_label = self.session_label(&session);
+        self.prompt = PromptState::PickEditor {
+            session_label,
+            worktree_path: session.worktree_path.clone(),
+            editors,
+            selected,
+        };
+        self.set_info("Choose an editor and press Enter to open the selected worktree.");
+        Ok(())
+    }
+
+    pub(crate) fn open_worktree_in_editor(
+        &mut self,
+        worktree_path: &str,
+        session_label: &str,
+        editor_choice: &editor::DetectedEditor,
+    ) -> Result<()> {
+        editor::launch_editor(editor_choice, Path::new(worktree_path))?;
+        self.set_info(format!(
+            "Opened agent \"{session_label}\" in {} via {}.",
+            editor_choice.label, editor_choice.command
+        ));
+        Ok(())
+    }
+
+    fn session_label(&self, session: &AgentSession) -> String {
+        session
+            .title
+            .clone()
+            .unwrap_or_else(|| session.branch_name.clone())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub struct Config {
     pub logging: LoggingConfig,
     pub projects: Vec<ProjectConfig>,
     pub ui: UiConfig,
+    pub editor: EditorConfig,
     pub keys: KeysConfig,
 }
 
@@ -63,6 +64,12 @@ pub struct ProvidersConfig {
 pub struct LoggingConfig {
     pub level: String,
     pub path: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EditorConfig {
+    pub default: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -119,6 +126,7 @@ impl Default for Config {
                 right_width_pct: 23,
                 agent_scrollback_lines: 10_000,
             },
+            editor: EditorConfig::default(),
             keys: KeysConfig::default(),
         }
     }
@@ -183,6 +191,14 @@ impl Default for LoggingConfig {
         Self {
             level: "info".to_string(),
             path: "dux.log".to_string(),
+        }
+    }
+}
+
+impl Default for EditorConfig {
+    fn default() -> Self {
+        Self {
+            default: "cursor".to_string(),
         }
     }
 }
@@ -392,6 +408,15 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
                 "# Maximum number of lines retained in the embedded agent terminal scrollback.",
             )),
             value_fn: |c| FieldValue::Usize(c.ui.agent_scrollback_lines),
+        },
+        ConfigEntry::Blank,
+        ConfigEntry::Section("editor"),
+        ConfigEntry::Field {
+            key: "default",
+            comment: Some(CommentSource::Static(
+                "# Preferred editor when opening a selected agent worktree.\n# Supported values are matched against popular editor CLIs on PATH\n# (for example: cursor, vscode/code, zed, antigravity).",
+            )),
+            value_fn: |c| FieldValue::Str(c.editor.default.clone()),
         },
         ConfigEntry::Blank,
         ConfigEntry::Keys,
@@ -775,6 +800,8 @@ mod tests {
         assert!(rendered.contains("oneshot_output = "));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
+        assert!(rendered.contains("[editor]"));
+        assert!(rendered.contains("default = \"cursor\""));
         assert!(rendered.contains("[keys]"));
         assert!(rendered.contains("show_terminal_keys = true"));
         assert!(rendered.contains("move_down = "));
@@ -859,6 +886,15 @@ mod tests {
         let rendered = render_config_default(&config);
         let parsed: Config = toml::from_str(&rendered).expect("config should parse");
         assert_eq!(parsed.ui.agent_scrollback_lines, 12_345);
+    }
+
+    #[test]
+    fn default_config_round_trips_default_editor() {
+        let mut config = Config::default();
+        config.editor.default = "zed".to_string();
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("config should parse");
+        assert_eq!(parsed.editor.default, "zed");
     }
 
     #[cfg(target_os = "macos")]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,206 @@
+use std::collections::HashSet;
+use std::env;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EditorKind {
+    Cursor,
+    VsCode,
+    Zed,
+    Antigravity,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetectedEditor {
+    pub kind: EditorKind,
+    pub label: &'static str,
+    pub config_key: &'static str,
+    pub command: String,
+}
+
+struct EditorSpec {
+    kind: EditorKind,
+    label: &'static str,
+    config_key: &'static str,
+    commands: &'static [&'static str],
+    aliases: &'static [&'static str],
+}
+
+const EDITOR_SPECS: &[EditorSpec] = &[
+    EditorSpec {
+        kind: EditorKind::Cursor,
+        label: "Cursor",
+        config_key: "cursor",
+        commands: &["cursor"],
+        aliases: &["cursor"],
+    },
+    EditorSpec {
+        kind: EditorKind::VsCode,
+        label: "VS Code",
+        config_key: "vscode",
+        commands: &["code", "code-insiders"],
+        aliases: &["vscode", "code", "code-insiders"],
+    },
+    EditorSpec {
+        kind: EditorKind::Zed,
+        label: "Zed",
+        config_key: "zed",
+        commands: &["zed"],
+        aliases: &["zed"],
+    },
+    EditorSpec {
+        kind: EditorKind::Antigravity,
+        label: "Antigravity",
+        config_key: "antigravity",
+        commands: &["antigravity"],
+        aliases: &["antigravity"],
+    },
+];
+
+pub fn detect_installed_editors() -> Vec<DetectedEditor> {
+    let mut executable_names = Vec::new();
+    let mut seen_dirs = HashSet::new();
+    let path = env::var_os("PATH").unwrap_or_default();
+
+    for dir in env::split_paths(&path) {
+        if !seen_dirs.insert(dir.clone()) {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                executable_names.push(name.to_string());
+            }
+        }
+    }
+
+    detect_editors_from_names(executable_names.iter().map(String::as_str))
+}
+
+pub fn preferred_editor(detected: &[DetectedEditor], configured: &str) -> Option<DetectedEditor> {
+    let configured = normalize_editor_name(configured);
+    if !configured.is_empty() {
+        if let Some(editor) = detected
+            .iter()
+            .find(|editor| matches_configured_editor(editor, &configured))
+        {
+            return Some(editor.clone());
+        }
+    }
+    detected.first().cloned()
+}
+
+pub fn matches_configured_editor(editor: &DetectedEditor, configured: &str) -> bool {
+    let configured = normalize_editor_name(configured);
+    if configured.is_empty() {
+        return false;
+    }
+    let spec = spec_for_kind(editor.kind);
+    configured == spec.config_key
+        || spec.aliases.iter().any(|alias| *alias == configured)
+        || spec.commands.iter().any(|command| *command == configured)
+}
+
+pub fn launch_editor(editor: &DetectedEditor, path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Err(anyhow!("Path does not exist: {}", path.display()));
+    }
+
+    Command::new(&editor.command)
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to launch {} via {}", editor.label, editor.command))?;
+
+    Ok(())
+}
+
+fn detect_editors_from_names<'a>(names: impl IntoIterator<Item = &'a str>) -> Vec<DetectedEditor> {
+    let normalized_names = names
+        .into_iter()
+        .map(normalize_executable_name)
+        .collect::<HashSet<_>>();
+
+    EDITOR_SPECS
+        .iter()
+        .filter_map(|spec| {
+            spec.commands.iter().find_map(|command| {
+                normalized_names.contains(*command).then(|| DetectedEditor {
+                    kind: spec.kind,
+                    label: spec.label,
+                    config_key: spec.config_key,
+                    command: (*command).to_string(),
+                })
+            })
+        })
+        .collect()
+}
+
+fn normalize_editor_name(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .replace(' ', "-")
+}
+
+fn normalize_executable_name(value: &str) -> String {
+    Path::new(value)
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or(value)
+        .to_ascii_lowercase()
+}
+
+fn spec_for_kind(kind: EditorKind) -> &'static EditorSpec {
+    EDITOR_SPECS
+        .iter()
+        .find(|spec| spec.kind == kind)
+        .expect("editor kind should always have a matching spec")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_editors_prefers_popular_order() {
+        let detected = detect_editors_from_names(["zed", "cursor", "code"].iter().copied());
+        let labels = detected
+            .iter()
+            .map(|editor| editor.label)
+            .collect::<Vec<_>>();
+        assert_eq!(labels, vec!["Cursor", "VS Code", "Zed"]);
+    }
+
+    #[test]
+    fn preferred_editor_uses_configured_alias_when_available() {
+        let detected = detect_editors_from_names(["code", "cursor"].iter().copied());
+        let preferred = preferred_editor(&detected, "vscode").expect("editor should resolve");
+        assert_eq!(preferred.label, "VS Code");
+        assert_eq!(preferred.command, "code");
+    }
+
+    #[test]
+    fn preferred_editor_falls_back_to_first_detected() {
+        let detected = detect_editors_from_names(["zed"].iter().copied());
+        let preferred = preferred_editor(&detected, "cursor").expect("editor should resolve");
+        assert_eq!(preferred.label, "Zed");
+    }
+
+    #[test]
+    fn configured_matching_accepts_command_aliases() {
+        let detected = detect_editors_from_names(["code-insiders"].iter().copied());
+        let editor = detected.first().expect("editor should be detected");
+        assert!(matches_configured_editor(editor, "vscode"));
+        assert!(matches_configured_editor(editor, "code-insiders"));
+    }
+}

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -13,6 +13,8 @@ pub enum Action {
     FocusAgent,
     OpenProjectBrowser,
     CopyPath,
+    OpenWorktreeInEditor,
+    ChooseWorktreeEditor,
     CycleProvider,
     RefreshProject,
     ReconnectAgent,
@@ -136,6 +138,8 @@ impl Action {
             Action::FocusAgent => "focus_agent",
             Action::OpenProjectBrowser => "open_project_browser",
             Action::CopyPath => "copy_path",
+            Action::OpenWorktreeInEditor => "open_worktree_in_editor",
+            Action::ChooseWorktreeEditor => "choose_worktree_editor",
             Action::CycleProvider => "cycle_provider",
             Action::RefreshProject => "refresh_project",
             Action::ReconnectAgent => "reconnect_agent",
@@ -186,6 +190,12 @@ impl Action {
             Action::FocusAgent => "Focus the selected agent's output pane.",
             Action::OpenProjectBrowser => "Open the project browser.",
             Action::CopyPath => "Copy the selected agent's worktree path.",
+            Action::OpenWorktreeInEditor => {
+                "Open the selected agent worktree in the configured editor."
+            }
+            Action::ChooseWorktreeEditor => {
+                "Open a picker and choose which editor should open the selected agent worktree."
+            }
             Action::CycleProvider => "Cycle the default provider for the selected project.",
             Action::RefreshProject => "Git pull the selected project checkout.",
             Action::ReconnectAgent => "Restart the CLI for the selected agent.",
@@ -236,6 +246,8 @@ impl Action {
             | Action::FocusAgent
             | Action::OpenProjectBrowser
             | Action::CopyPath
+            | Action::OpenWorktreeInEditor
+            | Action::ChooseWorktreeEditor
             | Action::CycleProvider
             | Action::RefreshProject
             | Action::InteractAgent
@@ -414,6 +426,34 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "copy-path",
             description: "Copy the selected agent's worktree path",
+        }),
+    },
+    BindingDef {
+        action: Action::OpenWorktreeInEditor,
+        default_keys: &[key!(o)],
+        scopes: &[BindingScope::Left],
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Open selected agent worktree in the default editor",
+        }),
+        hint_contexts: &[(HintContext::LeftSession, "Open")],
+        palette: Some(PaletteEntry {
+            name: "open-worktree",
+            description: "Open the selected agent worktree in the configured editor",
+        }),
+    },
+    BindingDef {
+        action: Action::ChooseWorktreeEditor,
+        default_keys: &[key!(shift - o)],
+        scopes: &[BindingScope::Left],
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Choose an editor and open the selected agent worktree",
+        }),
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "open-worktree-with",
+            description: "Choose which editor should open the selected agent worktree",
         }),
     },
     BindingDef {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod config;
 mod diff;
+mod editor;
 mod git;
 mod keybindings;
 mod logger;


### PR DESCRIPTION
- add project-pane actions to open the selected worktree in an editor
- detect supported editor CLIs and honor a configurable default choice
- show an in-app editor picker when multiple editors are available

## bar

<img width="1604" height="35" alt="Screenshot 2026-03-27 at 5 36 11 PM" src="https://github.com/user-attachments/assets/0777013d-2a74-4399-88be-3c3e4dbbb7e6" />

## help ?

<img width="1018" height="43" alt="Screenshot 2026-03-27 at 5 36 32 PM" src="https://github.com/user-attachments/assets/2fab14a4-fdf8-4c13-a433-50c37a27000b" />


## shift-o

<img width="1120" height="343" alt="Screenshot 2026-03-27 at 5 36 45 PM" src="https://github.com/user-attachments/assets/fdbfacb7-fac7-4870-bd3b-f45645dd5755" />
