### PR TITLE
Restore mouse interactions across panes

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1425,7 +1425,7 @@ impl App {
             if index < self.left_items().len() {
                 return Some(MouseTarget::LeftRow(index));
             }
-            return Some(MouseTarget::LeftRow(self.selected_left));
+            return Some(MouseTarget::LeftPane);
         }
 
         if contains_point(self.mouse_layout.left, column, row) {
@@ -2446,6 +2446,23 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 2));
 
         assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+        assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_double_click_left_pane_empty_space_does_not_activate_selected_row() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 9));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 9));
+
+        assert_eq!(app.focus, FocusPane::Left);
+        assert!(!app.fullscreen_agent);
+        assert_eq!(app.input_target, InputTarget::None);
         assert!(matches!(app.center_mode, CenterMode::Agent));
         assert_eq!(app.selected_left, 1);
     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -357,29 +357,7 @@ impl App {
         let in_diff = matches!(self.center_mode, CenterMode::Diff { .. });
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Center) {
             match action {
-                Action::FocusAgent if !in_diff => {
-                    if self.selected_session().is_some()
-                        && self
-                            .selected_session()
-                            .map(|s| self.providers.contains_key(&s.id))
-                            .unwrap_or(false)
-                    {
-                        self.reset_pty_scrollback();
-                        self.input_target = InputTarget::Agent;
-                        self.fullscreen_agent = true;
-                        let exit_key = self.bindings.label_for(Action::ExitInteractive);
-                        self.set_info(format!(
-                            "Interactive mode. Keys forwarded to agent. {exit_key} exits."
-                        ));
-                    } else if self.selected_session().is_some() {
-                        self.reconnect_selected_session()?;
-                    } else {
-                        let n = self.bindings.label_for(Action::NewAgent);
-                        self.set_error(format!(
-                            "No agent selected. Press \"{n}\" to create a new one."
-                        ));
-                    }
-                }
+                Action::FocusAgent if !in_diff => self.activate_center_agent()?,
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.
@@ -1602,6 +1580,40 @@ impl App {
         }
     }
 
+    fn activate_center_agent(&mut self) -> Result<()> {
+        if !matches!(self.center_mode, CenterMode::Agent) {
+            return Ok(());
+        }
+        if self.selected_session().is_some()
+            && self
+                .selected_session()
+                .map(|s| self.providers.contains_key(&s.id))
+                .unwrap_or(false)
+        {
+            self.reset_pty_scrollback();
+            self.input_target = InputTarget::Agent;
+            self.fullscreen_agent = true;
+            let exit_key = self.bindings.label_for(Action::ExitInteractive);
+            self.set_info(format!(
+                "Interactive mode. Keys forwarded to agent. {exit_key} exits."
+            ));
+        } else if self.selected_session().is_some() {
+            self.reconnect_selected_session()?;
+        } else {
+            let n = self.bindings.label_for(Action::NewAgent);
+            self.set_error(format!(
+                "No agent selected. Press \"{n}\" to create a new one."
+            ));
+        }
+        Ok(())
+    }
+
+    fn activate_center_agent_from_mouse(&mut self) {
+        if let Err(err) = self.activate_center_agent() {
+            self.set_error(format!("Mouse activation failed: {err}"));
+        }
+    }
+
     fn set_file_selection(&mut self, section: RightSection, index: Option<usize>) {
         self.focus = FocusPane::Files;
         self.input_target = InputTarget::None;
@@ -1827,7 +1839,11 @@ impl App {
                         }
                     }
                     Some(MouseTarget::Center) => {
+                        let double_click = self.register_mouse_click(MouseClickTarget::CenterPane);
                         self.focus = FocusPane::Center;
+                        if double_click {
+                            self.activate_center_agent_from_mouse();
+                        }
                     }
                     Some(MouseTarget::FilesPane) => {
                         self.focus = FocusPane::Files;
@@ -1913,6 +1929,7 @@ mod tests {
     use crate::config::{Config, DuxPaths};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
     use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
+    use crate::pty::PtyClient;
     use crate::statusline::StatusLine;
     use crate::storage::SessionStore;
     use crate::theme::Theme;
@@ -2363,6 +2380,34 @@ mod tests {
         assert_eq!(app.focus, FocusPane::Center);
         assert!(matches!(app.center_mode, CenterMode::Agent));
         assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_double_click_center_agent_pane_opens_fullscreen() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.center_mode = CenterMode::Agent;
+        app.focus = FocusPane::Center;
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn(
+                "sh",
+                &["-c".to_string(), "printf ready; sleep 0.2".to_string()],
+                std::path::Path::new("."),
+                10,
+                10,
+                100,
+            )
+            .expect("spawn pty"),
+        );
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+
+        assert_eq!(app.focus, FocusPane::Center);
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert!(app.fullscreen_agent);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1876,8 +1876,15 @@ impl App {
                         self.set_file_selection(RightSection::CommitInput, None);
                     }
                     Some(MouseTarget::CommitText) => {
-                        self.engage_commit_input();
-                        self.set_commit_cursor_from_mouse(mouse.column, mouse.row);
+                        let ready_to_edit = self.focus == FocusPane::Files
+                            && self.right_section == RightSection::CommitInput
+                            && self.input_target != InputTarget::CommitMessage;
+                        if ready_to_edit || self.input_target == InputTarget::CommitMessage {
+                            self.engage_commit_input();
+                            self.set_commit_cursor_from_mouse(mouse.column, mouse.row);
+                        } else {
+                            self.set_file_selection(RightSection::CommitInput, None);
+                        }
                     }
                     None => {}
                 }
@@ -2569,7 +2576,7 @@ mod tests {
     }
 
     #[test]
-    fn mouse_click_commit_text_engages_commit_input() {
+    fn mouse_click_commit_text_first_click_only_focuses_commit_input() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
         app.commit_input = "hello world".to_string();
@@ -2579,18 +2586,21 @@ mod tests {
 
         assert_eq!(app.focus, FocusPane::Files);
         assert_eq!(app.right_section, RightSection::CommitInput);
-        assert_eq!(app.input_target, InputTarget::CommitMessage);
+        assert_eq!(app.input_target, InputTarget::None);
     }
 
     #[test]
-    fn mouse_click_commit_text_moves_cursor() {
+    fn mouse_click_commit_text_second_click_enters_edit_mode_and_moves_cursor() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
         app.commit_input = "abc\ndef".to_string();
         app.commit_input_cursor = 0;
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 16));
+        assert_eq!(app.input_target, InputTarget::None);
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 16));
 
+        assert_eq!(app.input_target, InputTarget::CommitMessage);
         assert!(app.commit_input_cursor > 0);
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,4 +1,133 @@
 use super::*;
