### PR TITLE
Improve Changes pane diffing, search, and binary handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +441,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "chrono",
+ "content_inspector",
  "crokey",
  "crossterm 0.29.0",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = "1.0.98"
 arboard = "3.4.1"
 chrono = { version = "0.4.41", features = ["serde"] }
+content_inspector = "0.2.4"
 crossterm = "0.29.0"
 home = "0.5.11"
 ratatui = "0.29.0"

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -436,7 +436,40 @@ impl App {
         }
     }
 
+    fn handle_files_search_key(&mut self, key: KeyEvent) {
+        let is_plain_char =
+            matches!(key.code, KeyCode::Char(_)) && !key.modifiers.contains(KeyModifiers::CONTROL);
+
+        match key.code {
+            KeyCode::Esc | KeyCode::Enter => {
+                self.files_search_active = false;
+            }
+            KeyCode::Backspace => {
+                let mut query = self.files_search_query.clone();
+                query.pop();
+                let found_match = self.update_files_search(query);
+                if !found_match && self.has_files_search() {
+                    self.set_info("No file matches the current search.");
+                }
+            }
+            KeyCode::Char(c) if is_plain_char => {
+                let mut query = self.files_search_query.clone();
+                query.push(c);
+                let found_match = self.update_files_search(query);
+                if !found_match {
+                    self.set_info("No file matches the current search.");
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn handle_files_key(&mut self, key: KeyEvent) -> Result<()> {
+        if self.files_search_active {
+            self.handle_files_search_key(key);
+            return Ok(());
+        }
+
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Files) {
             match action {
                 Action::MoveDown => {
@@ -486,8 +519,18 @@ impl App {
                 Action::PullFromRemote => {
                     self.pull_from_remote()?;
                 }
+                Action::SearchFiles => {
+                    self.files_search_active = true;
+                }
+                Action::SearchNext => {
+                    if !self.advance_files_search_match() {
+                        self.set_info("No active file search matches.");
+                    }
+                }
                 _ => {}
             }
+        } else if key.code == KeyCode::Esc && self.has_files_search() {
+            self.clear_files_search();
         }
         Ok(())
     }
@@ -2054,6 +2097,8 @@ mod tests {
             selected_left: 0,
             right_section: RightSection::Unstaged,
             files_index: 0,
+            files_search_query: String::new(),
+            files_search_active: false,
             commit_input: String::new(),
             commit_input_cursor: 0,
             commit_scroll: 0,
@@ -2338,6 +2383,89 @@ mod tests {
     }
 
     #[test]
+    fn slash_search_selects_first_match_and_n_advances() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Files;
+        app.right_section = RightSection::Unstaged;
+        app.unstaged_files = vec![
+            ChangedFile {
+                path: "src/lib.rs".into(),
+                status: "M".into(),
+                additions: 1,
+                deletions: 0,
+                binary: false,
+            },
+            ChangedFile {
+                path: "src/main.rs".into(),
+                status: "M".into(),
+                additions: 2,
+                deletions: 1,
+                binary: false,
+            },
+        ];
+        app.staged_files = vec![ChangedFile {
+            path: "tests/main.rs".into(),
+            status: "A".into(),
+            additions: 3,
+            deletions: 0,
+            binary: false,
+        }];
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE))
+            .unwrap();
+        for ch in ['m', 'a', 'i', 'n'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE))
+                .unwrap();
+        }
+
+        assert!(app.files_search_active);
+        assert_eq!(app.files_search_query, "main");
+        assert_eq!(app.right_section, RightSection::Unstaged);
+        assert_eq!(app.files_index, 1);
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.right_section, RightSection::Staged);
+        assert_eq!(app.files_index, 0);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.right_section, RightSection::Unstaged);
+        assert_eq!(app.files_index, 1);
+    }
+
+    #[test]
+    fn enter_opens_selected_file_diff_from_files_pane() {
+        let mut app = test_app(default_bindings());
+        init_git_repo_with_modified_file(
+            &app,
+            "src/main.rs",
+            "fn main() {}\n",
+            "fn main() { println!(\"hi\"); }\n",
+        );
+        app.unstaged_files = vec![ChangedFile {
+            path: "src/main.rs".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 1,
+            binary: false,
+        }];
+        app.selected_left = 1;
+        app.focus = FocusPane::Files;
+        app.right_section = RightSection::Unstaged;
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Diff { .. }));
+    }
+
+    #[test]
     fn mouse_click_left_row_focuses_and_selects_it() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
