### PR TITLE
Restore rename modal usability

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2,10 +2,16 @@ use super::*;
 
 impl App {
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
-        // Interactive mode: ALL keys go to the PTY except Ctrl-G
-        // (ExitInteractive, handled inside handle_agent_input). This must be
-        // the very first check so that no global binding — including
-        // CloseOverlay / Escape — intercepts keys during interactive mode.
+        // Prompts take precedence over every other input target so modal text
+        // fields can safely capture keystrokes even when other modes were
+        // previously active.
+        if !matches!(self.prompt, PromptState::None) {
+            return self.handle_prompt_key(key);
+        }
+        // Interactive mode: ALL remaining keys go to the PTY except Ctrl-G
+        // (ExitInteractive, handled inside handle_agent_input). This must
+        // happen before global bindings so CloseOverlay / Escape do not
+        // intercept agent input during interactive mode.
         if self.input_target == InputTarget::Agent {
             return self.handle_agent_input(key);
         }
@@ -40,9 +46,6 @@ impl App {
                 *scroll = (*scroll + 1).min(max_help);
             }
             return Ok(false);
-        }
-        if !matches!(self.prompt, PromptState::None) {
-            return self.handle_prompt_key(key);
         }
         // When typing a commit message, route all keys to the commit input
         // handler so that q, ?, [ etc. are typed instead of triggering