+use alacritty_terminal::term::TermMode;
+
+const MOUSE_WHEEL_LINES: usize = 3;
+const MIN_LEFT_WIDTH_PCT: u16 = 14;
+const MAX_LEFT_WIDTH_PCT: u16 = 38;
+const MIN_RIGHT_WIDTH_PCT: u16 = 14;
+const MAX_RIGHT_WIDTH_PCT: u16 = 50;
+const MIN_CENTER_WIDTH_PCT: u16 = 20;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentWheelRoute {
+    HostScrollback,
+    ForwardMouse,
+    ForwardAlternateScroll,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MouseTarget {
+    LeftRow(usize),
+    Center,
+    UnstagedFile(Option<usize>),
+    StagedFile(Option<usize>),
+    CommitInput,
+}
+
+fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
+    rect.width > 0
+        && rect.height > 0
+        && column >= rect.x
+        && column < rect.x + rect.width
+        && row >= rect.y
+        && row < rect.y + rect.height
+}
+
+fn clamp_left_width_pct(left_width_pct: u16, right_width_pct: u16) -> u16 {
+    let max_left = MAX_LEFT_WIDTH_PCT.min(100 - MIN_CENTER_WIDTH_PCT - right_width_pct);
+    left_width_pct.clamp(MIN_LEFT_WIDTH_PCT, max_left.max(MIN_LEFT_WIDTH_PCT))
+}
+
+fn clamp_right_width_pct(right_width_pct: u16, left_width_pct: u16) -> u16 {
+    let max_right = MAX_RIGHT_WIDTH_PCT.min(100 - MIN_CENTER_WIDTH_PCT - left_width_pct);
+    right_width_pct.clamp(MIN_RIGHT_WIDTH_PCT, max_right.max(MIN_RIGHT_WIDTH_PCT))
+}
+
+fn pct_from_columns(columns: u16, total_width: u16) -> u16 {
+    if total_width == 0 {
+        return 0;
+    }
+
+    (((u32::from(columns) * 100) + (u32::from(total_width) / 2)) / u32::from(total_width)) as u16
+}
+
+fn encode_cursor_key(code: KeyCode, term_mode: TermMode) -> &'static [u8] {
+    let application_cursor = term_mode.contains(TermMode::APP_CURSOR);
+    match (code, application_cursor) {
+        (KeyCode::Up, true) => b"\x1bOA",
+        (KeyCode::Down, true) => b"\x1bOB",
+        (KeyCode::Right, true) => b"\x1bOC",
+        (KeyCode::Left, true) => b"\x1bOD",
+        (KeyCode::Up, false) => b"\x1b[A",
+        (KeyCode::Down, false) => b"\x1b[B",
+        (KeyCode::Right, false) => b"\x1b[C",
+        (KeyCode::Left, false) => b"\x1b[D",
+        _ => b"",
+    }
+}
+
+fn agent_wheel_route(term_mode: TermMode) -> AgentWheelRoute {
+    let mouse_reporting = term_mode
+        .intersects(TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION);
+
+    if mouse_reporting {
+        AgentWheelRoute::ForwardMouse
+    } else if term_mode.contains(TermMode::ALT_SCREEN)
+        && term_mode.contains(TermMode::ALTERNATE_SCROLL)
+    {
+        AgentWheelRoute::ForwardAlternateScroll
+    } else {
+        AgentWheelRoute::HostScrollback
+    }
+}
+
+fn push_mouse_codepoint(bytes: &mut Vec<u8>, value: u32) -> Option<()> {
+    let ch = char::from_u32(value)?;
+    let mut buf = [0u8; 4];
+    bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+    Some(())
+}
+
+fn encode_mouse_scroll(mouse: MouseEvent, area: Rect, term_mode: TermMode) -> Option<Vec<u8>> {
+    let mut cb = match mouse.kind {
+        MouseEventKind::ScrollUp => 64u16,
+        MouseEventKind::ScrollDown => 65u16,
+        MouseEventKind::ScrollLeft => 66u16,
+        MouseEventKind::ScrollRight => 67u16,
+        _ => return None,
+    };
+
+    if mouse.modifiers.contains(KeyModifiers::SHIFT) {
+        cb += 4;
+    }
+    if mouse.modifiers.contains(KeyModifiers::ALT) {
+        cb += 8;
+    }
+    if mouse.modifiers.contains(KeyModifiers::CONTROL) {
+        cb += 16;
+    }
+
+    let column = u32::from(mouse.column.saturating_sub(area.x).saturating_add(1));
+    let row = u32::from(mouse.row.saturating_sub(area.y).saturating_add(1));
+
+    if term_mode.contains(TermMode::SGR_MOUSE) {
+        return Some(format!("\x1b[<{cb};{column};{row}M").into_bytes());
+    }
+
+    if term_mode.contains(TermMode::UTF8_MOUSE) {
+        let mut bytes = Vec::with_capacity(16);
+        bytes.extend_from_slice(b"\x1b[M");
+        push_mouse_codepoint(&mut bytes, u32::from(cb) + 32)?;
+        push_mouse_codepoint(&mut bytes, column + 32)?;
+        push_mouse_codepoint(&mut bytes, row + 32)?;
+        return Some(bytes);
+    }
+
+    let cb = u8::try_from(cb + 32).ok()?;
+    let column = u8::try_from(column + 32).ok()?;
+    let row = u8::try_from(row + 32).ok()?;
+    Some(vec![0x1b, b'[', b'M', cb, column, row])
+}
 
 impl App {
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
@@ -708,16 +837,19 @@ impl App {
                 let _ = provider.write_bytes(b"\t");
             }
             KeyCode::Up => {
-                let _ = provider.write_bytes(b"\x1b[A");
+                let _ = provider.write_bytes(encode_cursor_key(KeyCode::Up, provider.term_mode()));
             }
             KeyCode::Down => {
-                let _ = provider.write_bytes(b"\x1b[B");
+                let _ =
+                    provider.write_bytes(encode_cursor_key(KeyCode::Down, provider.term_mode()));
             }
             KeyCode::Right => {
-                let _ = provider.write_bytes(b"\x1b[C");
+                let _ =
+                    provider.write_bytes(encode_cursor_key(KeyCode::Right, provider.term_mode()));
             }
             KeyCode::Left => {
-                let _ = provider.write_bytes(b"\x1b[D");
+                let _ =
+                    provider.write_bytes(encode_cursor_key(KeyCode::Left, provider.term_mode()));
             }
             KeyCode::Home => {
                 let _ = provider.write_bytes(b"\x1b[H");
@@ -1312,25 +1444,235 @@ impl App {
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Resize) {
             if self.focus == FocusPane::Files {
                 match action {
-                    Action::ResizeShrink => {
-                        self.right_width_pct = self.right_width_pct.saturating_add(2).min(50)
-                    }
+                    Action::ResizeShrink => self.set_right_width_pct(self.right_width_pct + 2),
                     Action::ResizeGrow => {
-                        self.right_width_pct = self.right_width_pct.saturating_sub(2).max(14)
+                        self.set_right_width_pct(self.right_width_pct.saturating_sub(2))
                     }
                     _ => {}
                 }
             } else {
                 match action {
                     Action::ResizeShrink => {
-                        self.left_width_pct = self.left_width_pct.saturating_sub(2).max(14)
+                        self.set_left_width_pct(self.left_width_pct.saturating_sub(2))
                     }
-                    Action::ResizeGrow => {
-                        self.left_width_pct = self.left_width_pct.saturating_add(2).min(38)
-                    }
+                    Action::ResizeGrow => self.set_left_width_pct(self.left_width_pct + 2),
                     _ => {}
                 }
             }
+        }
+    }
+
+    fn set_left_width_pct(&mut self, left_width_pct: u16) {
+        self.left_width_pct = clamp_left_width_pct(left_width_pct, self.right_width_pct);
+        self.right_width_pct = clamp_right_width_pct(self.right_width_pct, self.left_width_pct);
+    }
+
+    fn set_right_width_pct(&mut self, right_width_pct: u16) {
+        self.right_width_pct = clamp_right_width_pct(right_width_pct, self.left_width_pct);
+        self.left_width_pct = clamp_left_width_pct(self.left_width_pct, self.right_width_pct);
+    }
+
+    fn mouse_target(&self, column: u16, row: u16) -> Option<MouseTarget> {
+        if self.fullscreen_agent {
+            return self
+                .mouse_layout
+                .agent_term
+                .filter(|rect| contains_point(*rect, column, row))
+                .map(|_| MouseTarget::Center);
+        }
+
+        if contains_point(self.mouse_layout.left_list, column, row) {
+            let index = usize::from(row.saturating_sub(self.mouse_layout.left_list.y));
+            if index < self.left_items().len() {
+                return Some(MouseTarget::LeftRow(index));
+            }
+            return Some(MouseTarget::LeftRow(self.selected_left));
+        }
+
+        if let Some(area) = self.mouse_layout.unstaged_list
+            && contains_point(area, column, row)
+        {
+            let index = usize::from(row.saturating_sub(area.y));
+            let file_index = (index < self.unstaged_files.len()).then_some(index);
+            return Some(MouseTarget::UnstagedFile(file_index));
+        }
+
+        if let Some(area) = self.mouse_layout.staged_list
+            && contains_point(area, column, row)
+        {
+            let index = usize::from(row.saturating_sub(area.y));
+            let file_index = (index < self.staged_files.len()).then_some(index);
+            return Some(MouseTarget::StagedFile(file_index));
+        }
+
+        if let Some(area) = self.mouse_layout.commit_area
+            && contains_point(area, column, row)
+        {
+            return Some(MouseTarget::CommitInput);
+        }
+
+        if contains_point(self.mouse_layout.center, column, row) {
+            return Some(MouseTarget::Center);
+        }
+
+        None
+    }
+
+    fn resize_drag_at_mouse(&self, column: u16, row: u16) -> Option<ResizeDragState> {
+        let body = self.mouse_layout.body;
+        if !contains_point(body, column, row) {
+            return None;
+        }
+
+        let left_edge = self.mouse_layout.left.x + self.mouse_layout.left.width.saturating_sub(1);
+        let center_left = self.mouse_layout.center.x;
+        let center_right =
+            self.mouse_layout.center.x + self.mouse_layout.center.width.saturating_sub(1);
+        let right_left = self.mouse_layout.right.x;
+
+        if !self.left_collapsed && (column == left_edge || column == center_left) {
+            return Some(ResizeDragState::LeftDivider);
+        }
+
+        if column == center_right || column == right_left {
+            return Some(ResizeDragState::RightDivider);
+        }
+
+        None
+    }
+
+    fn set_left_selection(&mut self, index: usize) {
+        if index >= self.left_items().len() {
+            return;
+        }
+        self.focus = FocusPane::Left;
+        self.input_target = InputTarget::None;
+        self.fullscreen_agent = false;
+        if self.selected_left != index {
+            self.selected_left = index;
+            self.reload_changed_files();
+        }
+    }
+
+    fn set_file_selection(&mut self, section: RightSection, index: Option<usize>) {
+        self.focus = FocusPane::Files;
+        self.input_target = InputTarget::None;
+        self.fullscreen_agent = false;
+        self.right_section = section;
+        if let Some(index) = index {
+            self.files_index = index;
+        }
+        self.clamp_files_cursor();
+    }
+
+    fn scroll_file_selection(&mut self, section: RightSection, down: bool) {
+        self.set_file_selection(section, Some(self.files_index));
+        if self.right_section == RightSection::CommitInput {
+            return;
+        }
+
+        let len = self.current_files_len();
+        if len == 0 {
+            return;
+        }
+
+        if down {
+            if self.files_index + 1 < len {
+                self.files_index += 1;
+            }
+        } else if self.files_index > 0 {
+            self.files_index -= 1;
+        }
+    }
+
+    fn handle_left_mouse_wheel(&mut self, down: bool, column: u16, row: u16) {
+        let target_index = match self.mouse_target(column, row) {
+            Some(MouseTarget::LeftRow(index)) => index,
+            _ => self.selected_left,
+        };
+        self.set_left_selection(target_index);
+
+        if down {
+            if self.selected_left + 1 < self.left_items().len() {
+                self.selected_left += 1;
+                self.reload_changed_files();
+            }
+        } else if self.selected_left > 0 {
+            self.selected_left -= 1;
+            self.reload_changed_files();
+        }
+    }
+
+    fn handle_center_mouse_wheel(&mut self, mouse: MouseEvent) {
+        self.focus = FocusPane::Center;
+        if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+            let delta = MOUSE_WHEEL_LINES as u16;
+            if matches!(mouse.kind, MouseEventKind::ScrollDown) {
+                let max_scroll = self
+                    .last_diff_visual_lines
+                    .saturating_sub(self.last_diff_height.max(1));
+                *scroll = (*scroll + delta).min(max_scroll);
+            } else if matches!(mouse.kind, MouseEventKind::ScrollUp) {
+                *scroll = scroll.saturating_sub(delta);
+            }
+            return;
+        }
+
+        let Some(area) = self.mouse_layout.agent_term else {
+            return;
+        };
+        let Some(session_id) = self.selected_session().map(|session| session.id.clone()) else {
+            return;
+        };
+        let Some(provider) = self.providers.get(&session_id) else {
+            return;
+        };
+
+        match agent_wheel_route(provider.term_mode()) {
+            AgentWheelRoute::HostScrollback => {
+                provider.scroll(
+                    matches!(mouse.kind, MouseEventKind::ScrollUp),
+                    MOUSE_WHEEL_LINES,
+                );
+            }
+            AgentWheelRoute::ForwardMouse => {
+                provider.set_scrollback(0);
+                if let Some(bytes) = encode_mouse_scroll(mouse, area, provider.term_mode()) {
+                    let _ = provider.write_bytes(&bytes);
+                }
+            }
+            AgentWheelRoute::ForwardAlternateScroll => {
+                provider.set_scrollback(0);
+                let code = match mouse.kind {
+                    MouseEventKind::ScrollUp => KeyCode::Up,
+                    MouseEventKind::ScrollDown => KeyCode::Down,
+                    _ => return,
+                };
+                let _ = provider.write_bytes(encode_cursor_key(code, provider.term_mode()));
+            }
+        }
+    }
+
+    fn update_dragged_widths(&mut self, column: u16) {
+        let body = self.mouse_layout.body;
+        if body.width == 0 {
+            return;
+        }
+
+        let body_right = body.x + body.width;
+        match self.mouse_drag {
+            Some(ResizeDragState::LeftDivider) => {
+                let columns = column
+                    .saturating_sub(body.x)
+                    .saturating_add(1)
+                    .clamp(1, body.width);
+                self.set_left_width_pct(pct_from_columns(columns, body.width));
+            }
+            Some(ResizeDragState::RightDivider) => {
+                let columns = body_right.saturating_sub(column).clamp(1, body.width);
+                self.set_right_width_pct(pct_from_columns(columns, body.width));
+            }
+            None => {}
         }
     }
 
