### PR TITLE
Add provider-configured session resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ On first launch, `dux` creates the config file with the full default configurati
 
 ## Provider Setup
 
-The provider commands in `config.toml` point to the CLI tools you want dux to run. By default, `claude` and `codex` are configured. dux launches the configured command in a PTY inside the session's worktree directory, so the CLI tool sees the worktree as its working directory.
+The provider commands in `config.toml` point to the CLI tools you want dux to run. By default, `claude` and `codex` are configured, and new sessions start with `claude` unless you override it per project or in `[defaults]`. dux launches the configured command in a PTY inside the session's worktree directory, so the CLI tool sees the worktree as its working directory.
 
 To use a different CLI tool, set the `command` field in the `[providers.<name>]` section of your config.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This means:
 - **Bring any CLI.** Any AI coding tool that runs in a terminal works with dux. Configure the command and args in `config.toml` and you're set.
 - **No banning risks.** You're running the official CLI the way it was designed to be used — the same binary, the same auth, the same API calls.
 - **Full CLI feature support.** Hooks, MCP servers, skills, slash commands, permission dialogs, thinking indicators — everything the CLI supports works out of the box because dux is just hosting the real terminal session.
-- **Crash recovery.** If dux crashes, the agent process dies — and that's fine. Just start a new session on the same worktree. The worktree and all file changes are preserved.
+- **Crash recovery.** If dux crashes, the agent process dies, but dux can reconnect in the same worktree. Providers with configured `resume_args` (like the built-in Claude and Codex defaults) can resume the CLI conversation for that folder/worktree.
 
 ## Features
 
@@ -36,6 +36,15 @@ On first launch, `dux` creates the config file with the full default configurati
 The provider commands in `config.toml` point to the CLI tools you want dux to run. By default, `claude` and `codex` are configured. dux launches the configured command in a PTY inside the session's worktree directory, so the CLI tool sees the worktree as its working directory.
 
 To use a different CLI tool, set the `command` field in the `[providers.<name>]` section of your config.
