### PR TITLE
feat: arrow key and space line-by-line scrolling in all views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 - **Panes have local key combinations.** A key combo bound in one pane does not necessarily work in another.
 - **Panes have interactive and non-interactive modes.** In interactive mode, all key combos (including global ones) are suppressed and input is forwarded to the PTY. In non-interactive mode, both local and global key combos are active.
 - **Key combinations are documented in the help page.** The in-app `?` overlay is the authoritative reference. External docs describe how to configure bindings, not enumerate them.
+- **Line-scroll keys are gated by context.** In interactive (PTY) mode, arrow keys and Space only scroll when already scrolled back (`scrollback_offset > 0`); otherwise they pass through to the child process. In non-interactive views (diff overlay, non-interactive agent pane, help overlay), there is no competing use for these keys, so they scroll unconditionally. Page-scroll keys (`PgUp`/`PgDn`) always initiate scrolling regardless of context.
 
 ### Agents and Providers
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -16,16 +16,16 @@ impl App {
         }
         if let Some(ref mut scroll) = self.help_scroll {
             // Help overlay is open — consume all keys, only scroll keys do anything.
+            let max_help = self
+                .last_help_lines
+                .saturating_sub(self.last_help_height.max(1));
             if let Some(action) = self.bindings.lookup(&key, BindingScope::Help) {
                 match action {
-                    Action::MoveDown => *scroll = scroll.saturating_add(1),
+                    Action::MoveDown => *scroll = (*scroll + 1).min(max_help),
                     Action::MoveUp => *scroll = scroll.saturating_sub(1),
                     Action::ScrollPageDown => {
                         let page = self.last_help_height.max(1);
-                        *scroll = (*scroll + page).min(
-                            self.last_help_lines
-                                .saturating_sub(self.last_help_height.max(1)),
-                        );
+                        *scroll = (*scroll + page).min(max_help);
                     }
                     Action::ScrollPageUp => {
                         let page = self.last_help_height.max(1);
@@ -33,6 +33,11 @@ impl App {
                     }
                     _ => {}
                 }
+            } else if key.code == KeyCode::Char(' ') {
+                // Space scrolls down one line in the help overlay (not bound
+                // via MoveDown to avoid conflicting with ToggleProject/StageUnstage
+                // in other scopes).
+                *scroll = (*scroll + 1).min(max_help);
             }
             return Ok(false);
         }
@@ -317,6 +322,23 @@ impl App {
                         *scroll = (*scroll + page).min(max_scroll);
                     } else if self.last_pty_size.0 > 0 {
                         self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+                    }
+                }
+                Action::ScrollLineUp => {
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        *scroll = scroll.saturating_sub(1);
+                    } else if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Up, 1);
+                    }
+                }
+                Action::ScrollLineDown => {
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        let max_scroll = self
+                            .last_diff_visual_lines
+                            .saturating_sub(self.last_diff_height.max(1));
+                        *scroll = (*scroll + 1).min(max_scroll);
+                    } else if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Down, 1);
                     }
                 }
                 _ => {}
@@ -1446,6 +1468,36 @@ mod tests {
         let key = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
         assert_eq!(
             bindings.lookup(&key, BindingScope::Interactive),
+            Some(Action::ScrollLineDown),
+        );
+    }
+
+    #[test]
+    fn scroll_line_up_resolves_arrow_up_in_center_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::ScrollLineUp),
+        );
+    }
+
+    #[test]
+    fn scroll_line_down_resolves_arrow_down_in_center_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::ScrollLineDown),
+        );
+    }
+
+    #[test]
+    fn scroll_line_down_resolves_space_in_center_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
             Some(Action::ScrollLineDown),
         );
     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -293,6 +293,7 @@ impl App {
             let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
             let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
             let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
+            let scroll_line = self.bindings.label_for(Action::ScrollLineDown);
             let close = self.bindings.label_for(Action::CloseOverlay);
             let mut spans: Vec<Span> = Vec::new();
 
@@ -304,12 +305,16 @@ impl App {
                 spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" down, ", desc_style));
                 spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
-                spans.push(Span::styled(" up. ", desc_style));
+                spans.push(Span::styled(" up, ", desc_style));
+                spans.extend(self.theme.dim_key_badge(&scroll_line, Color::Reset));
+                spans.push(Span::styled(" one line. ", desc_style));
             } else {
                 spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                 spans.push(Span::styled(" ", desc_style));
                 spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" to scroll. ", desc_style));
+                spans.extend(self.theme.dim_key_badge(&scroll_line, Color::Reset));
+                spans.push(Span::styled(" one line. ", desc_style));
             }
             spans.extend(self.theme.dim_key_badge(&close, Color::Reset));
             spans.push(Span::styled(" close diff.", desc_style));