@@ -1345,54 +1687,86 @@ impl App {
     }
 
     pub(crate) fn handle_mouse(&mut self, mouse: MouseEvent) {
-        match mouse.kind {
-            MouseEventKind::Down(_) => {
-                self.set_info(
-                    format!(
-                        "Mouse support is available for wheel navigation; resize has a keyboard fallback via {}.",
-                        self.bindings.label_for(Action::ToggleResizeMode)
-                    ),
-                );
+        if !matches!(self.prompt, PromptState::None) {
+            return;
+        }
+
+        if let Some(ref mut scroll) = self.help_scroll {
+            let max_help = self
+                .last_help_lines
+                .saturating_sub(self.last_help_height.max(1));
+            match mouse.kind {
+                MouseEventKind::ScrollDown => {
+                    *scroll = (*scroll + MOUSE_WHEEL_LINES as u16).min(max_help)
+                }
+                MouseEventKind::ScrollUp => {
+                    *scroll = scroll.saturating_sub(MOUSE_WHEEL_LINES as u16)
+                }
+                _ => {}
             }
-            MouseEventKind::ScrollDown => match self.focus {
-                FocusPane::Left => {
-                    let items = self.left_items();
-                    if self.selected_left + 1 < items.len() {
-                        self.selected_left += 1;
-                        self.reload_changed_files();
-                    }
+            return;
+        }
+
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(drag) = self.resize_drag_at_mouse(mouse.column, mouse.row) {
+                    self.mouse_drag = Some(drag);
+                    self.update_dragged_widths(mouse.column);
+                    return;
                 }
-                FocusPane::Center => {
-                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
-                        let max_scroll = self
-                            .last_diff_visual_lines
-                            .saturating_sub(self.last_diff_height.max(1));
-                        *scroll = (*scroll + 3).min(max_scroll);
+
+                match self.mouse_target(mouse.column, mouse.row) {
+                    Some(MouseTarget::LeftRow(index)) => self.set_left_selection(index),
+                    Some(MouseTarget::Center) => {
+                        self.focus = FocusPane::Center;
                     }
-                }
-                FocusPane::Files => {
-                    if self.files_index + 1 < self.current_files_len() {
-                        self.files_index += 1;
+                    Some(MouseTarget::UnstagedFile(index)) => {
+                        self.set_file_selection(RightSection::Unstaged, index);
                     }
+                    Some(MouseTarget::StagedFile(index)) => {
+                        self.set_file_selection(RightSection::Staged, index);
+                    }
+                    Some(MouseTarget::CommitInput) => {
+                        self.set_file_selection(RightSection::CommitInput, None);
+                    }
+                    None => {}
                 }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self.mouse_drag.is_some() {
+                    self.update_dragged_widths(mouse.column);
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if self.mouse_drag.take().is_some() {
+                    self.persist_pane_widths();
+                }
+            }
+            MouseEventKind::ScrollDown => match self.mouse_target(mouse.column, mouse.row) {
+                Some(MouseTarget::LeftRow(_)) => {
+                    self.handle_left_mouse_wheel(true, mouse.column, mouse.row)
+                }
+                Some(MouseTarget::Center) => self.handle_center_mouse_wheel(mouse),
+                Some(MouseTarget::UnstagedFile(_)) => {
+                    self.scroll_file_selection(RightSection::Unstaged, true)
+                }
+                Some(MouseTarget::StagedFile(_)) => {
+                    self.scroll_file_selection(RightSection::Staged, true)
+                }
+                _ => {}
             },
-            MouseEventKind::ScrollUp => match self.focus {
-                FocusPane::Left => {
-                    if self.selected_left > 0 {
-                        self.selected_left -= 1;
-                        self.reload_changed_files();
-                    }
+            MouseEventKind::ScrollUp => match self.mouse_target(mouse.column, mouse.row) {
+                Some(MouseTarget::LeftRow(_)) => {
+                    self.handle_left_mouse_wheel(false, mouse.column, mouse.row)
                 }
-                FocusPane::Center => {
-                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
-                        *scroll = scroll.saturating_sub(3);
-                    }
+                Some(MouseTarget::Center) => self.handle_center_mouse_wheel(mouse),
+                Some(MouseTarget::UnstagedFile(_)) => {
+                    self.scroll_file_selection(RightSection::Unstaged, false)
                 }
-                FocusPane::Files => {
-                    if self.files_index > 0 {
-                        self.files_index -= 1;
-                    }
+                Some(MouseTarget::StagedFile(_)) => {
+                    self.scroll_file_selection(RightSection::Staged, false)
                 }
+                _ => {}
             },
             _ => {}
         }
@@ -1405,15 +1779,21 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex, mpsc};
 
-    use crate::app::{App, CenterMode, FocusPane, InputTarget, PromptState, RightSection};
+    use crate::app::{
+        App, CenterMode, FocusPane, InputTarget, MouseLayoutState, PromptState, RightSection,
+    };
     use crate::config::{Config, DuxPaths};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
-    use crate::model::{AgentSession, Project, ProviderKind, SessionStatus};
+    use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
     use crate::statusline::StatusLine;
     use crate::storage::SessionStore;
     use crate::theme::Theme;
+    use alacritty_terminal::term::TermMode;
     use chrono::Utc;
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::layout::Rect;
+    use ratatui::text::Line;
     use tempfile::tempdir;
 
     fn default_bindings() -> RuntimeBindings {
@@ -1527,10 +1907,35 @@ mod tests {
             has_active_agent: Arc::new(AtomicBool::new(false)),
             collapsed_projects: std::collections::HashSet::new(),
             left_items_cache: Vec::new(),
+            mouse_layout: MouseLayoutState::default(),
+            mouse_drag: None,
         };
         app.rebuild_left_items();
         app.selected_left = 1;
         app
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn install_mouse_layout(app: &mut App) {
+        app.mouse_layout = MouseLayoutState {
+            body: Rect::new(0, 0, 100, 20),
+            left: Rect::new(0, 0, 20, 20),
+            center: Rect::new(20, 0, 57, 20),
+            right: Rect::new(77, 0, 23, 20),
+            left_list: Rect::new(1, 1, 18, 10),
+            agent_term: Some(Rect::new(21, 1, 55, 16)),
+            unstaged_list: Some(Rect::new(78, 1, 21, 8)),
+            staged_list: Some(Rect::new(78, 9, 21, 5)),
+            commit_area: Some(Rect::new(77, 14, 23, 6)),
+        };
     }
 
     #[test]
@@ -1706,6 +2111,107 @@ mod tests {
         assert_eq!(
             bindings.lookup(&key, BindingScope::Center),
             Some(Action::ScrollLineDown),
+        );
+    }
+
+    #[test]
+    fn mouse_click_left_row_focuses_and_selects_it() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
+
+        assert_eq!(app.focus, FocusPane::Left);
+        assert_eq!(app.selected_left, 0);
+    }
+
+    #[test]
+    fn mouse_click_right_row_focuses_and_selects_unstaged_file() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.unstaged_files = vec![
+            ChangedFile {
+                path: "a.txt".into(),
+                status: "M".into(),
+                additions: 1,
+                deletions: 0,
+            },
+            ChangedFile {
+                path: "b.txt".into(),
+                status: "M".into(),
+                additions: 2,
+                deletions: 1,
+            },
+        ];
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 2));
+
+        assert_eq!(app.focus, FocusPane::Files);
+        assert_eq!(app.right_section, RightSection::Unstaged);
+        assert_eq!(app.files_index, 1);
+    }
+
+    #[test]
+    fn mouse_wheel_left_pane_advances_selection_under_cursor() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.focus = FocusPane::Center;
+        app.selected_left = 0;
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, 2, 1));
+
+        assert_eq!(app.focus, FocusPane::Left);
+        assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_wheel_center_diff_scrolls_lines() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.center_mode = CenterMode::Diff {
+            lines: vec![Line::from("one"), Line::from("two"), Line::from("three")],
+            scroll: 0,
+        };
+        app.last_diff_height = 2;
+        app.last_diff_visual_lines = 10;
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, 30, 5));
+
+        match app.center_mode {
+            CenterMode::Diff { scroll, .. } => assert_eq!(scroll, 3),
+            _ => panic!("expected diff mode"),
+        }
+    }
+
+    #[test]
+    fn mouse_drag_left_divider_updates_widths() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 19, 5));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 30, 5));
+
+        assert!(app.left_width_pct > 20);
+        assert!(app.left_width_pct + app.right_width_pct <= 80);
+    }
+
+    #[test]
+    fn agent_wheel_route_prefers_mouse_reporting_over_host_scrollback() {
+        let mode = TermMode::ALT_SCREEN | TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
+        assert_eq!(
+            super::agent_wheel_route(mode),
+            super::AgentWheelRoute::ForwardMouse
+        );
+    }
+
+    #[test]
+    fn agent_wheel_route_uses_alternate_scroll_for_alt_screen_apps() {
+        let mode = TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL;
+        assert_eq!(
+            super::agent_wheel_route(mode),
+            super::AgentWheelRoute::ForwardAlternateScroll
         );
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -8,6 +8,7 @@ const MAX_LEFT_WIDTH_PCT: u16 = 38;
 const MIN_RIGHT_WIDTH_PCT: u16 = 14;
 const MAX_RIGHT_WIDTH_PCT: u16 = 50;
 const MIN_CENTER_WIDTH_PCT: u16 = 20;
+const DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum AgentWheelRoute {
@@ -310,56 +311,7 @@ impl App {
                         self.reload_changed_files();
                     }
                 }
-                Action::FocusAgent => match self.left_items().get(self.selected_left) {
-                    Some(LeftItem::Project(project_index)) => {
-                        let project_id = self.projects[*project_index].id.clone();
-                        let has_sessions = self.sessions.iter().any(|s| s.project_id == project_id);
-                        if has_sessions {
-                            if self.collapsed_projects.contains(&project_id) {
-                                self.collapsed_projects.remove(&project_id);
-                                self.rebuild_left_items();
-                            }
-                            if let Some(pos) =
-                                    self.left_items().iter().position(|item| {
-                                        matches!(item, LeftItem::Session(si) if self.sessions[*si].project_id == project_id)
-                                    })
-                                {
-                                    self.selected_left = pos;
-                                    self.center_mode = CenterMode::Agent;
-                                    self.focus = FocusPane::Center;
-                                    self.reload_changed_files();
-                                    if self
-                                        .selected_session()
-                                        .map(|s| self.providers.contains_key(&s.id))
-                                        .unwrap_or(false)
-                                    {
-                                        self.input_target = InputTarget::Agent;
-                                        self.fullscreen_agent = true;
-                                    } else if self.selected_session().is_some() {
-                                        self.reconnect_selected_session()?;
-                                    }
-                                }
-                        } else {
-                            self.create_agent_for_selected_project()?;
-                        }
-                    }
-                    Some(LeftItem::Session(_)) => {
-                        self.center_mode = CenterMode::Agent;
-                        self.focus = FocusPane::Center;
-                        self.reload_changed_files();
-                        if self
-                            .selected_session()
-                            .map(|s| self.providers.contains_key(&s.id))
-                            .unwrap_or(false)
-                        {
-                            self.input_target = InputTarget::Agent;
-                            self.fullscreen_agent = true;
-                        } else if self.selected_session().is_some() {
-                            self.reconnect_selected_session()?;
-                        }
-                    }
-                    None => {}
-                },
+                Action::FocusAgent => self.activate_selected_left_item()?,
                 Action::OpenProjectBrowser => {
                     self.open_project_browser()?;
                 }
@@ -1578,6 +1530,78 @@ impl App {
         }
     }
 