@@ -2385,12 +2513,14 @@ mod tests {
                 status: "M".into(),
                 additions: 1,
                 deletions: 0,
+                binary: false,
             },
             ChangedFile {
                 path: "b.txt".into(),
                 status: "M".into(),
                 additions: 2,
                 deletions: 1,
+                binary: false,
             },
         ];
         app.focus = FocusPane::Center;
@@ -2400,6 +2530,7 @@ mod tests {
         assert_eq!(app.focus, FocusPane::Files);
         assert_eq!(app.right_section, RightSection::Unstaged);
         assert_eq!(app.files_index, 1);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
     }
 
     #[test]
@@ -2528,21 +2659,26 @@ mod tests {
             status: "M".into(),
             additions: 1,
             deletions: 0,
+            binary: false,
         }];
         app.staged_files = vec![ChangedFile {
             path: "b.txt".into(),
             status: "A".into(),
             additions: 3,
             deletions: 0,
+            binary: false,
         }];
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
         assert_eq!(app.right_section, RightSection::Unstaged);
         assert_eq!(app.files_index, 0);
+        assert_eq!(app.focus, FocusPane::Files);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 9));
         assert_eq!(app.right_section, RightSection::Staged);
         assert_eq!(app.files_index, 0);
+        assert_eq!(app.focus, FocusPane::Files);
     }
 
     #[test]
@@ -2560,6 +2696,7 @@ mod tests {
             status: "M".into(),
             additions: 1,
             deletions: 1,
+            binary: false,
         }];
         app.selected_left = 1;
         app.focus = FocusPane::Files;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -52,6 +52,8 @@ pub struct App {
     pub(crate) selected_left: usize,
     pub(crate) right_section: RightSection,
     pub(crate) files_index: usize,
+    pub(crate) files_search_query: String,
+    pub(crate) files_search_active: bool,
     pub(crate) commit_input: String,
     pub(crate) commit_input_cursor: usize,
     pub(crate) commit_scroll: u16,
@@ -356,6 +358,8 @@ impl App {
             selected_left: 0,
             right_section: RightSection::Unstaged,
             files_index: 0,
+            files_search_query: String::new(),
+            files_search_active: false,
             commit_input: String::new(),
             commit_input_cursor: 0,
             commit_scroll: 0,
@@ -620,6 +624,81 @@ impl App {
         } else if self.files_index >= len {
             self.files_index = len.saturating_sub(1);
         }
+    }
+
+    pub(crate) fn has_files_search(&self) -> bool {
+        !self.files_search_query.is_empty()
+    }
+
+    pub(crate) fn clear_files_search(&mut self) {
+        self.files_search_query.clear();
+        self.files_search_active = false;
+    }
+
+    pub(crate) fn update_files_search(&mut self, query: String) -> bool {
+        self.files_search_query = query;
+        if self.files_search_query.is_empty() {
+            return false;
+        }
+        self.select_files_search_match(0)
+    }
+
+    pub(crate) fn advance_files_search_match(&mut self) -> bool {
+        let matches = self.files_search_matches();
+        if matches.is_empty() {
+            return false;
+        }
+
+        let current = (self.right_section, self.files_index);
+        let next_index = matches
+            .iter()
+            .position(|candidate| *candidate == current)
+            .map(|index| (index + 1) % matches.len())
+            .unwrap_or(0);
+
+        self.apply_files_match(matches[next_index]);
+        true
+    }
+
+    fn select_files_search_match(&mut self, match_index: usize) -> bool {
+        let matches = self.files_search_matches();
+        if matches.is_empty() {
+            return false;
+        }
+
+        let target = matches[match_index.min(matches.len().saturating_sub(1))];
+        self.apply_files_match(target);
+        true
+    }
+
+    fn apply_files_match(&mut self, target: (RightSection, usize)) {
+        self.right_section = target.0;
+        self.files_index = target.1;
+        self.clamp_files_cursor();
+    }
+
+    fn files_search_matches(&self) -> Vec<(RightSection, usize)> {
+        if self.files_search_query.is_empty() {
+            return Vec::new();
+        }
+
+        let needle = self.files_search_query.to_lowercase();
+        let mut matches = Vec::new();
+        matches.extend(
+            self.unstaged_files
+                .iter()
+                .enumerate()
+                .filter(|(_, file)| file.path.to_lowercase().contains(&needle))
+                .map(|(index, _)| (RightSection::Unstaged, index)),
+        );
+        matches.extend(
+            self.staged_files
+                .iter()
+                .enumerate()
+                .filter(|(_, file)| file.path.to_lowercase().contains(&needle))
+                .map(|(index, _)| (RightSection::Staged, index)),
+        );
+        matches
     }
 
     pub(crate) fn open_rename_session(&mut self) -> Result<()> {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -703,16 +703,40 @@ impl App {
         let inner = block.inner(area);
         block.render(area, frame.buffer_mut());
 
+        let show_search =
+            is_active_section && (self.files_search_active || self.has_files_search());
+        let (search_area, list_inner) = if show_search && inner.height >= 4 {
+            let [sa, la] = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(2), Constraint::Min(1)])
+                .areas(inner);
+            (Some(sa), la)
+        } else {
+            (None, inner)
+        };
+
         // Optionally reserve 2 lines at the bottom for the hint bar (border + text).
-        let (list_area, hint_area) = if show_hint && pane_focused && inner.height >= 4 {
+        let (list_area, hint_area) = if show_hint && pane_focused && list_inner.height >= 4 {
             let [la, ha] = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(1), Constraint::Length(2)])
-                .areas(inner);
+                .areas(list_inner);
             (la, Some(ha))
         } else {
-            (inner, None)
+            (list_inner, None)
         };