+
+If your CLI supports resuming the most recent session for the current repository/folder, add `resume_args` for reconnects after a crash or detached session. If `resume_args` is omitted or empty, dux assumes that CLI does **not** support session resume and will relaunch it normally.
+
+```toml
+[providers.example]
+command = "example-agent"
+args = []
+resume_args = ["resume", "--last"]
+```
 
 ## Logging
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -364,10 +364,10 @@ impl App {
     }
 
     fn reset_pty_scrollback(&self) {
-        if let Some(session) = self.selected_session() {
-            if let Some(provider) = self.providers.get(&session.id) {
-                provider.set_scrollback(0);
-            }
+        if let Some(session) = self.selected_session()
+            && let Some(provider) = self.providers.get(&session.id)
+        {
+            provider.set_scrollback(0);
         }
     }
 
@@ -778,10 +778,10 @@ impl App {
                     }
                 }
                 Some(Action::MoveUp) => {
-                    if let PromptState::Command { selected, .. } = &mut self.prompt {
-                        if *selected > 0 {
-                            *selected -= 1;
-                        }
+                    if let PromptState::Command { selected, .. } = &mut self.prompt
+                        && *selected > 0
+                    {
+                        *selected -= 1;
                     }
                 }
                 Some(Action::Confirm) => {
@@ -1034,10 +1034,10 @@ impl App {
                     }
                 }
                 Some(Action::MoveUp) => {
-                    if let PromptState::BrowseProjects { selected, .. } = &mut self.prompt {
-                        if *selected > 0 {
-                            *selected -= 1;
-                        }
+                    if let PromptState::BrowseProjects { selected, .. } = &mut self.prompt
+                        && *selected > 0
+                    {
+                        *selected -= 1;
                     }
                 }
                 Some(Action::GoToPath) if !is_searching => {
@@ -1102,22 +1102,21 @@ impl App {
                 }
                 _ => {
                     // Text input fallback for search mode.
-                    if is_searching {
-                        if let PromptState::BrowseProjects {
+                    if is_searching
+                        && let PromptState::BrowseProjects {
                             filter, selected, ..
                         } = &mut self.prompt
-                        {
-                            match key.code {
-                                KeyCode::Backspace => {
-                                    filter.pop();
-                                    *selected = 0;
-                                }
-                                KeyCode::Char(c) if is_plain_char => {
-                                    filter.push(c);
-                                    *selected = 0;
-                                }
-                                _ => {}
+                    {
+                        match key.code {
+                            KeyCode::Backspace => {
+                                filter.pop();
+                                *selected = 0;
                             }
+                            KeyCode::Char(c) if is_plain_char => {
+                                filter.push(c);
+                                *selected = 0;
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -1152,10 +1151,10 @@ impl App {
                     let worktree = worktree_path.clone();
                     let label = session_label.clone();
                     self.prompt = PromptState::None;
-                    if let Some(editor) = editor {
-                        if let Err(e) = self.open_worktree_in_editor(&worktree, &label, &editor) {
-                            self.set_error(format!("{e:#}"));
-                        }
+                    if let Some(editor) = editor
+                        && let Err(e) = self.open_worktree_in_editor(&worktree, &label, &editor)
+                    {
+                        self.set_error(format!("{e:#}"));
                     }
                 }
                 _ => {}
@@ -1349,7 +1348,10 @@ impl App {
         match mouse.kind {
             MouseEventKind::Down(_) => {
                 self.set_info(
-                    &format!("Mouse support is available for wheel navigation; resize has a keyboard fallback via {}.", self.bindings.label_for(Action::ToggleResizeMode)),
+                    format!(
+                        "Mouse support is available for wheel navigation; resize has a keyboard fallback via {}.",
+                        self.bindings.label_for(Action::ToggleResizeMode)
+                    ),
                 );
             }
             MouseEventKind::ScrollDown => match self.focus {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -587,11 +587,11 @@ impl App {
         let worktree = session.worktree_path.clone();
 
         // Skip the git rename if the branch name is unchanged.
-        if name != old_branch {
-            if let Err(e) = git::rename_branch(Path::new(&worktree), &old_branch, &name) {
-                self.set_error(format!("Rename failed: {e}"));
-                return;
-            }
+        if name != old_branch
+            && let Err(e) = git::rename_branch(Path::new(&worktree), &old_branch, &name)
+        {
+            self.set_error(format!("Rename failed: {e}"));
+            return;
         }
 
         // Git rename succeeded — update the session.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -269,11 +269,7 @@ impl App {
             .iter()
             .map(|l| {
                 let lw = l.width();
-                if lw <= w {
-                    1u16
-                } else {
-                    ((lw + w - 1) / w) as u16
-                }
+                if lw <= w { 1u16 } else { lw.div_ceil(w) as u16 }
             })
             .sum();
 
@@ -376,154 +372,149 @@ impl App {
             .map(|id| self.providers.contains_key(id))
             .unwrap_or(false);
 
-        if let Some(ref sid) = session_id {
-            if let Some(provider) = self.providers.get(sid) {
-                rendered_content = true;
-                // Resize PTY if needed.
-                let new_size = (term_area.height, term_area.width);
-                if new_size != self.last_pty_size && new_size.0 > 0 && new_size.1 > 0 {
-                    let _ = provider.resize(new_size.0, new_size.1);
-                    self.last_pty_size = new_size;
+        if let Some(ref sid) = session_id
+            && let Some(provider) = self.providers.get(sid)
+        {
+            rendered_content = true;
+            // Resize PTY if needed.
+            let new_size = (term_area.height, term_area.width);
+            if new_size != self.last_pty_size && new_size.0 > 0 && new_size.1 > 0 {
+                let _ = provider.resize(new_size.0, new_size.1);
+                self.last_pty_size = new_size;
+            }
+
+            if !provider.has_output() {
+                // Show a centered loading card until the PTY produces output.
+                let spinner_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+                let idx = (self.tick_count as usize) % spinner_chars.len();
+                let spinner = spinner_chars[idx];
+                let (label_spans, label_len) = match session_provider_name.as_deref() {
+                    Some(name) => {
+                        let text_len = "Starting ".len() + name.len() + "...".len();
+                        let spans = vec![
+                            Span::styled("Starting ", Style::default().fg(self.theme.hint_desc_fg)),
+                            Span::styled(
+                                name.to_owned(),
+                                Style::default().fg(self.theme.branch_fg),
+                            ),
+                            Span::styled("...", Style::default().fg(self.theme.hint_desc_fg)),
+                        ];
+                        (spans, text_len)
+                    }
+                    None => {
+                        let text = "Starting agent...";
+                        let spans = vec![Span::styled(
+                            text,
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        )];
+                        (spans, text.len())
+                    }
+                };
+
+                // Card dimensions: border + padding + content + padding + border.
+                // +2 for spinner + space prefix.
+                let content_w = label_len as u16 + 2;
+                let card_w = (content_w + 2 + 6).min(term_area.width); // 2 borders + 6 padding
+                let card_h: u16 = 5; // top border, blank, spinner, blank, bottom border
+
+                if term_area.width >= card_w && term_area.height >= card_h {
+                    let cx = term_area.x + (term_area.width - card_w) / 2;
+                    let cy = term_area.y + (term_area.height - card_h) / 2;
+                    let card_area = Rect::new(cx, cy, card_w, card_h);
+
+                    let card_block = Block::default()
+                        .borders(Borders::ALL)
+                        .border_type(ratatui::widgets::BorderType::Rounded)
+                        .border_style(Style::default().fg(self.theme.border_normal));
+                    let card_inner = card_block.inner(card_area);
+                    card_block.render(card_area, frame.buffer_mut());
+
+                    // Render spinner + label centered inside the card.
+                    let mut spans = vec![Span::styled(
+                        format!("{spinner} "),
+                        Style::default()
+                            .fg(self.theme.hint_key_fg)
+                            .add_modifier(Modifier::BOLD),
+                    )];
+                    spans.extend(label_spans);
+                    let line = Line::from(spans);
+                    Paragraph::new(line)
+                        .alignment(ratatui::layout::Alignment::Center)
+                        .render(
+                            Rect::new(
+                                card_inner.x,
+                                card_inner.y + card_inner.height / 2,
+                                card_inner.width,
+                                1,
+                            ),
+                            frame.buffer_mut(),
+                        );
+                }
+            } else {
+                // Render the current terminal viewport into the ratatui
+                // buffer from an owned snapshot to avoid holding locks
+                // during painting.
+                let snapshot = provider.snapshot();
+                scrollback_offset = snapshot.scrollback_offset;
+                let buf = frame.buffer_mut();
+                for cell in &snapshot.cells {
+                    if cell.row >= snapshot.rows
+                        || cell.col >= snapshot.cols
+                        || cell.row >= term_area.height
+                        || cell.col >= term_area.width
+                    {
+                        continue;
+                    }
+                    let x = term_area.x + cell.col;
+                    let y = term_area.y + cell.row;
+                    let style = Style::default()
+                        .fg(cell.fg)
+                        .bg(cell.bg)
+                        .add_modifier(cell.modifier);
+                    let ratatui_cell = &mut buf[(x, y)];
+                    ratatui_cell.set_symbol(&cell.symbol);
+                    ratatui_cell.set_style(style);
                 }
 
-                if !provider.has_output() {
-                    // Show a centered loading card until the PTY produces output.
-                    let spinner_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-                    let idx = (self.tick_count as usize) % spinner_chars.len();
-                    let spinner = spinner_chars[idx];
-                    let (label_spans, label_len) = match session_provider_name.as_deref() {
-                        Some(name) => {
-                            let text_len = "Starting ".len() + name.len() + "...".len();
-                            let spans = vec![
-                                Span::styled(
-                                    "Starting ",
-                                    Style::default().fg(self.theme.hint_desc_fg),
-                                ),
-                                Span::styled(
-                                    name.to_owned(),
-                                    Style::default().fg(self.theme.branch_fg),
-                                ),
-                                Span::styled("...", Style::default().fg(self.theme.hint_desc_fg)),
-                            ];
-                            (spans, text_len)
-                        }
-                        None => {
-                            let text = "Starting agent...";
-                            let spans = vec![Span::styled(
-                                text,
-                                Style::default().fg(self.theme.hint_desc_fg),
-                            )];
-                            (spans, text.len())
-                        }
-                    };
-
-                    // Card dimensions: border + padding + content + padding + border.
-                    // +2 for spinner + space prefix.
-                    let content_w = label_len as u16 + 2;
-                    let card_w = (content_w + 2 + 6).min(term_area.width); // 2 borders + 6 padding
-                    let card_h: u16 = 5; // top border, blank, spinner, blank, bottom border
-
-                    if term_area.width >= card_w && term_area.height >= card_h {
-                        let cx = term_area.x + (term_area.width - card_w) / 2;
-                        let cy = term_area.y + (term_area.height - card_h) / 2;
-                        let card_area = Rect::new(cx, cy, card_w, card_h);
-
-                        let card_block = Block::default()
-                            .borders(Borders::ALL)
-                            .border_type(ratatui::widgets::BorderType::Rounded)
-                            .border_style(Style::default().fg(self.theme.border_normal));
-                        let card_inner = card_block.inner(card_area);
-                        card_block.render(card_area, frame.buffer_mut());
-
-                        // Render spinner + label centered inside the card.
-                        let mut spans = vec![Span::styled(
-                            format!("{spinner} "),
+                // Render cursor if in input mode.
+                if is_input
+                    && let Some(cursor) = snapshot.cursor
+                    && cursor.row < snapshot.rows
+                    && cursor.col < snapshot.cols
+                {
+                    let cx = term_area.x + cursor.col;
+                    let cy = term_area.y + cursor.row;
+                    if cx < term_area.x + term_area.width && cy < term_area.y + term_area.height {
+                        let cursor_cell = &mut buf[(cx, cy)];
+                        cursor_cell.set_style(
                             Style::default()
-                                .fg(self.theme.hint_key_fg)
-                                .add_modifier(Modifier::BOLD),
-                        )];
-                        spans.extend(label_spans);
-                        let line = Line::from(spans);
-                        Paragraph::new(line)
-                            .alignment(ratatui::layout::Alignment::Center)
+                                .fg(Color::Black)
+                                .bg(self.theme.prompt_cursor),
+                        );
+                    }
+                }
+
+                if let Some(label) = scrollback_indicator_label(
+                    snapshot.scrollback_offset,
+                    snapshot.scrollback_total,
+                ) {
+                    let badge_width = label.len() as u16;
+                    if term_area.height > 0 && badge_width <= term_area.width {
+                        Paragraph::new(label)
+                            .style(
+                                Style::default()
+                                    .fg(self.theme.scroll_indicator_fg)
+                                    .bg(self.theme.scroll_indicator_bg),
+                            )
                             .render(
                                 Rect::new(
-                                    card_inner.x,
-                                    card_inner.y + card_inner.height / 2,
-                                    card_inner.width,
+                                    term_area.x + term_area.width - badge_width,
+                                    term_area.y,
+                                    badge_width,
                                     1,
                                 ),
                                 frame.buffer_mut(),
                             );
-                    }
-                } else {
-                    // Render the current terminal viewport into the ratatui
-                    // buffer from an owned snapshot to avoid holding locks
-                    // during painting.
-                    let snapshot = provider.snapshot();
-                    scrollback_offset = snapshot.scrollback_offset;
-                    let buf = frame.buffer_mut();
-                    for cell in &snapshot.cells {
-                        if cell.row >= snapshot.rows
-                            || cell.col >= snapshot.cols
-                            || cell.row >= term_area.height
-                            || cell.col >= term_area.width
-                        {
-                            continue;
-                        }
-                        let x = term_area.x + cell.col;
-                        let y = term_area.y + cell.row;
-                        let style = Style::default()
-                            .fg(cell.fg)
-                            .bg(cell.bg)
-                            .add_modifier(cell.modifier);
-                        let ratatui_cell = &mut buf[(x, y)];
-                        ratatui_cell.set_symbol(&cell.symbol);
-                        ratatui_cell.set_style(style);
-                    }
-
-                    // Render cursor if in input mode.
-                    if is_input {
-                        if let Some(cursor) = snapshot.cursor {
-                            if cursor.row < snapshot.rows && cursor.col < snapshot.cols {
-                                let cx = term_area.x + cursor.col;
-                                let cy = term_area.y + cursor.row;
-                                if cx < term_area.x + term_area.width
-                                    && cy < term_area.y + term_area.height
-                                {
-                                    let cursor_cell = &mut buf[(cx, cy)];
-                                    cursor_cell.set_style(
-                                        Style::default()
-                                            .fg(Color::Black)
-                                            .bg(self.theme.prompt_cursor),
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    if let Some(label) = scrollback_indicator_label(
-                        snapshot.scrollback_offset,
-                        snapshot.scrollback_total,
-                    ) {
-                        let badge_width = label.len() as u16;
-                        if term_area.height > 0 && badge_width <= term_area.width {
-                            Paragraph::new(label)
-                                .style(
-                                    Style::default()
-                                        .fg(self.theme.scroll_indicator_fg)
-                                        .bg(self.theme.scroll_indicator_bg),
-                                )
-                                .render(
-                                    Rect::new(
-                                        term_area.x + term_area.width - badge_width,
-                                        term_area.y,
-                                        badge_width,
-                                        1,
-                                    ),
-                                    frame.buffer_mut(),
-                                );
-                        }
                     }
                 }
             }
@@ -636,7 +627,6 @@ impl App {
                 "Changes",
                 &self.unstaged_files,
                 RightSection::Unstaged,
-                focused,
                 true,
             );
             self.render_staged_with_commit(frame, chunks[1], focused);
@@ -647,7 +637,6 @@ impl App {
                 "Changes",
                 &self.unstaged_files,
                 RightSection::Unstaged,
-                focused,
                 true,
             );
         }
@@ -669,7 +658,6 @@ impl App {
             "Staged Changes",
             &self.staged_files,
             RightSection::Staged,
-            pane_focused,
             false,
         );
 
@@ -684,9 +672,9 @@ impl App {
         title_prefix: &str,
         files: &[ChangedFile],
         section: RightSection,
-        pane_focused: bool,
         show_hint: bool,
     ) {
+        let pane_focused = self.focus == FocusPane::Files;
         let is_active_section = pane_focused && self.right_section == section;
         let title = format!("{title_prefix} ({})", files.len());
         let block = self.themed_block(&title, is_active_section);
@@ -2257,9 +2245,8 @@ mod tests {
                      col {col} > line len {} at row {row}",
                     line.len()
                 );
-            } else {
+            } else if let Some(expected_char) = at_char {
                 // Cursor points at a visible character; it should match.
-                let expected_char = at_char.unwrap();
                 let actual_char = line[col..].chars().next().unwrap_or('\0');
                 assert_eq!(
                     actual_char, expected_char,
@@ -2335,7 +2322,7 @@ mod tests {
                 .unwrap();
 
             let buf = terminal.backend().buffer();
-            let cell = buf.cell((ccol as u16, crow as u16)).unwrap();
+            let cell = buf.cell((ccol as u16, crow)).unwrap();
             let expected = &text[cursor..cursor + 1];
             assert_eq!(
                 cell.symbol(),
@@ -2372,7 +2359,7 @@ mod tests {
             .unwrap();
 
         let buf = terminal.backend().buffer();
-        let cell = buf.cell((ccol as u16, crow as u16)).unwrap();
+        let cell = buf.cell((ccol as u16, crow)).unwrap();
         let expected_char = after_delete[new_cursor..].chars().next().unwrap();
         assert_eq!(
             cell.symbol(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -121,18 +121,24 @@ impl App {
 
     pub(crate) fn spawn_pty_for_session(&self, session: &AgentSession) -> Result<PtyClient> {
         let cfg = provider_config(&self.config, &session.provider);
+        let launch_args = cfg.interactive_args(true);
         let (rows, cols) = if self.last_pty_size != (0, 0) {
             self.last_pty_size
         } else {
             (24, 80)
         };
         logger::debug(&format!(
-            "spawning PTY {:?} {:?} in {} ({}x{})",
-            cfg.command, cfg.args, session.worktree_path, cols, rows
+            "spawning PTY {:?} {:?} in {} ({}x{}, resume_supported={})",
+            cfg.command,
+            launch_args,
+            session.worktree_path,
+            cols,
+            rows,
+            cfg.supports_session_resume()
         ));
         PtyClient::spawn(
             &cfg.command,
-            &cfg.args,
+            launch_args,
             Path::new(&session.worktree_path),
             rows,
             cols,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -93,12 +93,11 @@ impl App {
                         selected,
                         ..
                     } = &mut self.prompt
+                        && *current_dir == dir
                     {
-                        if *current_dir == dir {
-                            *current_entries = entries;
-                            *loading = false;
-                            *selected = 0;
-                        }
+                        *current_entries = entries;
+                        *loading = false;
+                        *selected = 0;
                     }
                 }
             }
@@ -116,16 +115,16 @@ impl App {
         }
         if !exited.is_empty() {
             // If the currently-viewed session just exited, leave interactive mode.
-            if let Some(current) = self.selected_session() {
-                if exited.contains(&current.id) {
-                    self.input_target = InputTarget::None;
-                    self.fullscreen_agent = false;
-                    self.focus = FocusPane::Left;
-                    let key = self.bindings.label_for(Action::ReconnectAgent);
-                    self.set_info(format!(
-                        "Agent CLI process has exited. Press \"{key}\" to relaunch."
-                    ));
-                }
+            if let Some(current) = self.selected_session()
+                && exited.contains(&current.id)
+            {
+                self.input_target = InputTarget::None;
+                self.fullscreen_agent = false;
+                self.focus = FocusPane::Left;
+                let key = self.bindings.label_for(Action::ReconnectAgent);
+                self.set_info(format!(
+                    "Agent CLI process has exited. Press \"{key}\" to relaunch."
+                ));
             }
         }
         // Keep the poller's interval flag in sync with whether any agent is running.
@@ -163,15 +162,13 @@ impl App {
                 };
                 thread::sleep(interval);
                 let path = watched.lock().ok().and_then(|guard| guard.clone());
-                if let Some(worktree_path) = path {
-                    if let Ok((staged, unstaged)) = git::changed_files(&worktree_path) {
-                        if tx
-                            .send(WorkerEvent::ChangedFilesReady { staged, unstaged })
-                            .is_err()
-                        {
-                            break; // receiver dropped, app is shutting down
-                        }
-                    }
+                if let Some(worktree_path) = path
+                    && let Ok((staged, unstaged)) = git::changed_files(&worktree_path)
+                    && tx
+                        .send(WorkerEvent::ChangedFilesReady { staged, unstaged })
+                        .is_err()
+                {
+                    break; // receiver dropped, app is shutting down
                 }
             }
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,7 +158,7 @@ impl Default for Defaults {
     fn default() -> Self {
         let start_directory = home::home_dir().map(|p| p.to_string_lossy().to_string());
         Self {
-            provider: "codex".to_string(),
+            provider: "claude".to_string(),
             start_directory,
             commit_prompt: Some(DEFAULT_COMMIT_PROMPT.to_string()),
         }
@@ -832,6 +832,7 @@ mod tests {
         let rendered = render_default_config();
         assert!(rendered.contains("# dux configuration"));
         assert!(rendered.contains("[defaults]"));
+        assert!(rendered.contains("provider = \"claude\""));
         assert!(rendered.contains("[providers.claude]"));
         assert!(rendered.contains("[providers.codex]"));
         assert!(rendered.contains("oneshot_args = "));
@@ -939,6 +940,7 @@ mod tests {
     #[test]
     fn built_in_providers_ship_resume_args() {
         let config = Config::default();
+        assert_eq!(config.defaults.provider, "claude");
         let claude = config
             .providers
             .get("claude")

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub enum OneshotOutput {
 pub struct ProviderCommandConfig {
     pub command: String,
     pub args: Vec<String>,
+    pub resume_args: Option<Vec<String>>,
     pub oneshot_args: Vec<String>,
     pub oneshot_output: OneshotOutput,
     pub install_hint: Option<String>,
@@ -179,10 +180,29 @@ impl Default for ProviderCommandConfig {
         Self {
             command: String::new(),
             args: Vec::new(),
+            resume_args: None,
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
         }
+    }
+}
+
+impl ProviderCommandConfig {
+    pub fn interactive_args(&self, resume_session: bool) -> &[String] {
+        if resume_session
+            && let Some(resume_args) = self.resume_args.as_deref().filter(|args| !args.is_empty())
+        {
+            return resume_args;
+        }
+        &self.args
+    }
+
+    pub fn supports_session_resume(&self) -> bool {
+        self.resume_args
+            .as_ref()
+            .map(|args| !args.is_empty())
+            .unwrap_or(false)
     }
 }
 
@@ -221,12 +241,11 @@ impl Config {
     /// Returns the effective commit prompt for a project, checking project-level
     /// override first, then system default, then the hardcoded fallback.
     pub fn commit_prompt_for_project(&self, project_path: &str) -> String {
-        if let Some(project) = self.projects.iter().find(|p| p.path == project_path) {
-            if let Some(ref prompt) = project.commit_prompt {
-                if !prompt.is_empty() {
-                    return prompt.clone();
-                }
-            }
+        if let Some(project) = self.projects.iter().find(|p| p.path == project_path)
+            && let Some(ref prompt) = project.commit_prompt
+            && !prompt.is_empty()
+        {
+            return prompt.clone();
         }
         self.defaults
             .commit_prompt
@@ -244,7 +263,16 @@ impl ProvidersConfig {
 
     pub fn ensure_defaults(&mut self) {
         for (name, config) in default_provider_commands() {
-            self.commands.entry(name.to_string()).or_insert(config);
+            match self.commands.entry(name.to_string()) {
+                indexmap::map::Entry::Vacant(entry) => {
+                    entry.insert(config);
+                }
+                indexmap::map::Entry::Occupied(mut entry) => {
+                    if entry.get().resume_args.is_none() {
+                        entry.get_mut().resume_args = config.resume_args;
+                    }
+                }
+            }
         }
     }
 }
@@ -634,6 +662,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
             ProviderCommandConfig {
                 command: "claude".to_string(),
                 args: Vec::new(),
+                resume_args: Some(vec!["--continue".to_string()]),
                 oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
                 oneshot_output: OneshotOutput::Stdout,
                 install_hint: Some("npm install -g @anthropic-ai/claude-code".to_string()),
@@ -644,6 +673,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
             ProviderCommandConfig {
                 command: "codex".to_string(),
                 args: Vec::new(),
+                resume_args: Some(vec!["resume".to_string(), "--last".to_string()]),
                 oneshot_args: vec![
                     "exec".to_string(),
                     "-o".to_string(),
@@ -671,6 +701,14 @@ fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommand
         escape_toml_string(&config.command)
     ));
     out.push_str(&format!("args = {}\n", render_string_list(&config.args)));
+    out.push_str(
+        "# Optional args dux should use when reconnecting a detached session.\n\
+         # Leave this empty for CLIs that do not support cwd/repo-scoped session resume.\n",
+    );
+    out.push_str(&format!(
+        "resume_args = {}\n",
+        render_string_list(config.resume_args.as_deref().unwrap_or(&[]))
+    ));
     out.push_str("# Oneshot args for non-interactive use (e.g. AI commit messages).\n");
     out.push_str("# Placeholders: {prompt} = the prompt text, {tempfile} = temp file path.\n");
     out.push_str(&format!(
@@ -798,6 +836,7 @@ mod tests {
         assert!(rendered.contains("[providers.codex]"));
         assert!(rendered.contains("oneshot_args = "));
         assert!(rendered.contains("oneshot_output = "));
+        assert!(rendered.contains("resume_args = "));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
         assert!(rendered.contains("[editor]"));
@@ -895,6 +934,163 @@ mod tests {
         let rendered = render_config_default(&config);
         let parsed: Config = toml::from_str(&rendered).expect("config should parse");
         assert_eq!(parsed.editor.default, "zed");
+    }
+
+    #[test]
+    fn built_in_providers_ship_resume_args() {
+        let config = Config::default();
+        let claude = config
+            .providers
+            .get("claude")
+            .expect("claude provider should exist");
+        assert_eq!(
+            claude.resume_args.clone(),
+            Some(vec!["--continue".to_string()])
+        );
+        assert!(claude.supports_session_resume());
+
+        let codex = config
+            .providers
+            .get("codex")
+            .expect("codex provider should exist");
+        assert_eq!(
+            codex.resume_args.clone(),
+            Some(vec!["resume".to_string(), "--last".to_string()])
+        );
+        assert!(codex.supports_session_resume());
+    }
+
+    #[test]
+    fn provider_command_config_selects_resume_args_only_when_available() {
+        let cfg = ProviderCommandConfig {
+            command: "example".to_string(),
+            args: vec!["--interactive".to_string()],
+            resume_args: Some(vec!["--resume".to_string(), "--last".to_string()]),
+            oneshot_args: Vec::new(),
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
+        };
+        assert_eq!(cfg.interactive_args(false), ["--interactive"]);
+        assert_eq!(cfg.interactive_args(true), ["--resume", "--last"]);
+
+        let unsupported = ProviderCommandConfig {
+            command: "example".to_string(),
+            args: vec!["--interactive".to_string()],
+            resume_args: None,
+            oneshot_args: Vec::new(),
+            oneshot_output: OneshotOutput::Stdout,
+            install_hint: None,
+        };
+        assert_eq!(unsupported.interactive_args(true), ["--interactive"]);
+        assert!(!unsupported.supports_session_resume());
+    }
+
+    #[test]
+    fn ensure_defaults_backfills_missing_resume_args_for_builtins() {
+        let mut providers = ProvidersConfig {
+            commands: IndexMap::from([(
+                "claude".to_string(),
+                ProviderCommandConfig {
+                    command: "claude".to_string(),
+                    args: Vec::new(),
+                    resume_args: None,
+                    oneshot_args: Vec::new(),
+                    oneshot_output: OneshotOutput::Stdout,
+                    install_hint: None,
+                },
+            )]),
+        };
+
+        providers.ensure_defaults();
+
+        let claude = providers
+            .get("claude")
+            .expect("claude provider should still exist");
+        assert_eq!(
+            claude.resume_args.clone(),
+            Some(vec!["--continue".to_string()])
+        );
+    }
+
+    #[test]
+    fn ensure_defaults_preserves_explicit_resume_disable() {
+        let mut providers = ProvidersConfig {
+            commands: IndexMap::from([(
+                "claude".to_string(),
+                ProviderCommandConfig {
+                    command: "claude".to_string(),
+                    args: Vec::new(),
+                    resume_args: Some(Vec::new()),
+                    oneshot_args: Vec::new(),
+                    oneshot_output: OneshotOutput::Stdout,
+                    install_hint: None,
+                },
+            )]),
+        };
+
+        providers.ensure_defaults();
+
+        let claude = providers
+            .get("claude")
+            .expect("claude provider should still exist");
+        assert_eq!(claude.resume_args, Some(Vec::new()));
+        assert!(!claude.supports_session_resume());
+    }
+
+    #[test]
+    fn provider_configs_without_resume_args_still_parse() {
+        let parsed: Config = toml::from_str(
+            r#"
+            [defaults]
+            provider = "claude"
+
+            [logging]
+            level = "info"
+            path = "dux.log"
+
+            [ui]
+            left_width_pct = 20
+            right_width_pct = 23
+            agent_scrollback_lines = 10000
+
+            [editor]
+            default = "cursor"
+
+            [keys]
+            show_terminal_keys = true
+
+            [providers.custom]
+            command = "custom-agent"
+            args = ["chat"]
+            oneshot_args = ["ask", "{prompt}"]
+            oneshot_output = "stdout"
+            "#,
+        )
+        .expect("legacy provider config should parse");
+
+        let provider = parsed
+            .providers
+            .get("custom")
+            .expect("custom provider should exist");
+        assert_eq!(provider.resume_args, None);
+        assert_eq!(provider.interactive_args(true), ["chat"]);
+    }
+
+    #[test]
+    fn legacy_provider_config_without_resume_args_still_parses() {
+        let parsed: ProviderCommandConfig = toml::from_str(
+            r#"
+command = "legacy-agent"
+args = ["serve"]
+oneshot_args = ["--prompt", "{prompt}"]
+oneshot_output = "stdout"
+"#,
+        )
+        .expect("legacy provider config should parse");
+        assert_eq!(parsed.command, "legacy-agent");
+        assert_eq!(parsed.args, vec!["serve"]);
+        assert_eq!(parsed.resume_args, None);
+        assert!(!parsed.supports_session_resume());
     }
 
     #[cfg(target_os = "macos")]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -85,13 +85,12 @@ pub fn detect_installed_editors() -> Vec<DetectedEditor> {
 
 pub fn preferred_editor(detected: &[DetectedEditor], configured: &str) -> Option<DetectedEditor> {
     let configured = normalize_editor_name(configured);
-    if !configured.is_empty() {
-        if let Some(editor) = detected
+    if !configured.is_empty()
+        && let Some(editor) = detected
             .iter()
             .find(|editor| matches_configured_editor(editor, &configured))
-        {
-            return Some(editor.clone());
-        }
+    {
+        return Some(editor.clone());
     }
     detected.first().cloned()
 }
@@ -145,11 +144,7 @@ fn detect_editors_from_names<'a>(names: impl IntoIterator<Item = &'a str>) -> Ve
 }
 
 fn normalize_editor_name(value: &str) -> String {
-    value
-        .trim()
-        .to_ascii_lowercase()
-        .replace('_', "-")
-        .replace(' ', "-")
+    value.trim().to_ascii_lowercase().replace(['_', ' '], "-")
 }
 
 fn normalize_executable_name(value: &str) -> String {

--- a/src/git.rs
+++ b/src/git.rs
@@ -217,14 +217,13 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     if let Ok(ns) = Command::new("git")
         .args(["-C", wt.as_ref(), "diff", "--numstat"])
         .output()
+        && ns.status.success()
     {
-        if ns.status.success() {
-            let stats = parse_numstat(&ns.stdout);
-            for file in &mut unstaged {
-                if let Some(&(a, d)) = stats.get(&file.path) {
-                    file.additions = a;
-                    file.deletions = d;
-                }
+        let stats = parse_numstat(&ns.stdout);
+        for file in &mut unstaged {
+            if let Some(&(a, d)) = stats.get(&file.path) {
+                file.additions = a;
+                file.deletions = d;
             }
         }
     }
@@ -232,14 +231,13 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     if let Ok(ns) = Command::new("git")
         .args(["-C", wt.as_ref(), "diff", "--cached", "--numstat"])
         .output()
+        && ns.status.success()
     {
-        if ns.status.success() {
-            let stats = parse_numstat(&ns.stdout);
-            for file in &mut staged {
-                if let Some(&(a, d)) = stats.get(&file.path) {
-                    file.additions = a;
-                    file.deletions = d;
-                }
+        let stats = parse_numstat(&ns.stdout);
+        for file in &mut staged {
+            if let Some(&(a, d)) = stats.get(&file.path) {
+                file.additions = a;
+                file.deletions = d;
             }
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1222,10 +1222,10 @@ impl RuntimeBindings {
             if let Some(name) = b.palette_name {
                 if name.contains(&needle) {
                     name_matches.push(b);
-                } else if let Some(desc) = b.palette_description {
-                    if desc.to_lowercase().contains(&needle) {
-                        desc_matches.push(b);
-                    }
+                } else if let Some(desc) = b.palette_description
+                    && desc.to_lowercase().contains(&needle)
+                {
+                    desc_matches.push(b);
                 }
             }
         }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -82,6 +82,7 @@ mod tests {
         ProviderCommandConfig {
             command: "echo".to_string(),
             args: Vec::new(),
+            resume_args: None,
             oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
@@ -92,6 +93,7 @@ mod tests {
         ProviderCommandConfig {
             command: "bash".to_string(),
             args: Vec::new(),
+            resume_args: None,
             oneshot_args: vec!["-c".to_string(), "echo {prompt} > {tempfile}".to_string()],
             oneshot_output: OneshotOutput::Tempfile,
             install_hint: None,
@@ -161,6 +163,7 @@ mod tests {
         let config = ProviderCommandConfig {
             command: "false".to_string(),
             args: Vec::new(),
+            resume_args: None,
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
@@ -177,6 +180,7 @@ mod tests {
         let config = ProviderCommandConfig {
             command: "echo".to_string(),
             args: Vec::new(),
+            resume_args: None,
             oneshot_args: vec![
                 "--format".to_string(),
                 "plain".to_string(),

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -140,11 +140,11 @@ impl PtyClient {
                     let data = &buf[..n];
                     if let Ok(mut terminal) = terminal.lock() {
                         let replies = terminal.process(data);
-                        if !replies.is_empty() {
-                            if let Ok(mut w) = writer.lock() {
-                                let _ = w.write_all(&replies);
-                                let _ = w.flush();
-                            }
+                        if !replies.is_empty()
+                            && let Ok(mut w) = writer.lock()
+                        {
+                            let _ = w.write_all(&replies);
+                            let _ = w.flush();
                         }
                         if !has_output.load(Ordering::Acquire) && terminal.has_visible_output() {
                             has_output.store(true, Ordering::Release);


### PR DESCRIPTION
## Summary
- add provider-level `resume_args` so reconnects can resume CLI sessions when supported
- ship built-in resume defaults for Claude (`--continue`) and Codex (`resume --last`)
- make Claude the default provider for new sessions while still keeping Codex available
- clean up existing Clippy warnings so strict linting passes again

## Details
Dux already preserved worktrees and session metadata, but reconnecting after a crash started a fresh CLI conversation. This change keeps reconnect behavior config-driven and cwd/worktree-scoped so supported CLIs can resume their latest local session, while unsupported custom tools continue to relaunch normally.

For Codex specifically: older behavior appears to have used global session lookup, but current Codex documents `--all` as the flag that disables cwd filtering. In practice, that means `codex resume --last` is expected to follow the current worktree/repository rather than just picking the newest session anywhere.

It also changes the generated default config so new sessions start with Claude by default, without removing Codex as a built-in option.

## Verification
- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