+    fn register_mouse_click(&mut self, target: MouseClickTarget) -> bool {
+        let now = Instant::now();
+        if let Some(last) = self.last_mouse_click
+            && last.target == target
+            && now.duration_since(last.at) <= DOUBLE_CLICK_THRESHOLD
+        {
+            self.last_mouse_click = None;
+            return true;
+        }
+
+        self.last_mouse_click = Some(RecentMouseClick { target, at: now });
+        false
+    }
+
+    fn activate_selected_left_item(&mut self) -> Result<()> {
+        match self.left_items().get(self.selected_left) {
+            Some(LeftItem::Project(project_index)) => {
+                let project_id = self.projects[*project_index].id.clone();
+                let has_sessions = self.sessions.iter().any(|s| s.project_id == project_id);
+                if has_sessions {
+                    if self.collapsed_projects.contains(&project_id) {
+                        self.collapsed_projects.remove(&project_id);
+                        self.rebuild_left_items();
+                    }
+                    if let Some(pos) = self.left_items().iter().position(|item| {
+                        matches!(item, LeftItem::Session(si) if self.sessions[*si].project_id == project_id)
+                    }) {
+                        self.selected_left = pos;
+                        self.center_mode = CenterMode::Agent;
+                        self.focus = FocusPane::Center;
+                        self.reload_changed_files();
+                        if self
+                            .selected_session()
+                            .map(|s| self.providers.contains_key(&s.id))
+                            .unwrap_or(false)
+                        {
+                            self.input_target = InputTarget::Agent;
+                            self.fullscreen_agent = true;
+                        } else if self.selected_session().is_some() {
+                            self.reconnect_selected_session()?;
+                        }
+                    }
+                } else {
+                    self.create_agent_for_selected_project()?;
+                }
+            }
+            Some(LeftItem::Session(_)) => {
+                self.center_mode = CenterMode::Agent;
+                self.focus = FocusPane::Center;
+                self.reload_changed_files();
+                if self
+                    .selected_session()
+                    .map(|s| self.providers.contains_key(&s.id))
+                    .unwrap_or(false)
+                {
+                    self.input_target = InputTarget::Agent;
+                    self.fullscreen_agent = true;
+                } else if self.selected_session().is_some() {
+                    self.reconnect_selected_session()?;
+                }
+            }
+            None => {}
+        }
+        Ok(())
+    }
+
+    fn activate_selected_left_item_from_mouse(&mut self) {
+        if let Err(err) = self.activate_selected_left_item() {
+            self.set_error(format!("Mouse activation failed: {err}"));
+        }
+    }
+
     fn set_file_selection(&mut self, section: RightSection, index: Option<usize>) {
         self.focus = FocusPane::Files;
         self.input_target = InputTarget::None;
@@ -1794,7 +1818,14 @@ impl App {
                         self.input_target = InputTarget::None;
                         self.fullscreen_agent = false;
                     }
-                    Some(MouseTarget::LeftRow(index)) => self.set_left_selection(index),
+                    Some(MouseTarget::LeftRow(index)) => {
+                        let double_click =
+                            self.register_mouse_click(MouseClickTarget::LeftRow(index));
+                        self.set_left_selection(index);
+                        if double_click {
+                            self.activate_selected_left_item_from_mouse();
+                        }
+                    }
                     Some(MouseTarget::Center) => {
                         self.focus = FocusPane::Center;
                     }
@@ -2006,6 +2037,7 @@ mod tests {
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
             mouse_drag: None,
+            last_mouse_click: None,
         };
         app.rebuild_left_items();
         app.selected_left = 1;
@@ -2301,6 +2333,36 @@ mod tests {
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
         assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
+    fn mouse_double_click_project_row_activates_like_enter() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 0;
+        app.focus = FocusPane::Left;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
+
+        assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+        assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_double_click_session_row_activates_like_enter() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.focus = FocusPane::Left;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 2));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 2));
+
+        assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+        assert_eq!(app.selected_left, 1);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -18,8 +18,10 @@ enum AgentWheelRoute {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MouseTarget {
+    LeftPane,
     LeftRow(usize),
     Center,
+    FilesPane,
     UnstagedFile(Option<usize>),
     StagedFile(Option<usize>),
     CommitChrome,
@@ -1493,6 +1495,10 @@ impl App {
             return Some(MouseTarget::LeftRow(self.selected_left));
         }
 
+        if contains_point(self.mouse_layout.left, column, row) {
+            return Some(MouseTarget::LeftPane);
+        }
+
         if let Some(area) = self.mouse_layout.unstaged_list
             && contains_point(area, column, row)
         {
@@ -1520,6 +1526,10 @@ impl App {
                 return Some(MouseTarget::CommitText);
             }
             return Some(MouseTarget::CommitChrome);
+        }
+
+        if contains_point(self.mouse_layout.right, column, row) {
+            return Some(MouseTarget::FilesPane);
         }
 
         if contains_point(self.mouse_layout.center, column, row) {
@@ -1776,9 +1786,19 @@ impl App {
                 }
 
                 match self.mouse_target(mouse.column, mouse.row) {
+                    Some(MouseTarget::LeftPane) => {
+                        self.focus = FocusPane::Left;
+                        self.input_target = InputTarget::None;
+                        self.fullscreen_agent = false;
+                    }
                     Some(MouseTarget::LeftRow(index)) => self.set_left_selection(index),
                     Some(MouseTarget::Center) => {
                         self.focus = FocusPane::Center;
+                    }
+                    Some(MouseTarget::FilesPane) => {
+                        self.focus = FocusPane::Files;
+                        self.input_target = InputTarget::None;
+                        self.fullscreen_agent = false;
                     }
                     Some(MouseTarget::UnstagedFile(index)) => {
                         self.set_file_selection(RightSection::Unstaged, index);
@@ -2202,6 +2222,17 @@ mod tests {
     }
 
     #[test]
+    fn mouse_click_left_pane_chrome_focuses_left_pane() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.focus = FocusPane::Files;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+
+        assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
     fn mouse_click_right_row_focuses_and_selects_unstaged_file() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
@@ -2226,6 +2257,17 @@ mod tests {
         assert_eq!(app.focus, FocusPane::Files);
         assert_eq!(app.right_section, RightSection::Unstaged);
         assert_eq!(app.files_index, 1);
+    }
+
+    #[test]
+    fn mouse_click_right_pane_chrome_focuses_files_pane() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.focus = FocusPane::Left;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 99, 0));
+
+        assert_eq!(app.focus, FocusPane::Files);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1841,7 +1841,15 @@ impl App {
                             self.register_mouse_click(MouseClickTarget::LeftRow(index));
                         self.set_left_selection(index);
                         if double_click {
-                            self.activate_selected_left_item_from_mouse();
+                            match self.left_items().get(self.selected_left) {
+                                Some(LeftItem::Project(_)) => {
+                                    self.toggle_collapse_selected_project()
+                                }
+                                Some(LeftItem::Session(_)) => {
+                                    self.activate_selected_left_item_from_mouse()
+                                }
+                                None => {}
+                            }
                         }
                     }
                     Some(MouseTarget::Center) => {
@@ -2421,18 +2429,21 @@ mod tests {
     }
 
     #[test]
-    fn mouse_double_click_project_row_activates_like_enter() {
+    fn mouse_double_click_project_row_toggles_collapse_like_space() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
         app.selected_left = 0;
         app.focus = FocusPane::Left;
+        let project_id = app.projects[0].id.clone();
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
 
-        assert_eq!(app.focus, FocusPane::Center);
-        assert!(matches!(app.center_mode, CenterMode::Agent));
-        assert_eq!(app.selected_left, 1);
+        assert_eq!(app.focus, FocusPane::Left);
+        assert!(app.collapsed_projects.contains(&project_id));
+        assert_eq!(app.selected_left, 0);
+        assert_eq!(app.input_target, InputTarget::None);
+        assert!(!app.fullscreen_agent);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,3 +1,4 @@
+use super::render::{cursor_from_wrapped_position, wrap_text_at_width};
 use super::*;
 use alacritty_terminal::term::TermMode;
 
@@ -21,7 +22,8 @@ enum MouseTarget {
     Center,
     UnstagedFile(Option<usize>),
     StagedFile(Option<usize>),
-    CommitInput,
+    CommitChrome,
+    CommitText,
 }
 
 fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
@@ -69,8 +71,10 @@ fn encode_cursor_key(code: KeyCode, term_mode: TermMode) -> &'static [u8] {
 fn agent_wheel_route(term_mode: TermMode) -> AgentWheelRoute {
     let mouse_reporting = term_mode
         .intersects(TermMode::MOUSE_REPORT_CLICK | TermMode::MOUSE_DRAG | TermMode::MOUSE_MOTION);
+    let modern_mouse_encoding =
+        term_mode.contains(TermMode::SGR_MOUSE) || term_mode.contains(TermMode::UTF8_MOUSE);
 
-    if mouse_reporting {
+    if mouse_reporting && modern_mouse_encoding {
         AgentWheelRoute::ForwardMouse
     } else if term_mode.contains(TermMode::ALT_SCREEN)
         && term_mode.contains(TermMode::ALTERNATE_SCROLL)
@@ -1508,7 +1512,14 @@ impl App {
         if let Some(area) = self.mouse_layout.commit_area
             && contains_point(area, column, row)
         {
-            return Some(MouseTarget::CommitInput);
+            if self
+                .mouse_layout
+                .commit_text_area
+                .is_some_and(|text_area| contains_point(text_area, column, row))
+            {
+                return Some(MouseTarget::CommitText);
+            }
+            return Some(MouseTarget::CommitChrome);
         }
 
         if contains_point(self.mouse_layout.center, column, row) {
@@ -1563,6 +1574,55 @@ impl App {
             self.files_index = index;
         }
         self.clamp_files_cursor();
+    }
+
+    fn engage_commit_input(&mut self) {
+        self.focus = FocusPane::Files;
+        self.right_section = RightSection::CommitInput;
+        self.input_target = InputTarget::CommitMessage;
+        self.fullscreen_agent = false;
+    }
+
+    fn commit_scroll_max(&self) -> u16 {
+        let Some(text_area) = self.mouse_layout.commit_text_area else {
+            return 0;
+        };
+        let width = text_area.width as usize;
+        if width == 0 {
+            return 0;
+        }
+
+        let wrapped = wrap_text_at_width(&self.commit_input, width);
+        let total_lines = wrapped.split('\n').count() as u16;
+        total_lines.saturating_sub(text_area.height)
+    }
+
+    fn set_commit_cursor_from_mouse(&mut self, column: u16, row: u16) {
+        let Some(text_area) = self.mouse_layout.commit_text_area else {
+            self.commit_input_cursor = self.commit_input.len();
+            return;
+        };
+        let width = text_area.width as usize;
+        if width == 0 {
+            self.commit_input_cursor = self.commit_input.len();
+            return;
+        }
+
+        let relative_row = row
+            .saturating_sub(text_area.y)
+            .saturating_add(self.commit_scroll);
+        let relative_col = usize::from(column.saturating_sub(text_area.x));
+        self.commit_input_cursor =
+            cursor_from_wrapped_position(&self.commit_input, width, relative_row, relative_col);
+    }
+
+    fn scroll_commit_input(&mut self, down: bool) {
+        let max_scroll = self.commit_scroll_max();
+        if down {
+            self.commit_scroll = (self.commit_scroll + MOUSE_WHEEL_LINES as u16).min(max_scroll);
+        } else {
+            self.commit_scroll = self.commit_scroll.saturating_sub(MOUSE_WHEEL_LINES as u16);
+        }
     }
 
     fn scroll_file_selection(&mut self, section: RightSection, down: bool) {
@@ -1726,8 +1786,12 @@ impl App {
                     Some(MouseTarget::StagedFile(index)) => {
                         self.set_file_selection(RightSection::Staged, index);
                     }
-                    Some(MouseTarget::CommitInput) => {
+                    Some(MouseTarget::CommitChrome) => {
                         self.set_file_selection(RightSection::CommitInput, None);
+                    }
+                    Some(MouseTarget::CommitText) => {
+                        self.engage_commit_input();
+                        self.set_commit_cursor_from_mouse(mouse.column, mouse.row);
                     }
                     None => {}
                 }
@@ -1753,6 +1817,11 @@ impl App {
                 Some(MouseTarget::StagedFile(_)) => {
                     self.scroll_file_selection(RightSection::Staged, true)
                 }
+                Some(MouseTarget::CommitChrome | MouseTarget::CommitText) => {
+                    self.focus = FocusPane::Files;
+                    self.right_section = RightSection::CommitInput;
+                    self.scroll_commit_input(true);
+                }
                 _ => {}
             },
             MouseEventKind::ScrollUp => match self.mouse_target(mouse.column, mouse.row) {
@@ -1765,6 +1834,11 @@ impl App {
                 }
                 Some(MouseTarget::StagedFile(_)) => {
                     self.scroll_file_selection(RightSection::Staged, false)
+                }
+                Some(MouseTarget::CommitChrome | MouseTarget::CommitText) => {
+                    self.focus = FocusPane::Files;
+                    self.right_section = RightSection::CommitInput;
+                    self.scroll_commit_input(false);
                 }
                 _ => {}
             },
@@ -1935,6 +2009,7 @@ mod tests {
             unstaged_list: Some(Rect::new(78, 1, 21, 8)),
             staged_list: Some(Rect::new(78, 9, 21, 5)),
             commit_area: Some(Rect::new(77, 14, 23, 6)),
+            commit_text_area: Some(Rect::new(78, 15, 21, 4)),
         };
     }
 
@@ -2198,7 +2273,46 @@ mod tests {
     }
 
     #[test]
-    fn agent_wheel_route_prefers_mouse_reporting_over_host_scrollback() {
+    fn mouse_click_commit_text_engages_commit_input() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.commit_input = "hello world".to_string();
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 15));
+
+        assert_eq!(app.focus, FocusPane::Files);
+        assert_eq!(app.right_section, RightSection::CommitInput);
+        assert_eq!(app.input_target, InputTarget::CommitMessage);
+    }
+
+    #[test]
+    fn mouse_click_commit_text_moves_cursor() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.commit_input = "abc\ndef".to_string();
+        app.commit_input_cursor = 0;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 16));
+
+        assert!(app.commit_input_cursor > 0);
+    }
+
+    #[test]
+    fn mouse_wheel_commit_text_scrolls_commit_viewport() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.commit_input = (0..20).map(|i| format!("line {i}\n")).collect::<String>();
+        app.commit_scroll = 0;
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, 80, 15));
+
+        assert!(app.commit_scroll > 0);
+        assert_eq!(app.right_section, RightSection::CommitInput);
+    }
+
+    #[test]
+    fn agent_wheel_route_prefers_mouse_reporting_with_modern_encoding() {
         let mode = TermMode::ALT_SCREEN | TermMode::MOUSE_REPORT_CLICK | TermMode::SGR_MOUSE;
         assert_eq!(
             super::agent_wheel_route(mode),
@@ -2207,11 +2321,20 @@ mod tests {
     }
 
     #[test]
-    fn agent_wheel_route_uses_alternate_scroll_for_alt_screen_apps() {
-        let mode = TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL;
+    fn agent_wheel_route_uses_alternate_scroll_without_modern_encoding() {
+        let mode = TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL | TermMode::MOUSE_REPORT_CLICK;
         assert_eq!(
             super::agent_wheel_route(mode),
             super::AgentWheelRoute::ForwardAlternateScroll
+        );
+    }
+
+    #[test]
+    fn agent_wheel_route_falls_back_to_host_scrollback_without_modern_encoding() {
+        let mode = TermMode::MOUSE_REPORT_CLICK;
+        assert_eq!(
+            super::agent_wheel_route(mode),
+            super::AgentWheelRoute::HostScrollback
         );
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2289,6 +2289,21 @@ mod tests {
     }
 
     #[test]
+    fn mouse_journey_can_switch_focus_across_all_panes() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 99, 0));
+        assert_eq!(app.focus, FocusPane::Files);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+        assert_eq!(app.focus, FocusPane::Center);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+        assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
     fn mouse_wheel_left_pane_advances_selection_under_cursor() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
@@ -2299,6 +2314,32 @@ mod tests {
 
         assert_eq!(app.focus, FocusPane::Left);
         assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_journey_can_switch_files_sections_by_clicking_rows() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.unstaged_files = vec![ChangedFile {
+            path: "a.txt".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 0,
+        }];
+        app.staged_files = vec![ChangedFile {
+            path: "b.txt".into(),
+            status: "A".into(),
+            additions: 3,
+            deletions: 0,
+        }];
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
+        assert_eq!(app.right_section, RightSection::Unstaged);
+        assert_eq!(app.files_index, 0);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 9));
+        assert_eq!(app.right_section, RightSection::Staged);
+        assert_eq!(app.files_index, 0);
     }
 
     #[test]
@@ -2359,6 +2400,22 @@ mod tests {
     }
 
     #[test]
+    fn mouse_journey_commit_chrome_then_text_enters_editing() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.commit_input = "hello".to_string();
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 14));
+        assert_eq!(app.focus, FocusPane::Files);
+        assert_eq!(app.right_section, RightSection::CommitInput);
+        assert_eq!(app.input_target, InputTarget::None);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 15));
+        assert_eq!(app.input_target, InputTarget::CommitMessage);
+    }
+
+    #[test]
     fn mouse_wheel_commit_text_scrolls_commit_viewport() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