+
+        if let Some(search_area) = search_area {
+            let query = format!("/ {}", self.files_search_query);
+            Paragraph::new(query)
+                .block(
+                    Block::default()
+                        .borders(Borders::BOTTOM)
+                        .border_style(Style::default().fg(self.theme.border_normal)),
+                )
+                .render(search_area, frame.buffer_mut());
+        }
+
         let inner_width = list_area.width as usize;
         let sel_style = self.theme.selection_style();
         let items = files
@@ -722,7 +746,7 @@ impl App {
                 let is_selected = is_active_section && index == self.files_index;
 
                 // Build the right-aligned stats string, e.g. "+12 -3".
-                let stats = format_line_stats(file.additions, file.deletions);
+                let stats = format_line_stats(file.additions, file.deletions, file.binary);
                 let stats_width = stats.iter().map(|s| s.width()).sum::<usize>();
 
                 // Status prefix takes 3 chars ("M  ").
@@ -785,10 +809,27 @@ impl App {
         // Hint bar inside the block (same style as agent terminal / diff view).
         if let Some(ha) = hint_area {
             let stage_key = self.bindings.label_for(Action::StageUnstage);
+            let search_key = self.bindings.label_for(Action::SearchFiles);
+            let next_key = self.bindings.label_for(Action::SearchNext);
             let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
             let mut spans: Vec<Span> = Vec::new();
             spans.extend(self.theme.dim_key_badge(&stage_key, Color::Reset));
             spans.push(Span::styled(" stage/unstage.", desc_style));
+            spans.push(Span::raw("  "));
+            if self.files_search_active {
+                spans.extend(self.theme.dim_key_badge("Enter", Color::Reset));
+                spans.push(Span::styled(" done  ", desc_style));
+                spans.extend(self.theme.dim_key_badge("Esc", Color::Reset));
+                spans.push(Span::styled(" clear", desc_style));
+            } else {
+                spans.extend(self.theme.dim_key_badge(&search_key, Color::Reset));
+                spans.push(Span::styled(" search", desc_style));
+                if self.has_files_search() {
+                    spans.push(Span::raw("  "));
+                    spans.extend(self.theme.dim_key_badge(&next_key, Color::Reset));
+                    spans.push(Span::styled(" next match", desc_style));
+                }
+            }
             Paragraph::new(Line::from(spans))
                 .block(
                     Block::default()
@@ -2004,8 +2045,15 @@ impl App {
 }
 
 /// Format additions/deletions as right-aligned colored spans.
-/// Returns an empty vec when both counts are zero.
-pub(crate) fn format_line_stats(additions: usize, deletions: usize) -> Vec<Span<'static>> {
+/// Returns an empty vec when both counts are zero for text files.
+pub(crate) fn format_line_stats(
+    additions: usize,
+    deletions: usize,
+    binary: bool,
+) -> Vec<Span<'static>> {
+    if binary {
+        return vec![Span::styled("bin", Style::default().fg(Color::Yellow))];
+    }
     if additions == 0 && deletions == 0 {
         return Vec::new();
     }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,7 +1,7 @@
-use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
+use content_inspector::{ContentType, inspect};
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use similar::{ChangeTag, TextDiff};
@@ -21,15 +21,27 @@ pub struct DiffOutput {
 /// `worktree_path` is the root of the git worktree and `rel_path` is the
 /// file path relative to it (as reported by `git status --porcelain`).
 pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Result<DiffOutput> {
-    let old_text = crate::git::file_at_head(worktree_path, rel_path)?.unwrap_or_default();
+    let old_bytes = crate::git::file_bytes_at_head(worktree_path, rel_path)?.unwrap_or_default();
     let abs_path = worktree_path.join(rel_path);
-    let new_text = fs::read_to_string(&abs_path).unwrap_or_default();
+    let new_bytes = std::fs::read(&abs_path).unwrap_or_default();
 
-    if old_text == new_text {
+    if old_bytes == new_bytes {
         return Ok(DiffOutput {
             lines: vec![Line::from("No changes.")],
         });
     }
+
+    if !is_renderable_text(&old_bytes) || !is_renderable_text(&new_bytes) {
+        return Ok(binary_diff_output(
+            rel_path,
+            old_bytes.len(),
+            new_bytes.len(),
+            theme,
+        ));
+    }
+
+    let old_text = String::from_utf8(old_bytes).unwrap_or_default();
+    let new_text = String::from_utf8(new_bytes).unwrap_or_default();
 
     let syntax_set = SyntaxSet::load_defaults_newlines();
     let theme_set = ThemeSet::load_defaults();
@@ -146,6 +158,38 @@ pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Resu
     Ok(DiffOutput { lines })
 }
 
+fn is_renderable_text(bytes: &[u8]) -> bool {
+    bytes.is_empty() || matches!(inspect(bytes), ContentType::UTF_8)
+}
+
+fn binary_diff_output(
+    rel_path: &str,
+    old_size: usize,
+    new_size: usize,
+    theme: &AppTheme,
+) -> DiffOutput {
+    DiffOutput {
+        lines: vec![
+            Line::from(Span::styled(
+                format!("--- a/{rel_path}"),
+                Style::default()
+                    .fg(theme.diff_file_header)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(Span::styled(
+                format!("+++ b/{rel_path}"),
+                Style::default()
+                    .fg(theme.diff_file_header)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from("Binary file changed."),
+            Line::from(format!("Old size: {old_size} bytes")),
+            Line::from(format!("New size: {new_size} bytes")),
+            Line::from("No text diff available for binary or non-UTF-8 content."),
+        ],
+    }
+}
+
 /// Convert a syntect `Style` to a ratatui `Style`.
 fn syntect_to_ratatui(style: SynStyle) -> Style {
     let fg = syntect_color(style.foreground);
@@ -172,5 +216,72 @@ fn syntect_color(c: SynColor) -> Option<Color> {
         None
     } else {
         Some(Color::Rgb(c.r, c.g, c.b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    #[test]
+    fn binary_files_render_summary_instead_of_text_diff() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        let file = repo.join("image.bin");
+        std::fs::write(&file, [0_u8, 159, 146, 150]).unwrap();
+        Command::new("git")
+            .args(["add", "image.bin"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        std::fs::write(&file, [0_u8, 159, 146, 151, 152]).unwrap();
+
+        let output = diff_file(repo, "image.bin", &AppTheme::default_dark()).unwrap();
+        let rendered = output
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Binary file changed."))
+        );
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Old size: 4 bytes"))
+        );
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("New size: 5 bytes"))
+        );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,8 +4,19 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result, anyhow};
+use content_inspector::{ContentType, inspect};
 
 use crate::model::ChangedFile;
+
+enum DiffStat {
+    Text(usize, usize),
+    Binary,
+}
+
+#[cfg(windows)]
+const NULL_DEVICE: &str = "NUL";
+#[cfg(not(windows))]
+const NULL_DEVICE: &str = "/dev/null";
 
 pub fn current_branch(repo_path: &Path) -> Result<String> {
     let output = Command::new("git")
@@ -164,7 +175,13 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     let wt = worktree_path.to_string_lossy();
 
     let output = Command::new("git")
-        .args(["-C", wt.as_ref(), "status", "--porcelain"])
+        .args([
+            "-C",
+            wt.as_ref(),
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        ])
         .output()?;
     if !output.status.success() {
         return Err(anyhow!(
@@ -191,6 +208,7 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path,
                 additions: 0,
                 deletions: 0,
+                binary: false,
             });
             continue;
         }
@@ -201,6 +219,7 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path: path.clone(),
                 additions: 0,
                 deletions: 0,
+                binary: false,
             });
         }
 
@@ -210,6 +229,7 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
                 path: path.clone(),
                 additions: 0,
                 deletions: 0,
+                binary: false,
             });
         }
     }
@@ -221,9 +241,32 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     {
         let stats = parse_numstat(&ns.stdout);
         for file in &mut unstaged {
-            if let Some(&(a, d)) = stats.get(&file.path) {
-                file.additions = a;
-                file.deletions = d;
+            if let Some(stat) = stats.get(&file.path) {
+                match stat {
+                    DiffStat::Text(a, d) => {
+                        file.additions = *a;
+                        file.deletions = *d;
+                    }
+                    DiffStat::Binary => {
+                        file.binary = true;
+                    }
+                }
+            } else if file.status == "?" {
+                match untracked_file_diff_stat(worktree_path, &file.path) {
+                    Some(DiffStat::Text(a, d)) => {
+                        file.additions = a;
+                        file.deletions = d;
+                    }
+                    Some(DiffStat::Binary) => {
+                        file.binary = true;
+                    }
+                    None => {
+                        let (additions, binary) =
+                            classify_untracked_file_fallback(&worktree_path.join(&file.path));
+                        file.additions = additions;
+                        file.binary = binary;
+                    }
+                }
             }
         }
     }
@@ -235,9 +278,16 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     {
         let stats = parse_numstat(&ns.stdout);
         for file in &mut staged {
-            if let Some(&(a, d)) = stats.get(&file.path) {
-                file.additions = a;
-                file.deletions = d;
+            if let Some(stat) = stats.get(&file.path) {
+                match stat {
+                    DiffStat::Text(a, d) => {
+                        file.additions = *a;
+                        file.deletions = *d;
+                    }
+                    DiffStat::Binary => {
+                        file.binary = true;
+                    }
+                }
             }
         }
     }
@@ -245,17 +295,63 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     Ok((staged, unstaged))
 }
 
-fn parse_numstat(raw: &[u8]) -> HashMap<String, (usize, usize)> {
+fn untracked_file_diff_stat(worktree_path: &Path, rel_path: &str) -> Option<DiffStat> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            worktree_path.to_string_lossy().as_ref(),
+            "diff",
+            "--no-index",
+            "--numstat",
+            "--",
+            NULL_DEVICE,
+            rel_path,
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() && output.status.code() != Some(1) {
+        return None;
+    }
+
+    parse_numstat_line(String::from_utf8_lossy(&output.stdout).lines().next()?)
+}
+
+fn classify_untracked_file_fallback(path: &Path) -> (usize, bool) {
+    let Ok(bytes) = fs::read(path) else {
+        return (0, false);
+    };
+    match inspect(&bytes) {
+        ContentType::UTF_8 => match std::str::from_utf8(&bytes) {
+            Ok(text) => (text.lines().count(), false),
+            Err(_) => (0, true),
+        },
+        _ => (0, true),
+    }
+}
+
+fn parse_numstat(raw: &[u8]) -> HashMap<String, DiffStat> {
     String::from_utf8_lossy(raw)
         .lines()
         .filter_map(|line| {
             let mut parts = line.split('\t');
-            let add = parts.next()?.parse::<usize>().ok()?;
-            let del = parts.next()?.parse::<usize>().ok()?;
+            let _ = parts.next()?;
+            let _ = parts.next()?;
             let path = parts.next()?.to_string();
-            Some((path, (add, del)))
+            Some((path, parse_numstat_line(line)?))
         })
         .collect()
+}
+
+fn parse_numstat_line(line: &str) -> Option<DiffStat> {
+    let mut parts = line.split('\t');
+    let add = parts.next()?;
+    let del = parts.next()?;
+    if add == "-" || del == "-" {
+        Some(DiffStat::Binary)
+    } else {
+        Some(DiffStat::Text(add.parse().ok()?, del.parse().ok()?))
+    }
 }
 
 pub fn stage_file(worktree_path: &Path, file_path: &str) -> Result<()> {
@@ -338,10 +434,10 @@ pub fn push(worktree_path: &Path) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Return the contents of a file as it exists at HEAD, or `None` for new
-/// (untracked) files. Uses the plumbing command `cat-file` which is immune
-/// to user configuration.
-pub fn file_at_head(worktree_path: &Path, path: &str) -> Result<Option<String>> {
+/// Return the contents of a file as raw bytes as it exists at HEAD, or `None`
+/// for new (untracked) files. Uses the plumbing command `cat-file` which is
+/// immune to user configuration.
+pub fn file_bytes_at_head(worktree_path: &Path, path: &str) -> Result<Option<Vec<u8>>> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -355,7 +451,7 @@ pub fn file_at_head(worktree_path: &Path, path: &str) -> Result<Option<String>> 
         // File doesn't exist at HEAD (new/untracked file).
         return Ok(None);
     }
-    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
+    Ok(Some(output.stdout))
 }
 
 pub fn is_under(base: &Path, candidate: &Path) -> bool {
@@ -577,5 +673,72 @@ mod tests {
 
         let branch = current_branch(&wt).unwrap();
         assert_eq!(branch, "same-name");
+    }
+
+    #[test]
+    fn changed_files_expands_untracked_directories_into_files() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "changes-pane-folder");
+
+        let nested = wt.join("new-folder").join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(
+            wt.join("new-folder").join("one.txt"),
+            "first line\nsecond line\n",
+        )
+        .unwrap();
+        fs::write(nested.join("two.txt"), "nested line\n").unwrap();
+
+        let (_staged, unstaged) = changed_files(&wt).unwrap();
+        let mut actual: Vec<_> = unstaged
+            .into_iter()
+            .map(|file| {
+                (
+                    file.path,
+                    file.status,
+                    file.additions,
+                    file.deletions,
+                    file.binary,
+                )
+            })
+            .collect();
+        actual.sort();
+
+        assert_eq!(
+            actual,
+            vec![
+                (
+                    "new-folder/nested/two.txt".to_string(),
+                    "?".to_string(),
+                    1,
+                    0,
+                    false,
+                ),
+                (
+                    "new-folder/one.txt".to_string(),
+                    "?".to_string(),
+                    2,
+                    0,
+                    false
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn changed_files_marks_untracked_binary_files() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "changes-pane-binary");
+
+        fs::write(wt.join("image.bin"), [0_u8, 159, 146, 150]).unwrap();
+
+        let (_staged, unstaged) = changed_files(&wt).unwrap();
+        assert_eq!(unstaged.len(), 1);
+        let file = &unstaged[0];
+        assert_eq!(file.path, "image.bin");
+        assert_eq!(file.status, "?");
+        assert_eq!(file.additions, 0);
+        assert_eq!(file.deletions, 0);
+        assert!(file.binary);
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -36,6 +36,8 @@ pub enum Action {
     EngageCommitInput,
     PushToRemote,
     PullFromRemote,
+    SearchFiles,
+    SearchNext,
     // Commit message editor
     ExitCommitInput,
     // Global
@@ -163,6 +165,8 @@ impl Action {
             Action::EngageCommitInput => "engage_commit_input",
             Action::PushToRemote => "push_to_remote",
             Action::PullFromRemote => "pull_from_remote",
+            Action::SearchFiles => "search_files",
+            Action::SearchNext => "search_next",
             Action::ExitCommitInput => "exit_commit_input",
             Action::FocusNext => "focus_next",
             Action::FocusPrev => "focus_prev",
@@ -221,6 +225,8 @@ impl Action {
             Action::EngageCommitInput => "Open the commit message editor.",
             Action::PushToRemote => "Push to remote.",
             Action::PullFromRemote => "Pull from remote.",
+            Action::SearchFiles => "Start searching changed files in the files pane.",
+            Action::SearchNext => "Jump to the next active search match in the files pane.",
             Action::ExitCommitInput => "Exit the commit message editor.",
             Action::FocusNext => "Focus the next pane.",
             Action::FocusPrev => "Focus the previous pane.",
@@ -232,7 +238,7 @@ impl Action {
             Action::CloseOverlay => "Close the current overlay or dialog.",
             Action::ResizeGrow => "Grow the left pane width.",
             Action::ResizeShrink => "Shrink the left pane width.",
-            Action::SearchToggle => "Toggle search mode in palette and project browser.",
+            Action::SearchToggle => "Toggle search mode in search-capable lists and overlays.",
             Action::GoToPath => "Open path editor in the project browser.",
             Action::OpenEntry => "Open or navigate into the selected entry in the project browser.",
             Action::AddCurrentDir => "Add the current directory as a project.",
@@ -273,7 +279,9 @@ impl Action {
             | Action::DiscardChanges
             | Action::EngageCommitInput
             | Action::PushToRemote
-            | Action::PullFromRemote => Some("Files pane"),
+            | Action::PullFromRemote
+            | Action::SearchFiles
+            | Action::SearchNext => Some("Files pane"),
             Action::ExitCommitInput => Some("Commit input"),
             Action::FocusNext
             | Action::FocusPrev
@@ -693,6 +701,31 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             description: "Pull from remote",
         }),
         hint_contexts: &[(HintContext::Files, "Pull")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::SearchFiles,
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char('/'),
+            KeyModifiers::NONE,
+        )],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Search changed files",
+        }),
+        hint_contexts: &[(HintContext::Files, "Search")],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::SearchNext,
+        default_keys: &[key!(n)],
+        scopes: &[BindingScope::Files],
+        help: Some(HelpEntry {
+            section: "Files pane",
+            description: "Jump to next search match",
+        }),
+        hint_contexts: &[(HintContext::Files, "Next match")],
         palette: None,
     },
     // ── Commit message editor ─────────────────────────────────────
@@ -1489,6 +1522,28 @@ mod tests {
         assert!(actions_in_defs.contains(&Action::ExitCommitInput));
         assert!(actions_in_defs.contains(&Action::PushToRemote));
         assert!(actions_in_defs.contains(&Action::AddCurrentDir));
+        assert!(actions_in_defs.contains(&Action::SearchFiles));
+        assert!(actions_in_defs.contains(&Action::SearchNext));
+    }
+
+    #[test]
+    fn files_scope_resolves_slash_to_search_toggle() {
+        let bindings = default_bindings();
+        let slash = KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&slash, BindingScope::Files),
+            Some(Action::SearchFiles)
+        );
+    }
+
+    #[test]
+    fn files_scope_resolves_n_to_search_next() {
+        let bindings = default_bindings();
+        let n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&n, BindingScope::Files),
+            Some(Action::SearchNext)
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -72,4 +72,5 @@ pub struct ChangedFile {
     pub path: String,
     pub additions: usize,
     pub deletions: usize,
+    pub binary: bool,
 }


### PR DESCRIPTION
This updates the Changes pane so newly added folders expand into individual files, Enter still opens diffs, double-click opens diffs without making single-clicks risky, and / plus n search works directly in the pane.

It also improves diff accuracy for non-text files by showing explicit binary stats in the file list and a safe binary summary view instead of attempting a text diff. For untracked files, binary detection now prefers Git-native diff output before falling back to local inspection.

Verification: cargo test, cargo check, and cargo clippy --all-targets -- -D warnings all pass.