@@ -576,7 +581,9 @@ impl App {
                 spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
                 spans.push(Span::styled(" down, ", desc_style));
                 spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
-                spans.push(Span::styled(" up.", desc_style));
+                spans.push(Span::styled(" up, ", desc_style));
+                spans.extend(self.theme.dim_key_badge(&scroll_line, Color::Reset));
+                spans.push(Span::styled(" one line.", desc_style));
                 Line::from(spans)
             } else {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
@@ -587,7 +594,9 @@ impl App {
                     spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
                     spans.push(Span::styled(" ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
-                    spans.push(Span::styled(" to scroll.", desc_style));
+                    spans.push(Span::styled(" to scroll. ", desc_style));
+                    spans.extend(self.theme.dim_key_badge(&scroll_line, Color::Reset));
+                    spans.push(Span::styled(" one line.", desc_style));
                 } else if session_id.is_some() {
                     spans.push(Span::styled("Agent CLI exited. Press ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&reconnect, Color::Reset));
@@ -1098,6 +1107,8 @@ impl App {
             spans.extend(self.theme.dim_key_badge(&move_down, Color::Reset));
             spans.push(Span::styled(" ", desc_style));
             spans.extend(self.theme.dim_key_badge(&move_up, Color::Reset));
+            spans.push(Span::styled(" or ", desc_style));
+            spans.extend(self.theme.dim_key_badge("Space", Color::Reset));
             spans.push(Span::styled(" scroll, ", desc_style));
             spans.extend(self.theme.dim_key_badge(&scroll_down, Color::Reset));
             spans.push(Span::styled(" ", desc_style));

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -153,8 +153,8 @@ impl Action {
             Action::ToggleFullscreen => "toggle_fullscreen",
             Action::ScrollPageUp => "scroll_page_up",
             Action::ScrollPageDown => "scroll_page_down",
-            Action::ScrollLineUp => "agent_scroll_line_up",
-            Action::ScrollLineDown => "agent_scroll_line_down",
+            Action::ScrollLineUp => "scroll_line_up",
+            Action::ScrollLineDown => "scroll_line_down",
             Action::OpenDiff => "open_diff",
             Action::StageUnstage => "stage_unstage",
             Action::CommitChanges => "commit_changes",
@@ -211,10 +211,8 @@ impl Action {
             Action::ToggleFullscreen => "Toggle fullscreen overlay for the agent terminal.",
             Action::ScrollPageUp => "Scroll up one page in the agent output.",
             Action::ScrollPageDown => "Scroll down one page in the agent output.",
-            Action::ScrollLineUp => "Scroll up one line while scrolled back in interactive mode.",
-            Action::ScrollLineDown => {
-                "Scroll down one line while scrolled back in interactive mode."
-            }
+            Action::ScrollLineUp => "Scroll up one line in any scrollable view.",
+            Action::ScrollLineDown => "Scroll down one line in any scrollable view.",
             Action::OpenDiff => "Open the selected file's diff.",
             Action::StageUnstage => "Stage or unstage the selected file.",
             Action::CommitChanges => "Commit staged changes.",
@@ -266,9 +264,8 @@ impl Action {
             Action::ExitInteractive
             | Action::ToggleFullscreen
             | Action::ScrollPageUp
-            | Action::ScrollPageDown
-            | Action::ScrollLineUp
-            | Action::ScrollLineDown => Some("Agent pane"),
+            | Action::ScrollPageDown => Some("Agent pane"),
+            Action::ScrollLineUp | Action::ScrollLineDown => Some("Scrolling"),
             Action::OpenDiff
             | Action::StageUnstage
             | Action::CommitChanges
@@ -590,10 +587,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::ScrollLineUp,
         default_keys: &[key!(Up)],
-        scopes: &[BindingScope::Interactive],
+        scopes: &[BindingScope::Interactive, BindingScope::Center],
         help: Some(HelpEntry {
-            section: "Agent pane",
-            description: "Scroll up one line (while scrolled back)",
+            section: "Scrolling",
+            description: "Scroll up one line",
         }),
         hint_contexts: &[],
         palette: None,
@@ -601,10 +598,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::ScrollLineDown,
         default_keys: &[key!(Down), key!(space)],
-        scopes: &[BindingScope::Interactive],
+        scopes: &[BindingScope::Interactive, BindingScope::Center],
         help: Some(HelpEntry {
-            section: "Agent pane",
-            description: "Scroll down one line (while scrolled back)",
+            section: "Scrolling",
+            description: "Scroll down one line",
         }),
         hint_contexts: &[],
         palette: None,


### PR DESCRIPTION
## Summary

- Extends `ScrollLineUp`/`ScrollLineDown` (Up/Down/Space) from the interactive agent pane to the diff overlay, non-interactive agent pane, and help overlay
- Updates hint bars across all scrollable views to show arrow/space key options
- Renames binding config keys from `agent_scroll_line_*` to `scroll_line_*` to reflect broader scope
- Adds 3 keybinding resolution tests for Center scope and documents the line-scroll gating rule in CLAUDE.md

## Test plan

- [x] `cargo fmt && cargo test` — 113 tests pass, no regressions
- [ ] Open a diff → verify Up/Down scroll one line, Space scrolls down, PgUp/PgDn still work
- [ ] Non-interactive agent pane → verify Up/Down/Space scroll line by line
- [ ] Help overlay (`?`) → verify Space scrolls down one line
- [ ] Fullscreen interactive agent → verify arrows still go to PTY when not scrolled back