@@ -2369,6 +2426,23 @@ mod tests {
 
         assert!(app.commit_scroll > 0);
         assert_eq!(app.right_section, RightSection::CommitInput);
+    }
+
+    #[test]
+    fn mouse_journey_divider_drag_persists_widths_on_release() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        let original_left = app.config.ui.left_width_pct;
+        let original_right = app.config.ui.right_width_pct;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 19, 5));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 30, 5));
+
+        assert_ne!(app.left_width_pct, original_left);
+        assert_eq!(app.config.ui.left_width_pct, app.left_width_pct);
+        assert_eq!(app.config.ui.right_width_pct, app.right_width_pct);
+        assert_eq!(app.config.ui.right_width_pct, original_right);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1614,6 +1614,12 @@ impl App {
         }
     }
 
+    fn open_selected_file_diff_from_mouse(&mut self) {
+        if let Err(err) = self.open_diff_for_selected_file() {
+            self.set_error(format!("Mouse activation failed: {err}"));
+        }
+    }
+
     fn set_file_selection(&mut self, section: RightSection, index: Option<usize>) {
         self.focus = FocusPane::Files;
         self.input_target = InputTarget::None;
@@ -1851,10 +1857,20 @@ impl App {
                         self.fullscreen_agent = false;
                     }
                     Some(MouseTarget::UnstagedFile(index)) => {
+                        let double_click = index
+                            .map(|i| self.register_mouse_click(MouseClickTarget::UnstagedFile(i)));
                         self.set_file_selection(RightSection::Unstaged, index);
+                        if matches!(double_click, Some(true)) {
+                            self.open_selected_file_diff_from_mouse();
+                        }
                     }
                     Some(MouseTarget::StagedFile(index)) => {
+                        let double_click = index
+                            .map(|i| self.register_mouse_click(MouseClickTarget::StagedFile(i)));
                         self.set_file_selection(RightSection::Staged, index);
+                        if matches!(double_click, Some(true)) {
+                            self.open_selected_file_diff_from_mouse();
+                        }
                     }
                     Some(MouseTarget::CommitChrome) => {
                         self.set_file_selection(RightSection::CommitInput, None);
@@ -1939,6 +1955,7 @@ mod tests {
     use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
     use ratatui::layout::Rect;
     use ratatui::text::Line;
+    use std::process::Command;
     use tempfile::tempdir;
 
     fn default_bindings() -> RuntimeBindings {
@@ -2083,6 +2100,50 @@ mod tests {
             commit_area: Some(Rect::new(77, 14, 23, 6)),
             commit_text_area: Some(Rect::new(78, 15, 21, 4)),
         };
+    }
+
+    fn init_git_repo_with_modified_file(
+        app: &App,
+        relative_path: &str,
+        original: &str,
+        updated: &str,
+    ) {
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        std::fs::create_dir_all(worktree).expect("worktree dir");
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(worktree)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(worktree)
+            .output()
+            .expect("git email");
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(worktree)
+            .output()
+            .expect("git name");
+
+        let file_path = worktree.join(relative_path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).expect("file parent");
+        }
+        std::fs::write(&file_path, original).expect("write original");
+        Command::new("git")
+            .args(["add", relative_path])
+            .current_dir(worktree)
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(worktree)
+            .output()
+            .expect("git commit");
+
+        std::fs::write(&file_path, updated).expect("write updated");
     }
 
     #[test]
@@ -2447,6 +2508,33 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 9));
         assert_eq!(app.right_section, RightSection::Staged);
         assert_eq!(app.files_index, 0);