@@ -1247,48 +1250,58 @@ impl App {
             cursor,
         } = &mut self.prompt
         {
-            match key.code {
-                KeyCode::Esc => {
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
+            let action = if is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::Dialog)
+            };
+
+            match action {
+                Some(Action::CloseOverlay) => {
                     self.prompt = PromptState::None;
                 }
-                KeyCode::Enter => {
+                Some(Action::Confirm) => {
                     let id = session_id.clone();
                     let new_name = input.clone();
                     self.prompt = PromptState::None;
                     self.apply_rename_session(&id, new_name);
                 }
-                KeyCode::Backspace => {
-                    if *cursor > 0 {
-                        input.remove(*cursor - 1);
-                        *cursor -= 1;
+                _ => match key.code {
+                    KeyCode::Backspace => {
+                        if *cursor > 0 {
+                            input.remove(*cursor - 1);
+                            *cursor -= 1;
+                        }
                     }
-                }
-                KeyCode::Delete => {
-                    if *cursor < input.len() {
-                        input.remove(*cursor);
+                    KeyCode::Delete => {
+                        if *cursor < input.len() {
+                            input.remove(*cursor);
+                        }
                     }
-                }
-                KeyCode::Left => {
-                    if *cursor > 0 {
-                        *cursor -= 1;
+                    KeyCode::Left => {
+                        if *cursor > 0 {
+                            *cursor -= 1;
+                        }
                     }
-                }
-                KeyCode::Right => {
-                    if *cursor < input.len() {
+                    KeyCode::Right => {
+                        if *cursor < input.len() {
+                            *cursor += 1;
+                        }
+                    }
+                    KeyCode::Home => {
+                        *cursor = 0;
+                    }
+                    KeyCode::End => {
+                        *cursor = input.len();
+                    }
+                    KeyCode::Char(c) if is_plain_char => {
+                        input.insert(*cursor, c);
                         *cursor += 1;
                     }
-                }
-                KeyCode::Home => {
-                    *cursor = 0;
-                }
-                KeyCode::End => {
-                    *cursor = input.len();
-                }
-                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    input.insert(*cursor, c);
-                    *cursor += 1;
-                }
-                _ => {}
+                    _ => {}
+                },
             }
             return Ok(false);
         }
@@ -1386,8 +1399,20 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::{Arc, Mutex, mpsc};
+
+    use crate::app::{App, CenterMode, FocusPane, InputTarget, PromptState, RightSection};
+    use crate::config::{Config, DuxPaths};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
+    use crate::model::{AgentSession, Project, ProviderKind, SessionStatus};
+    use crate::statusline::StatusLine;
+    use crate::storage::SessionStore;
+    use crate::theme::Theme;
+    use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use tempfile::tempdir;
 
     fn default_bindings() -> RuntimeBindings {
         RuntimeBindings::new(
@@ -1400,6 +1425,186 @@ mod tests {
             },
             true,
         )
+    }
+
+    fn bindings_with_overrides(overrides: &[(Action, &[&str])]) -> RuntimeBindings {
+        RuntimeBindings::new(
+            |action| {
+                if let Some((_, keys)) =
+                    overrides.iter().find(|(candidate, _)| *candidate == action)
+                {
+                    return keys
+                        .iter()
+                        .map(|key| crokey::parse(key).expect("valid test binding"))
+                        .collect();
+                }
+                BINDING_DEFS
+                    .iter()
+                    .find(|d| d.action == action)
+                    .map(|d| d.default_keys.to_vec())
+                    .unwrap_or_default()
+            },
+            true,
+        )
+    }
+
+    fn test_app(bindings: RuntimeBindings) -> App {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            root: root.clone(),
+        };
+        std::fs::create_dir_all(&paths.worktrees_root).expect("worktrees dir");
+        let session_store = SessionStore::open(&paths.sessions_db_path).expect("session store");
+        let now = Utc::now();
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: root.to_string_lossy().to_string(),
+            default_provider: ProviderKind::from_str("codex"),
+            current_branch: "main".to_string(),
+        };
+        let session = AgentSession {
+            id: "session-1".to_string(),
+            project_id: project.id.clone(),
+            project_path: Some(project.path.clone()),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "agent-branch".to_string(),
+            worktree_path: paths.worktrees_root.to_string_lossy().to_string(),
+            title: None,
+            status: SessionStatus::Detached,
+            created_at: now,
+            updated_at: now,
+        };
+        let (worker_tx, worker_rx) = mpsc::channel();
+        let mut app = App {
+            config: Config::default(),
+            paths,
+            bindings,
+            session_store,
+            projects: vec![project],
+            sessions: vec![session],
+            staged_files: Vec::new(),
+            unstaged_files: Vec::new(),
+            selected_left: 0,
+            right_section: RightSection::Unstaged,
+            files_index: 0,
+            commit_input: String::new(),
+            commit_input_cursor: 0,
+            commit_scroll: 0,
+            commit_generating: false,
+            left_width_pct: 20,
+            right_width_pct: 23,
+            focus: FocusPane::Left,
+            center_mode: CenterMode::Agent,
+            left_collapsed: false,
+            resize_mode: false,
+            help_scroll: None,
+            last_help_height: 0,
+            last_help_lines: 0,
+            fullscreen_agent: false,
+            status: StatusLine::new("ready"),
+            prompt: PromptState::None,
+            input_target: InputTarget::None,
+            worker_tx,
+            worker_rx,
+            providers: std::collections::HashMap::new(),
+            create_agent_in_flight: false,
+            last_pty_size: (0, 0),
+            last_diff_height: 0,
+            last_diff_visual_lines: 0,
+            theme: Theme::default_dark(),
+            tick_count: 0,
+            watched_worktree: Arc::new(Mutex::new(None::<PathBuf>)),
+            has_active_agent: Arc::new(AtomicBool::new(false)),
+            collapsed_projects: std::collections::HashSet::new(),
+            left_items_cache: Vec::new(),
+        };
+        app.rebuild_left_items();
+        app.selected_left = 1;
+        app
+    }
+
+    #[test]
+    fn rename_session_prompt_accepts_text_before_agent_input() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::RenameSession {
+            session_id: "session-1".to_string(),
+            input: "agent".to_string(),
+            cursor: 5,
+        };
+        app.input_target = InputTarget::Agent;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::RenameSession { input, cursor, .. } => {
+                assert_eq!(input, "agentx");
+                assert_eq!(*cursor, 6);
+            }
+            other => panic!("expected rename prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rename_session_text_ignores_printable_close_overlay_binding() {
+        let mut app = test_app(bindings_with_overrides(&[(Action::CloseOverlay, &["x"])]));
+        app.prompt = PromptState::RenameSession {
+            session_id: "session-1".to_string(),
+            input: "agent".to_string(),
+            cursor: 5,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::RenameSession { input, cursor, .. } => {
+                assert_eq!(input, "agentx");
+                assert_eq!(*cursor, 6);
+            }
+            other => panic!("expected rename prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rename_session_uses_custom_dialog_confirm_binding() {
+        let mut app = test_app(bindings_with_overrides(&[(Action::Confirm, &["tab"])]));
+        app.prompt = PromptState::RenameSession {
+            session_id: "session-1".to_string(),
+            input: "agent-branch".to_string(),
+            cursor: "agent-branch".len(),
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(
+            app.sessions[0].title.as_deref(),
+            Some("agent-branch"),
+            "custom confirm binding should apply the rename"
+        );
+    }
+
+    #[test]
+    fn open_rename_session_clears_interactive_target() {
+        let mut app = test_app(default_bindings());
+        app.input_target = InputTarget::Agent;
+        app.fullscreen_agent = true;
+
+        app.open_rename_session().unwrap();
+
+        assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
+        assert_eq!(app.input_target, InputTarget::None);
+        assert!(!app.fullscreen_agent);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -556,14 +556,13 @@ impl App {
     }
 
     pub(crate) fn open_rename_session(&mut self) -> Result<()> {
-        if let Some(session) = self.selected_session() {
-            let current_name = session
-                .title
-                .clone()
-                .unwrap_or_else(|| session.branch_name.clone());
+        if let Some(session) = self.selected_session().cloned() {
+            let current_name = session.title.unwrap_or_else(|| session.branch_name.clone());
             let cursor = current_name.len();
+            self.input_target = InputTarget::None;
+            self.fullscreen_agent = false;
             self.prompt = PromptState::RenameSession {
-                session_id: session.id.clone(),
+                session_id: session.id,
                 input: current_name,
                 cursor,
             };

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1857,20 +1857,18 @@ impl App {
             }
             PromptState::RenameSession { input, cursor, .. } => {
                 self.render_dim_overlay(frame);
-                let area = centered_rect(56, 14, frame.area());
+                let area = centered_rect_exact(56, 9, frame.area());
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                let [label_area, _, input_area, _, hint_area] = Layout::default()
+                let [label_area, input_area, hint_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Length(1),
-                        Constraint::Length(1),
                         Constraint::Length(3),
-                        Constraint::Length(1),
                         Constraint::Min(1),
                     ])
                     .areas(inner);
@@ -2038,6 +2036,14 @@ pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect 
         .split(vertical)[1]
 }
 
+pub(crate) fn centered_rect_exact(width: u16, height: u16, area: Rect) -> Rect {
+    let width = width.min(area.width.max(1));
+    let height = height.min(area.height.max(1));
+    let x = area.x + area.width.saturating_sub(width) / 2;
+    let y = area.y + area.height.saturating_sub(height) / 2;
+    Rect::new(x, y, width, height)
+}
+
 fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {
     if scrolled == 0 {
         return None;
@@ -2168,6 +2174,18 @@ mod tests {
     #[test]
     fn wrap_width_zero_returns_unchanged() {
         assert_eq!(wrap_text_at_width("abc", 0), "abc");
+    }
+
+    #[test]
+    fn centered_rect_exact_centers_requested_size() {
+        let area = Rect::new(0, 0, 100, 40);
+        assert_eq!(centered_rect_exact(56, 9, area), Rect::new(22, 15, 56, 9));
+    }
+
+    #[test]
+    fn centered_rect_exact_clamps_to_available_area() {
+        let area = Rect::new(0, 0, 40, 6);
+        assert_eq!(centered_rect_exact(56, 9, area), area);
     }
 
     // ── Unit tests for cursor_pos_in_wrapped ───────────────────────


### PR DESCRIPTION
## Summary
- fix rename-agent input routing so the modal receives text even when interactive agent mode was active
- honor dialog bindings for rename confirm/cancel and prevent printable overlay shortcuts from stealing text input
- render the rename modal with a compact fixed size that clamps to short terminals so it stays visible

## Why
The rename flow had two usability regressions:
1. prompt input could lose priority to interactive/global key handling
2. the modal used percentage-based sizing that could keep a small dialog off-screen on shorter terminal heights

## Impact
Users can type into the rename dialog reliably, custom keybindings remain consistent with the UI hints, and the modal stays visible in shorter terminal windows.

## Root cause
The rename dialog lived on the prompt path, but key routing still let other input modes and global overlay bindings preempt it. Separately, the modal height was derived from viewport percentages despite being a very small dialog.

## Validation
- `cargo fmt --check`
- `cargo test app::render -- --nocapture`
- `cargo test`