+    }
+
+    #[test]
+    fn mouse_double_click_unstaged_file_row_opens_diff() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        init_git_repo_with_modified_file(
+            &app,
+            "src/main.rs",
+            "fn main() {}\n",
+            "fn main() { println!(\"hi\"); }\n",
+        );
+        app.unstaged_files = vec![ChangedFile {
+            path: "src/main.rs".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 1,
+        }];
+        app.selected_left = 1;
+        app.focus = FocusPane::Files;
+        app.right_section = RightSection::Unstaged;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
+
+        assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Diff { .. }));
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1488,6 +1488,9 @@ impl App {
         }
 
         if contains_point(self.mouse_layout.left_list, column, row) {
+            if self.left_items().is_empty() {
+                return Some(MouseTarget::LeftPane);
+            }
             let index = usize::from(row.saturating_sub(self.mouse_layout.left_list.y));
             if index < self.left_items().len() {
                 return Some(MouseTarget::LeftRow(index));
@@ -2228,6 +2231,21 @@ mod tests {
         app.focus = FocusPane::Files;
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+
+        assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
+    fn mouse_click_empty_left_list_focuses_left_pane() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.projects.clear();
+        app.sessions.clear();
+        app.left_items_cache.clear();
+        app.selected_left = 0;
+        app.focus = FocusPane::Center;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
 
         assert_eq!(app.focus, FocusPane::Left);
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use chrono::Utc;
@@ -84,6 +84,7 @@ pub struct App {
     pub(crate) left_items_cache: Vec<LeftItem>,
     pub(crate) mouse_layout: MouseLayoutState,
     pub(crate) mouse_drag: Option<ResizeDragState>,
+    pub(crate) last_mouse_click: Option<RecentMouseClick>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -264,6 +265,17 @@ pub(crate) enum ResizeDragState {
     RightDivider,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MouseClickTarget {
+    LeftRow(usize),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RecentMouseClick {
+    pub(crate) target: MouseClickTarget,
+    pub(crate) at: Instant,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LeftItem {
     Project(usize),
@@ -371,6 +383,7 @@ impl App {
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
             mouse_drag: None,
+            last_mouse_click: None,
         };
         app.restore_sessions();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use chrono::Utc;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
+use crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::{Color, Modifier, Style};
@@ -77,6 +79,8 @@ pub struct App {
     pub(crate) has_active_agent: Arc<AtomicBool>,
     pub(crate) collapsed_projects: HashSet<String>,
     pub(crate) left_items_cache: Vec<LeftItem>,
+    pub(crate) mouse_layout: MouseLayoutState,
+    pub(crate) mouse_drag: Option<ResizeDragState>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -222,6 +226,39 @@ pub(crate) enum ScrollDirection {
     Down,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MouseLayoutState {
+    pub(crate) body: Rect,
+    pub(crate) left: Rect,
+    pub(crate) center: Rect,
+    pub(crate) right: Rect,
+    pub(crate) left_list: Rect,
+    pub(crate) agent_term: Option<Rect>,
+    pub(crate) unstaged_list: Option<Rect>,
+    pub(crate) staged_list: Option<Rect>,
+    pub(crate) commit_area: Option<Rect>,
+}
+
+impl MouseLayoutState {
+    pub(crate) fn reset(&mut self, body: Rect, left: Rect, center: Rect, right: Rect) {
+        self.body = body;
+        self.left = left;
+        self.center = center;
+        self.right = right;
+        self.left_list = Rect::default();
+        self.agent_term = None;
+        self.unstaged_list = None;
+        self.staged_list = None;
+        self.commit_area = None;
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResizeDragState {
+    LeftDivider,
+    RightDivider,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LeftItem {
     Project(usize),
@@ -327,6 +364,8 @@ impl App {
             has_active_agent: Arc::new(AtomicBool::new(false)),
             collapsed_projects: HashSet::new(),
             left_items_cache: Vec::new(),
+            mouse_layout: MouseLayoutState::default(),
+            mouse_drag: None,
         };
         app.restore_sessions();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -269,6 +269,8 @@ pub(crate) enum ResizeDragState {
 pub(crate) enum MouseClickTarget {
     LeftRow(usize),
     CenterPane,
+    UnstagedFile(usize),
+    StagedFile(usize),
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -237,6 +237,7 @@ pub(crate) struct MouseLayoutState {
     pub(crate) unstaged_list: Option<Rect>,
     pub(crate) staged_list: Option<Rect>,
     pub(crate) commit_area: Option<Rect>,
+    pub(crate) commit_text_area: Option<Rect>,
 }
 
 impl MouseLayoutState {
@@ -250,6 +251,7 @@ impl MouseLayoutState {
         self.unstaged_list = None;
         self.staged_list = None;
         self.commit_area = None;
+        self.commit_text_area = None;
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io::stdout;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -10,8 +11,10 @@ use std::time::Duration;
 use anyhow::Result;
 use chrono::Utc;
 use crossterm::event::{
-    self, Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
+    MouseButton, MouseEvent, MouseEventKind,
 };
+use crossterm::execute;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::prelude::{Color, Modifier, Style};
@@ -378,25 +381,32 @@ impl App {
     pub fn run(&mut self) -> Result<()> {
         self.spawn_changed_files_poller();
         let mut terminal = ratatui::init();
-        loop {
-            self.drain_events();
-            self.tick_count = self.tick_count.wrapping_add(1);
-            terminal.draw(|frame| self.render(frame))?;
-            if event::poll(Duration::from_millis(100))? {
-                match event::read()? {
-                    Event::Key(key) => {
-                        if self.handle_key(key)? {
-                            break;
+        execute!(stdout(), EnableMouseCapture)?;
+
+        let result = (|| -> Result<()> {
+            loop {
+                self.drain_events();
+                self.tick_count = self.tick_count.wrapping_add(1);
+                terminal.draw(|frame| self.render(frame))?;
+                if event::poll(Duration::from_millis(100))? {
+                    match event::read()? {
+                        Event::Key(key) => {
+                            if self.handle_key(key)? {
+                                break;
+                            }
                         }
+                        Event::Mouse(mouse) => self.handle_mouse(mouse),
+                        Event::Resize(_, _) => {}
+                        _ => {}
                     }
-                    Event::Mouse(mouse) => self.handle_mouse(mouse),
-                    Event::Resize(_, _) => {}
-                    _ => {}
                 }
             }
-        }
+            Ok(())
+        })();
+
+        let _ = execute!(stdout(), DisableMouseCapture);
         ratatui::restore();
-        Ok(())
+        result
     }
 
     fn restore_sessions(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -268,6 +268,7 @@ pub(crate) enum ResizeDragState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MouseClickTarget {
     LeftRow(usize),
+    CenterPane,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -814,6 +814,7 @@ impl App {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(1), Constraint::Length(1)])
             .areas(inner);
+        self.mouse_layout.commit_text_area = Some(text_area);
 
         if self.commit_generating {
             let dots = ".".repeat((self.tick_count as usize / 5) % 4);
@@ -2066,7 +2067,7 @@ fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {
 
 /// Pre-wrap text at exact character boundaries to match the manual cursor
 /// position calculation used in the commit input box.
-fn wrap_text_at_width(text: &str, width: usize) -> String {
+pub(crate) fn wrap_text_at_width(text: &str, width: usize) -> String {
     if width == 0 {
         return text.to_string();
     }
@@ -2090,7 +2091,7 @@ fn wrap_text_at_width(text: &str, width: usize) -> String {
 
 /// Compute the (row, col) position of a cursor in text that wraps at `width`.
 /// This mirrors the inline cursor calculation used in `render_commit_input_inner`.
-fn cursor_pos_in_wrapped(text: &str, cursor: usize, width: usize) -> (u16, usize) {
+pub(crate) fn cursor_pos_in_wrapped(text: &str, cursor: usize, width: usize) -> (u16, usize) {
     let mut row: u16 = 0;
     let mut col: usize = 0;
     for (i, ch) in text.char_indices() {
@@ -2109,6 +2110,49 @@ fn cursor_pos_in_wrapped(text: &str, cursor: usize, width: usize) -> (u16, usize
         }
     }
     (row, col)
+}
+
+pub(crate) fn cursor_from_wrapped_position(
+    text: &str,
+    width: usize,
+    row: u16,
+    col: usize,
+) -> usize {
+    if width == 0 || text.is_empty() {
+        return 0;
+    }
+
+    let target_row = usize::from(row);
+    let target_col = col.min(width.saturating_sub(1));
+    let mut current_row = 0usize;
+    let mut current_col = 0usize;
+
+    for (index, ch) in text.char_indices() {
+        if current_row == target_row && current_col >= target_col {
+            return index;
+        }
+
+        if ch == '\n' {
+            if current_row == target_row {
+                return index;
+            }
+            current_row += 1;
+            current_col = 0;
+            continue;
+        }
+
+        current_col += 1;
+        if current_row == target_row && current_col > target_col {
+            return index + ch.len_utf8();
+        }
+
+        if current_col >= width {
+            current_row += 1;
+            current_col = 0;
+        }
+    }
+
+    text.len()
 }
 
 #[cfg(test)]
@@ -2230,6 +2274,16 @@ mod tests {
     fn cursor_at_end() {
         // Cursor past last char (len = 5), sits at (1, 0) after wrapping.
         assert_eq!(cursor_pos_in_wrapped("abcde", 5, 5), (1, 0));
+    }
+
+    #[test]
+    fn wrapped_position_maps_back_to_cursor_index() {
+        assert_eq!(cursor_from_wrapped_position("hello world", 5, 1, 0), 5);
+    }
+
+    #[test]
+    fn wrapped_position_handles_newline_rows() {
+        assert_eq!(cursor_from_wrapped_position("ab\ncd", 10, 1, 1), 4);
     }
 
     // ── Consistency: cursor pos matches wrapped text layout ────────

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -56,6 +56,7 @@ impl App {
                 ])
                 .areas(body)
         };
+        self.mouse_layout.reset(body, left, center, right);
         self.render_left(frame, left);
         self.render_center(frame, center);
         self.render_files(frame, right);
@@ -108,10 +109,11 @@ impl App {
             .render(area, frame.buffer_mut());
     }
 
-    fn render_left(&self, frame: &mut Frame, area: Rect) {
+    fn render_left(&mut self, frame: &mut Frame, area: Rect) {
         let focused = self.focus == FocusPane::Left;
 
         if self.left_collapsed {
+            self.mouse_layout.left_list = self.themed_block("", focused).inner(area);
             let collapsed_left_items = self.left_items();
             let items = collapsed_left_items
                 .iter()
@@ -211,6 +213,7 @@ impl App {
             })
             .collect::<Vec<_>>();
         let title = format!("Projects ({})", self.projects.len());
+        self.mouse_layout.left_list = self.themed_block(&title, focused).inner(area);
         let mut state = ListState::default().with_selected(Some(self.selected_left));
         StatefulWidget::render(
             List::new(items)
@@ -260,6 +263,7 @@ impl App {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(1), Constraint::Length(hint_height)])
             .areas(inner);
+        self.mouse_layout.agent_term = Some(content_area);
 
         self.last_diff_height = content_area.height;
 
@@ -361,6 +365,7 @@ impl App {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(1), Constraint::Length(hint_height)])
             .areas(inner);
+        self.mouse_layout.agent_term = Some(term_area);
 
         // Get the selected session's PTY screen.
         let session_id = self.selected_session().map(|s| s.id.clone());
@@ -621,6 +626,7 @@ impl App {
                     Constraint::Min(3), // Staged Changes (with commit input)
                 ])
                 .split(area);
+            self.mouse_layout.unstaged_list = Some(self.file_list_area(chunks[0], true));
             self.render_file_list(
                 frame,
                 chunks[0],
@@ -631,6 +637,7 @@ impl App {
             );
             self.render_staged_with_commit(frame, chunks[1], focused);
         } else {
+            self.mouse_layout.unstaged_list = Some(self.file_list_area(area, true));
             self.render_file_list(
                 frame,
                 area,
@@ -652,6 +659,7 @@ impl App {
             .areas(area);
 
         // Staged files — normal titled block.
+        self.mouse_layout.staged_list = Some(self.file_list_area(files_area, false));
         self.render_file_list(
             frame,
             files_area,
@@ -663,6 +671,20 @@ impl App {
 
         // Commit input block.
         self.render_commit_input_inner(frame, commit_area, pane_focused);
+    }
+
+    fn file_list_area(&self, area: Rect, show_hint: bool) -> Rect {
+        let inner = self.themed_block("", false).inner(area);
+        let pane_focused = self.focus == FocusPane::Files;
+        if show_hint && pane_focused && inner.height >= 4 {
+            let [list_area, _] = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(2)])
+                .areas(inner);
+            list_area
+        } else {
+            inner
+        }
     }
 
     fn render_file_list(
@@ -691,7 +713,6 @@ impl App {
         } else {
             (inner, None)
         };
-
         let inner_width = list_area.width as usize;
         let sel_style = self.theme.selection_style();
         let items = files
@@ -780,6 +801,7 @@ impl App {
 
     /// Render the commit input as its own bordered block.
     fn render_commit_input_inner(&mut self, frame: &mut Frame, area: Rect, pane_focused: bool) {
+        self.mouse_layout.commit_area = Some(area);
         let is_active_section = pane_focused && self.right_section == RightSection::CommitInput;
         let focused = self.input_target == InputTarget::CommitMessage;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -807,10 +807,10 @@ fn discover_root(home: &Path, xdg_config_home: Option<std::ffi::OsString>) -> Pa
 
     #[cfg(not(target_os = "macos"))]
     {
-        if let Some(xdg) = xdg_config_home.map(PathBuf::from) {
-            if xdg.is_absolute() {
-                return xdg.join("dux");
-            }
+        if let Some(xdg) = xdg_config_home.map(PathBuf::from)
+            && xdg.is_absolute()
+        {
+            return xdg.join("dux");
         }
         home.join(".config").join("dux")
     }

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -7,7 +7,7 @@ use std::thread;
 use alacritty_terminal::event::{Event, EventListener, WindowSize};
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::term::cell::Flags;
-use alacritty_terminal::term::{self, Config, Term};
+use alacritty_terminal::term::{self, Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{
     Color as TermColor, CursorShape, NamedColor, Processor, Rgb, StdSyncHandler,
 };
@@ -177,6 +177,11 @@ impl PtyClient {
     pub fn scrollback_offset(&self) -> usize {
         let terminal = self.terminal.lock().expect("terminal mutex poisoned");
         terminal.scrollback_offset()
+    }
+
+    pub fn term_mode(&self) -> TermMode {
+        let terminal = self.terminal.lock().expect("terminal mutex poisoned");
+        terminal.term_mode()
     }
 
     /// Atomically adjust the scrollback offset by the given amount in the
@@ -353,6 +358,10 @@ impl TerminalState {
 
     fn scrollback_offset(&self) -> usize {
         self.term.grid().display_offset()
+    }
+
+    fn term_mode(&self) -> TermMode {
+        *self.term.mode()
     }
 
     fn scroll(&mut self, up: bool, amount: usize) {


### PR DESCRIPTION
Restores mouse-driven interactions in dux by bringing back click-to-focus/select in the left and right panes, pointer-based wheel routing, and drag resizing for both pane dividers. Pane widths still initialize from config and persist after mouse drag, and the existing keyboard resize flow remains intact.

This also closes the remaining follow-up gaps in the commit editor and agent pane. Commit-message clicks now enter editing and place the cursor against the wrapped text layout, commit text can be wheel-scrolled, and agent wheel forwarding is now conservative: synthetic mouse wheel packets are only sent when the embedded terminal advertises a modern mouse encoding, otherwise dux falls back to alternate-scroll or host scrollback.

```sh
cargo fmt --check
cargo check --quiet
cargo test --quiet
```
