### PR TITLE
Add mouse support to floating overlays

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -29,6 +29,20 @@ enum MouseTarget {
     CommitText,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PromptMouseTarget {
+    CommandItem(usize),
+    BrowseProjectItem(usize),
+    PickEditorItem(usize),
+    ConfirmDeleteCancel,
+    ConfirmDeleteConfirm,
+    ConfirmQuitCancel,
+    ConfirmQuitConfirm,
+    ConfirmDiscardCancel,
+    ConfirmDiscardConfirm,
+    RenameInput,
+}
+
 fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
     rect.width > 0
         && rect.height > 0
@@ -901,24 +915,7 @@ impl App {
                             *searching = false;
                         }
                     } else {
-                        let command = if let PromptState::Command {
-                            input, selected, ..
-                        } = &self.prompt
-                        {
-                            if let Some(binding) =
-                                self.bindings.filtered_palette(input).get(*selected)
-                            {
-                                binding.palette_name.unwrap().to_string()
-                            } else {
-                                input.trim().to_string()
-                            }
-                        } else {
-                            String::new()
-                        };
-                        self.prompt = PromptState::None;
-                        if let Err(e) = self.execute_command(command) {
-                            self.set_error(format!("{e:#}"));
-                        }
+                        self.execute_selected_command_palette();
                     }
                 }
                 _ => {
@@ -1097,7 +1094,6 @@ impl App {
                 self.bindings.lookup(&key, BindingScope::Browser)
             };
 
-            let mut browse_to: Option<PathBuf> = None;
             match action {
                 Some(Action::CloseOverlay) => {
                     if let PromptState::BrowseProjects {
@@ -1173,34 +1169,7 @@ impl App {
                     }
                 }
                 Some(Action::OpenEntry) if !is_searching => {
-                    if let PromptState::BrowseProjects {
-                        current_dir,
-                        entries,
-                        loading,
-                        selected,
-                        filter,
-                        ..
-                    } = &mut self.prompt
-                    {
-                        let visible: Vec<_> = if filter.is_empty() {
-                            entries.iter().collect()
-                        } else {
-                            let needle = filter.to_lowercase();
-                            entries
-                                .iter()
-                                .filter(|e| e.label.to_lowercase().contains(&needle))
-                                .collect()
-                        };
-                        if let Some(entry) = visible.get(*selected).cloned() {
-                            let new_dir = entry.path.clone();
-                            *current_dir = new_dir.clone();
-                            entries.clear();
-                            *loading = true;
-                            *selected = 0;
-                            filter.clear();
-                            browse_to = Some(new_dir);
-                        }
-                    }
+                    self.open_selected_browser_entry();
                 }
                 Some(Action::AddCurrentDir) if !is_searching => {
                     if let PromptState::BrowseProjects { current_dir, .. } = &self.prompt {
@@ -1232,17 +1201,11 @@ impl App {
                     }
                 }
             }
-            if let Some(dir) = browse_to {
-                self.spawn_browser_entries(&dir);
-            }
             return Ok(false);
         }
 
         if let PromptState::PickEditor {
-            session_label,
-            worktree_path,
-            editors,
-            selected,
+            editors, selected, ..
         } = &mut self.prompt
         {
             match self.bindings.lookup(&key, BindingScope::Palette) {
@@ -1258,15 +1221,7 @@ impl App {
                     }
                 }
                 Some(Action::Confirm) => {
-                    let editor = editors.get(*selected).cloned();
-                    let worktree = worktree_path.clone();
-                    let label = session_label.clone();
-                    self.prompt = PromptState::None;
-                    if let Some(editor) = editor
-                        && let Err(e) = self.open_worktree_in_editor(&worktree, &label, &editor)
-                    {
-                        self.set_error(format!("{e:#}"));
-                    }
+                    self.open_selected_pick_editor();
                 }
                 _ => {}
             }
@@ -1274,9 +1229,7 @@ impl App {
         }
 
         if let PromptState::ConfirmDeleteAgent {
-            session_id,
-            confirm_selected,
-            ..
+            confirm_selected, ..
         } = &mut self.prompt
         {
             match self.bindings.lookup(&key, BindingScope::Dialog) {
@@ -1285,15 +1238,8 @@ impl App {
                     *confirm_selected = !*confirm_selected;
                 }
                 Some(Action::Confirm) => {
-                    if *confirm_selected {
-                        let id = session_id.clone();
-                        self.prompt = PromptState::None;
-                        if let Err(e) = self.do_delete_session(&id) {
-                            self.set_error(format!("{e:#}"));
-                        }
-                    } else {
-                        self.prompt = PromptState::None;
-                    }
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_delete_agent(confirm));
                 }
                 _ => {}
             }
@@ -1309,20 +1255,15 @@ impl App {
                     *confirm_selected = !*confirm_selected;
                 }
                 Some(Action::Confirm) => {
-                    if *confirm_selected {
-                        return Ok(true);
-                    } else {
-                        self.prompt = PromptState::None;
-                    }
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_quit(confirm));
                 }
                 _ => {}
             }
         }
 
         if let PromptState::ConfirmDiscardFile {
-            file_path,
-            is_untracked,
-            confirm_selected,
+            confirm_selected, ..
         } = &mut self.prompt
         {
             match self.bindings.lookup(&key, BindingScope::Dialog) {
@@ -1331,23 +1272,8 @@ impl App {
                     *confirm_selected = !*confirm_selected;
                 }
                 Some(Action::Confirm) => {
-                    if *confirm_selected {
-                        let fp = file_path.clone();
-                        let ut = *is_untracked;
-                        self.prompt = PromptState::None;
-                        if let Some(session) = self.selected_session() {
-                            let worktree = PathBuf::from(&session.worktree_path);
-                            match git::discard_file(&worktree, &fp, ut) {
-                                Ok(()) => {
-                                    self.set_info(format!("Discarded changes to \"{fp}\". File restored to last committed state."));
-                                    self.reload_changed_files();
-                                }
-                                Err(e) => self.set_error(format!("Discard failed: {e}")),
-                            }
-                        }
-                    } else {
-                        self.prompt = PromptState::None;
-                    }
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_discard_file(confirm));
                 }
                 _ => {}
             }
@@ -1449,6 +1375,87 @@ impl App {
     fn set_right_width_pct(&mut self, right_width_pct: u16) {
         self.right_width_pct = clamp_right_width_pct(right_width_pct, self.left_width_pct);
         self.left_width_pct = clamp_left_width_pct(self.left_width_pct, self.right_width_pct);
+    }
+
+    fn overlay_row_at(
+        rect: Rect,
+        offset: usize,
+        items: usize,
+        column: u16,
+        row: u16,
+    ) -> Option<usize> {
+        if !contains_point(rect, column, row) {
+            return None;
+        }
+        let relative_row = usize::from(row.saturating_sub(rect.y));
+        let index = offset.saturating_add(relative_row);
+        (index < items).then_some(index)
+    }
+
+    fn prompt_mouse_target(&self, column: u16, row: u16) -> Option<PromptMouseTarget> {
+        match self.overlay_layout.active {
+            OverlayMouseLayout::None | OverlayMouseLayout::Help => None,
+            OverlayMouseLayout::Command {
+                list,
+                items,
+                offset,
+                ..
+            } => Self::overlay_row_at(list, offset, items, column, row)
+                .map(PromptMouseTarget::CommandItem),
+            OverlayMouseLayout::BrowseProjects {
+                list,
+                items,
+                offset,
+                ..
+            } => Self::overlay_row_at(list, offset, items, column, row)
+                .map(PromptMouseTarget::BrowseProjectItem),
+            OverlayMouseLayout::PickEditor {
+                list,
+                items,
+                offset,
+                ..
+            } => Self::overlay_row_at(list, offset, items, column, row)
+                .map(PromptMouseTarget::PickEditorItem),
+            OverlayMouseLayout::ConfirmDeleteAgent {
+                cancel_button,
+                delete_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteCancel)
+                } else if contains_point(delete_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmQuit {
+                cancel_button,
+                quit_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmQuitCancel)
+                } else if contains_point(quit_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmQuitConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmDiscardFile {
+                cancel_button,
+                discard_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDiscardCancel)
+                } else if contains_point(discard_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDiscardConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::RenameSession { input } => {
+                contains_point(input, column, row).then_some(PromptMouseTarget::RenameInput)
+            }
+        }
     }
 
     fn mouse_target(&self, column: u16, row: u16) -> Option<MouseTarget> {
@@ -1562,6 +1569,241 @@ impl App {
         }
 
         self.last_mouse_click = Some(RecentMouseClick { target, at: now });
+        false
+    }
+
+    fn set_command_palette_selection(&mut self, index: usize) {
+        let count = match &self.prompt {
+            PromptState::Command { input, .. } => self.bindings.filtered_palette(input).len(),
+            _ => 0,
+        };
+        if count == 0 {
+            return;
+        }
+        if let PromptState::Command { selected, .. } = &mut self.prompt {
+            *selected = index.min(count.saturating_sub(1));
+        }
+    }
+
+    fn execute_selected_command_palette(&mut self) {
+        let command = if let PromptState::Command {
+            input, selected, ..
+        } = &self.prompt
+        {
+            if let Some(binding) = self.bindings.filtered_palette(input).get(*selected) {
+                binding.palette_name.unwrap().to_string()
+            } else {
+                input.trim().to_string()
+            }
+        } else {
+            String::new()
+        };
+        self.prompt = PromptState::None;
+        if let Err(e) = self.execute_command(command) {
+            self.set_error(format!("{e:#}"));
+        }
+    }
+
+    fn visible_browser_entries(&self) -> Vec<BrowserEntry> {
+        if let PromptState::BrowseProjects {
+            entries, filter, ..
+        } = &self.prompt
+        {
+            if filter.is_empty() {
+                entries.clone()
+            } else {
+                let needle = filter.to_lowercase();
+                entries
+                    .iter()
+                    .filter(|entry| entry.label.to_lowercase().contains(&needle))
+                    .cloned()
+                    .collect()
+            }
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn set_browser_selection(&mut self, index: usize) {
+        let count = self.visible_browser_entries().len();
+        if count == 0 {
+            return;
+        }
+        if let PromptState::BrowseProjects { selected, .. } = &mut self.prompt {
+            *selected = index.min(count.saturating_sub(1));
+        }
+    }
+
+    fn open_selected_browser_entry(&mut self) {
+        let visible = self.visible_browser_entries();
+        let mut browse_to: Option<PathBuf> = None;
+        if let PromptState::BrowseProjects {
+            current_dir,
+            entries,
+            loading,
+            selected,
+            filter,
+            ..
+        } = &mut self.prompt
+            && let Some(entry) = visible.get(*selected)
+        {
+            let new_dir = entry.path.clone();
+            *current_dir = new_dir.clone();
+            entries.clear();
+            *loading = true;
+            *selected = 0;
+            filter.clear();
+            browse_to = Some(new_dir);
+        }
+        if let Some(dir) = browse_to {
+            self.spawn_browser_entries(&dir);
+        }
+    }
+
+    fn set_pick_editor_selection(&mut self, index: usize) {
+        let count = match &self.prompt {
+            PromptState::PickEditor { editors, .. } => editors.len(),
+            _ => 0,
+        };
+        if count == 0 {
+            return;
+        }
+        if let PromptState::PickEditor { selected, .. } = &mut self.prompt {
+            *selected = index.min(count.saturating_sub(1));
+        }
+    }
+
+    fn open_selected_pick_editor(&mut self) {
+        let (editor, worktree, label) = if let PromptState::PickEditor {
+            session_label,
+            worktree_path,
+            editors,
+            selected,
+        } = &self.prompt
+        {
+            (
+                editors.get(*selected).cloned(),
+                worktree_path.clone(),
+                session_label.clone(),
+            )
+        } else {
+            return;
+        };
+        self.prompt = PromptState::None;
+        if let Some(editor) = editor
+            && let Err(e) = self.open_worktree_in_editor(&worktree, &label, &editor)
+        {
+            self.set_error(format!("{e:#}"));
+        }
+    }
+
+    fn resolve_confirm_delete_agent(&mut self, confirm: bool) -> bool {
+        let session_id = match &self.prompt {
+            PromptState::ConfirmDeleteAgent { session_id, .. } => session_id.clone(),
+            _ => return false,
+        };
+        self.prompt = PromptState::None;
+        if confirm && let Err(e) = self.do_delete_session(&session_id) {
+            self.set_error(format!("{e:#}"));
+        }
+        false
+    }
+
+    fn resolve_confirm_quit(&mut self, confirm: bool) -> bool {
+        if matches!(self.prompt, PromptState::ConfirmQuit { .. }) {
+            self.prompt = PromptState::None;
+        }
+        confirm
+    }
+
+    fn resolve_confirm_discard_file(&mut self, confirm: bool) -> bool {
+        let (file_path, is_untracked) = match &self.prompt {
+            PromptState::ConfirmDiscardFile {
+                file_path,
+                is_untracked,
+                ..
+            } => (file_path.clone(), *is_untracked),
+            _ => return false,
+        };
+        self.prompt = PromptState::None;
+        if confirm && let Some(session) = self.selected_session() {
+            let worktree = PathBuf::from(&session.worktree_path);
+            match git::discard_file(&worktree, &file_path, is_untracked) {
+                Ok(()) => {
+                    self.set_info(format!(
+                        "Discarded changes to \"{file_path}\". File restored to last committed state."
+                    ));
+                    self.reload_changed_files();
+                }
+                Err(e) => self.set_error(format!("Discard failed: {e}")),
+            }
+        }
+        false
+    }
+
+    fn set_rename_cursor_from_mouse(&mut self, column: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::RenameSession { input } => input,
+            _ => return,
+        };
+        if let PromptState::RenameSession { input, cursor, .. } = &mut self.prompt {
+            let relative_col = usize::from(column.saturating_sub(input_area.x));
+            *cursor = relative_col.saturating_sub(1).min(input.len());
+        }
+    }
+
+    fn handle_prompt_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+            return false;
+        }
+
+        let Some(target) = self.prompt_mouse_target(mouse.column, mouse.row) else {
+            return false;
+        };
+
+        match target {
+            PromptMouseTarget::CommandItem(index) => {
+                let double_click = self.register_mouse_click(MouseClickTarget::CommandItem(index));
+                self.set_command_palette_selection(index);
+                if double_click {
+                    self.execute_selected_command_palette();
+                }
+            }
+            PromptMouseTarget::BrowseProjectItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::BrowseProjectItem(index));
+                self.set_browser_selection(index);
+                if double_click {
+                    self.open_selected_browser_entry();
+                }
+            }
+            PromptMouseTarget::PickEditorItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::PickEditorItem(index));
+                self.set_pick_editor_selection(index);
+                if double_click {
+                    self.open_selected_pick_editor();
+                }
+            }
+            PromptMouseTarget::ConfirmDeleteCancel => {
+                return self.resolve_confirm_delete_agent(false);
+            }
+            PromptMouseTarget::ConfirmDeleteConfirm => {
+                return self.resolve_confirm_delete_agent(true);
+            }
+            PromptMouseTarget::ConfirmQuitCancel => return self.resolve_confirm_quit(false),
+            PromptMouseTarget::ConfirmQuitConfirm => return self.resolve_confirm_quit(true),
+            PromptMouseTarget::ConfirmDiscardCancel => {
+                return self.resolve_confirm_discard_file(false);
+            }
+            PromptMouseTarget::ConfirmDiscardConfirm => {
+                return self.resolve_confirm_discard_file(true);
+            }
+            PromptMouseTarget::RenameInput => {
+                self.set_rename_cursor_from_mouse(mouse.column);
+            }
+        }
+
         false
     }
 
@@ -1844,9 +2086,9 @@ impl App {
         }
     }
 
-    pub(crate) fn handle_mouse(&mut self, mouse: MouseEvent) {
+    pub(crate) fn handle_mouse(&mut self, mouse: MouseEvent) -> bool {
         if !matches!(self.prompt, PromptState::None) {
-            return;
+            return self.handle_prompt_mouse(mouse);
         }
 
         if let Some(ref mut scroll) = self.help_scroll {
@@ -1862,7 +2104,7 @@ impl App {
                 }
                 _ => {}
             }
-            return;
+            return false;
         }
 
         match mouse.kind {
@@ -1870,7 +2112,7 @@ impl App {
                 if let Some(drag) = self.resize_drag_at_mouse(mouse.column, mouse.row) {
                     self.mouse_drag = Some(drag);
                     self.update_dragged_widths(mouse.column);
-                    return;
+                    return false;
                 }
 
                 match self.mouse_target(mouse.column, mouse.row) {
@@ -1988,6 +2230,7 @@ impl App {
             },
             _ => {}
         }
+        false
     }
 }
 
@@ -1998,9 +2241,11 @@ mod tests {
     use std::sync::{Arc, Mutex, mpsc};
 
     use crate::app::{
-        App, CenterMode, FocusPane, InputTarget, MouseLayoutState, PromptState, RightSection,
+        App, CenterMode, FocusPane, InputTarget, MouseLayoutState, OverlayMouseLayout,
+        OverlayMouseLayoutState, PromptState, RightSection,
     };
     use crate::config::{Config, DuxPaths};
+    use crate::editor::{DetectedEditor, EditorKind};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
     use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
     use crate::pty::PtyClient;
@@ -2130,6 +2375,7 @@ mod tests {
             collapsed_projects: std::collections::HashSet::new(),
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
+            overlay_layout: OverlayMouseLayoutState::default(),
             mouse_drag: None,
             last_mouse_click: None,
         };
@@ -2159,6 +2405,57 @@ mod tests {
             staged_list: Some(Rect::new(78, 9, 21, 5)),
             commit_area: Some(Rect::new(77, 14, 23, 6)),
             commit_text_area: Some(Rect::new(78, 15, 21, 4)),
+        };
+    }
+
+    fn install_command_overlay(app: &mut App, items: usize) {
+        app.overlay_layout.active = OverlayMouseLayout::Command {
+            list: Rect::new(15, 9, 70, 6),
+            items,
+            offset: 0,
+        };
+    }
+
+    fn install_browser_overlay(app: &mut App, items: usize) {
+        app.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+            list: Rect::new(15, 6, 70, 8),
+            items,
+            offset: 0,
+        };
+    }
+
+    fn install_pick_editor_overlay(app: &mut App, items: usize) {
+        app.overlay_layout.active = OverlayMouseLayout::PickEditor {
+            list: Rect::new(19, 8, 62, 6),
+            items,
+            offset: 0,
+        };
+    }
+
+    fn install_confirm_delete_overlay(app: &mut App) {
+        app.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
+            cancel_button: Rect::new(34, 10, 16, 3),
+            delete_button: Rect::new(52, 10, 16, 3),
+        };
+    }
+
+    fn install_confirm_quit_overlay(app: &mut App) {
+        app.overlay_layout.active = OverlayMouseLayout::ConfirmQuit {
+            cancel_button: Rect::new(34, 10, 16, 3),
+            quit_button: Rect::new(52, 10, 16, 3),
+        };
+    }
+
+    fn install_confirm_discard_overlay(app: &mut App) {
+        app.overlay_layout.active = OverlayMouseLayout::ConfirmDiscardFile {
+            cancel_button: Rect::new(34, 10, 16, 3),
+            discard_button: Rect::new(52, 10, 16, 3),
+        };
+    }
+
+    fn install_rename_overlay(app: &mut App) {
+        app.overlay_layout.active = OverlayMouseLayout::RenameSession {
+            input: Rect::new(24, 10, 30, 1),
         };
     }
 
@@ -2813,6 +3110,209 @@ mod tests {
         assert_eq!(app.config.ui.left_width_pct, app.left_width_pct);
         assert_eq!(app.config.ui.right_width_pct, app.right_width_pct);
         assert_eq!(app.config.ui.right_width_pct, original_right);
+    }
+
+    #[test]
+    fn mouse_click_command_palette_row_selects_then_double_click_executes() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::Command {
+            input: "help".to_string(),
+            selected: 0,
+            searching: false,
+        };
+        install_command_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 15, 9));
+        assert!(matches!(
+            app.prompt,
+            PromptState::Command { selected: 0, .. }
+        ));
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 15, 9));
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(app.help_scroll, Some(0));
+    }
+
+    #[test]
+    fn mouse_click_project_browser_row_selects_then_double_click_opens_entry() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        let child = root.join("child");
+        std::fs::create_dir_all(&child).expect("child dir");
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root.clone(),
+            entries: vec![crate::app::BrowserEntry {
+                path: child.clone(),
+                label: "child/".to_string(),
+                is_git_repo: false,
+            }],
+            loading: false,
+            selected: 0,
+            filter: String::new(),
+            searching: false,
+            editing_path: false,
+            path_input: String::new(),
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+        install_browser_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 15, 6));
+        assert!(matches!(
+            app.prompt,
+            PromptState::BrowseProjects { selected: 0, .. }
+        ));
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 15, 6));
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                current_dir,
+                loading,
+                selected,
+                ..
+            } => {
+                assert_eq!(current_dir, &child);
+                assert!(*loading);
+                assert_eq!(*selected, 0);
+            }
+            _ => panic!("expected browse projects prompt"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_pick_editor_row_selects_then_double_click_opens_editor() {
+        let mut app = test_app(default_bindings());
+        std::fs::create_dir_all(&app.sessions[0].worktree_path).expect("worktree");
+        app.prompt = PromptState::PickEditor {
+            session_label: "agent-branch".to_string(),
+            worktree_path: app.sessions[0].worktree_path.clone(),
+            editors: vec![DetectedEditor {
+                kind: EditorKind::VsCode,
+                label: "VS Code",
+                config_key: "vscode",
+                command: "true".to_string(),
+            }],
+            selected: 0,
+        };
+        install_pick_editor_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 20, 8));
+        assert!(matches!(
+            app.prompt,
+            PromptState::PickEditor { selected: 0, .. }
+        ));
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 20, 8));
+        assert!(matches!(app.prompt, PromptState::None));
+        assert!(app.status.text().contains("Opened agent"));
+    }
+
+    #[test]
+    fn mouse_click_quit_dialog_buttons_cancel_or_exit() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfirmQuit {
+            active_count: 1,
+            confirm_selected: false,
+        };
+        install_confirm_quit_overlay(&mut app);
+        let should_quit = app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 35, 10));
+        assert!(!should_quit);
+        assert!(matches!(app.prompt, PromptState::None));
+
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfirmQuit {
+            active_count: 1,
+            confirm_selected: true,
+        };
+        install_confirm_quit_overlay(&mut app);
+        let should_quit = app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 53, 10));
+        assert!(should_quit);
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn mouse_click_discard_dialog_button_discards_changes() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        init_git_repo_with_modified_file(
+            &app,
+            "src/main.rs",
+            "fn main() {}\n",
+            "fn main() { println!(\"hi\"); }\n",
+        );
+        app.selected_left = 1;
+        app.unstaged_files = vec![ChangedFile {
+            path: "src/main.rs".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 1,
+            binary: false,
+        }];
+        app.prompt = PromptState::ConfirmDiscardFile {
+            file_path: "src/main.rs".to_string(),
+            is_untracked: false,
+            confirm_selected: true,
+        };
+        install_confirm_discard_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 53, 10));
+
+        assert!(matches!(app.prompt, PromptState::None));
+        let contents = std::fs::read_to_string(
+            PathBuf::from(&app.sessions[0].worktree_path).join("src/main.rs"),
+        )
+        .expect("discarded file");
+        assert_eq!(contents, "fn main() {}\n");
+    }
+
+    #[test]
+    fn mouse_click_delete_dialog_cancel_button_closes_prompt() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfirmDeleteAgent {
+            session_id: app.sessions[0].id.clone(),
+            branch_name: app.sessions[0].branch_name.clone(),
+            confirm_selected: false,
+        };
+        install_confirm_delete_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 35, 10));
+
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn mouse_click_rename_input_moves_cursor() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::RenameSession {
+            session_id: app.sessions[0].id.clone(),
+            input: "rename me".to_string(),
+            cursor: 0,
+        };
+        install_rename_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 29, 10));
+
+        match app.prompt {
+            PromptState::RenameSession { cursor, .. } => assert_eq!(cursor, 4),
+            _ => panic!("expected rename prompt"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_while_prompt_open_does_not_change_underlying_focus() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Left;
+        app.prompt = PromptState::Command {
+            input: "help".to_string(),
+            selected: 0,
+            searching: false,
+        };
+        install_command_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+
+        assert_eq!(app.focus, FocusPane::Left);
+        assert!(matches!(app.prompt, PromptState::Command { .. }));
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -31,7 +31,9 @@ enum MouseTarget {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PromptMouseTarget {
+    CommandInput,
     CommandItem(usize),
+    BrowseProjectInput,
     BrowseProjectItem(usize),
     PickEditorItem(usize),
     ConfirmDeleteCancel,
@@ -50,6 +52,85 @@ fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
         && column < rect.x + rect.width
         && row >= rect.y
         && row < rect.y + rect.height
+}
+
+fn prev_char_boundary(text: &str, index: usize) -> usize {
+    let index = index.min(text.len());
+    text[..index]
+        .char_indices()
+        .last()
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+fn next_char_boundary(text: &str, index: usize) -> usize {
+    let index = index.min(text.len());
+    text[index..]
+        .char_indices()
+        .nth(1)
+        .map(|(offset, _)| index + offset)
+        .unwrap_or(text.len())
+}
+
+fn clamp_cursor(text: &str, cursor: usize) -> usize {
+    if cursor >= text.len() {
+        return text.len();
+    }
+    if text.is_char_boundary(cursor) {
+        cursor
+    } else {
+        prev_char_boundary(text, cursor)
+    }
+}
+
+fn move_cursor_left(text: &str, cursor: &mut usize) {
+    *cursor = prev_char_boundary(text, *cursor);
+}
+
+fn move_cursor_right(text: &str, cursor: &mut usize) {
+    *cursor = next_char_boundary(text, *cursor);
+}
+
+fn insert_at_cursor(text: &mut String, cursor: &mut usize, ch: char) {
+    let index = clamp_cursor(text, *cursor);
+    text.insert(index, ch);
+    *cursor = index + ch.len_utf8();
+}
+
+fn backspace_at_cursor(text: &mut String, cursor: &mut usize) {
+    let index = clamp_cursor(text, *cursor);
+    if index == 0 {
+        return;
+    }
+    let prev = prev_char_boundary(text, index);
+    text.replace_range(prev..index, "");
+    *cursor = prev;
+}
+
+fn delete_at_cursor(text: &mut String, cursor: &mut usize) {
+    let index = clamp_cursor(text, *cursor);
+    if index >= text.len() {
+        return;
+    }
+    let next = next_char_boundary(text, index);
+    text.replace_range(index..next, "");
+    *cursor = index;
+}
+
+fn cursor_from_single_line_position(
+    text: &str,
+    text_area: Rect,
+    prefix_width: usize,
+    column: u16,
+) -> usize {
+    let relative_col = usize::from(column.saturating_sub(text_area.x));
+    let target_col = relative_col
+        .saturating_sub(prefix_width)
+        .min(text.chars().count());
+    text.char_indices()
+        .nth(target_col)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len())
 }
 
 fn clamp_left_width_pct(left_width_pct: u16, right_width_pct: u16) -> u16 {
@@ -227,6 +308,7 @@ impl App {
                 Action::OpenPalette => {
                     self.prompt = PromptState::Command {
                         input: String::new(),
+                        cursor: 0,
                         selected: 0,
                         searching: false,
                     };
@@ -887,7 +969,14 @@ impl App {
                     }
                 }
                 Some(Action::SearchToggle) if !is_searching => {
-                    if let PromptState::Command { searching, .. } = &mut self.prompt {
+                    if let PromptState::Command {
+                        input,
+                        cursor,
+                        searching,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        *cursor = clamp_cursor(input, input.len());
                         *searching = true;
                     }
                 }
@@ -921,7 +1010,10 @@ impl App {
                 _ => {
                     // Text input fallback: Tab (autocomplete), Backspace, Char.
                     if let PromptState::Command {
-                        input, selected, ..
+                        input,
+                        cursor,
+                        selected,
+                        ..
                     } = &mut self.prompt
                     {
                         match key.code {
@@ -930,15 +1022,32 @@ impl App {
                                     self.bindings.filtered_palette(input).get(*selected)
                                 {
                                     *input = binding.palette_name.unwrap().to_string();
+                                    *cursor = input.len();
                                     *selected = 0;
                                 }
                             }
                             KeyCode::Backspace => {
-                                input.pop();
+                                backspace_at_cursor(input, cursor);
                                 *selected = 0;
                             }
+                            KeyCode::Delete => {
+                                delete_at_cursor(input, cursor);
+                                *selected = 0;
+                            }
+                            KeyCode::Left => {
+                                move_cursor_left(input, cursor);
+                            }
+                            KeyCode::Right => {
+                                move_cursor_right(input, cursor);
+                            }
+                            KeyCode::Home => {
+                                *cursor = 0;
+                            }
+                            KeyCode::End => {
+                                *cursor = input.len();
+                            }
                             KeyCode::Char(c) if is_plain_char => {
-                                input.push(c);
+                                insert_at_cursor(input, cursor, c);
                                 *selected = 0;
                             }
                             _ => {}
@@ -978,6 +1087,7 @@ impl App {
                     filter,
                     editing_path,
                     path_input,
+                    path_cursor,
                     tab_completions,
                     tab_index,
                     ..
@@ -989,11 +1099,13 @@ impl App {
                         KeyCode::Esc => {
                             *editing_path = false;
                             path_input.clear();
+                            *path_cursor = 0;
                             tab_completions.clear();
                             *tab_index = 0;
                         }
                         KeyCode::Backspace => {
-                            path_input.pop();
+                            backspace_at_cursor(path_input, path_cursor);
+                            *path_cursor = clamp_cursor(path_input, *path_cursor);
                             tab_completions.clear();
                             *tab_index = 0;
                         }
@@ -1050,6 +1162,7 @@ impl App {
                             }
                             if let Some(completion) = tab_completions.get(*tab_index) {
                                 *path_input = completion.clone();
+                                *path_cursor = path_input.len();
                             }
                         }
                         KeyCode::Enter => {
@@ -1067,11 +1180,33 @@ impl App {
                             }
                             *editing_path = false;
                             path_input.clear();
+                            *path_cursor = 0;
                             tab_completions.clear();
                             *tab_index = 0;
                         }
                         KeyCode::Char(c) if is_plain_char => {
-                            path_input.push(c);
+                            insert_at_cursor(path_input, path_cursor, c);
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        KeyCode::Delete => {
+                            delete_at_cursor(path_input, path_cursor);
+                            tab_completions.clear();
+                            *tab_index = 0;
+                        }
+                        KeyCode::Left => {
+                            move_cursor_left(path_input, path_cursor);
+                        }
+                        KeyCode::Right => {
+                            move_cursor_right(path_input, path_cursor);
+                        }
+                        KeyCode::Home => {
+                            *path_cursor = 0;
+                        }
+                        KeyCode::End => {
+                            *path_cursor = path_input.len();
+                        }
+                        KeyCode::Up | KeyCode::Down => {
                             tab_completions.clear();
                             *tab_index = 0;
                         }
@@ -1099,6 +1234,7 @@ impl App {
                     if let PromptState::BrowseProjects {
                         searching,
                         filter,
+                        filter_cursor,
                         selected,
                         ..
                     } = &mut self.prompt
@@ -1107,6 +1243,7 @@ impl App {
                             *searching = false;
                         } else if !filter.is_empty() {
                             filter.clear();
+                            *filter_cursor = 0;
                             *selected = 0;
                         } else {
                             self.prompt = PromptState::None;
@@ -1114,7 +1251,14 @@ impl App {
                     }
                 }
                 Some(Action::SearchToggle) if !is_searching => {
-                    if let PromptState::BrowseProjects { searching, .. } = &mut self.prompt {
+                    if let PromptState::BrowseProjects {
+                        filter,
+                        filter_cursor,
+                        searching,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        *filter_cursor = filter.len();
                         *searching = true;
                     }
                 }
@@ -1152,6 +1296,7 @@ impl App {
                         current_dir,
                         editing_path,
                         path_input,
+                        path_cursor,
                         ..
                     } = &mut self.prompt
                     {
@@ -1161,6 +1306,7 @@ impl App {
                             p.push('/');
                         }
                         *path_input = p;
+                        *path_cursor = path_input.len();
                     }
                 }
                 Some(Action::Confirm) if is_searching => {
@@ -1184,16 +1330,35 @@ impl App {
                     // Text input fallback for search mode.
                     if is_searching
                         && let PromptState::BrowseProjects {
-                            filter, selected, ..
+                            filter,
+                            filter_cursor,
+                            selected,
+                            ..
                         } = &mut self.prompt
                     {
                         match key.code {
                             KeyCode::Backspace => {
-                                filter.pop();
+                                backspace_at_cursor(filter, filter_cursor);
                                 *selected = 0;
                             }
+                            KeyCode::Delete => {
+                                delete_at_cursor(filter, filter_cursor);
+                                *selected = 0;
+                            }
+                            KeyCode::Left => {
+                                move_cursor_left(filter, filter_cursor);
+                            }
+                            KeyCode::Right => {
+                                move_cursor_right(filter, filter_cursor);
+                            }
+                            KeyCode::Home => {
+                                *filter_cursor = 0;
+                            }
+                            KeyCode::End => {
+                                *filter_cursor = filter.len();
+                            }
                             KeyCode::Char(c) if is_plain_char => {
-                                filter.push(c);
+                                insert_at_cursor(filter, filter_cursor, c);
                                 *selected = 0;
                             }
                             _ => {}
@@ -1396,19 +1561,33 @@ impl App {
         match self.overlay_layout.active {
             OverlayMouseLayout::None | OverlayMouseLayout::Help => None,
             OverlayMouseLayout::Command {
+                input,
                 list,
                 items,
                 offset,
                 ..
-            } => Self::overlay_row_at(list, offset, items, column, row)
-                .map(PromptMouseTarget::CommandItem),
+            } => {
+                if contains_point(input, column, row) {
+                    Some(PromptMouseTarget::CommandInput)
+                } else {
+                    Self::overlay_row_at(list, offset, items, column, row)
+                        .map(PromptMouseTarget::CommandItem)
+                }
+            }
             OverlayMouseLayout::BrowseProjects {
+                input,
                 list,
                 items,
                 offset,
                 ..
-            } => Self::overlay_row_at(list, offset, items, column, row)
-                .map(PromptMouseTarget::BrowseProjectItem),
+            } => {
+                if input.is_some_and(|rect| contains_point(rect, column, row)) {
+                    Some(PromptMouseTarget::BrowseProjectInput)
+                } else {
+                    Self::overlay_row_at(list, offset, items, column, row)
+                        .map(PromptMouseTarget::BrowseProjectItem)
+                }
+            }
             OverlayMouseLayout::PickEditor {
                 list,
                 items,
@@ -1585,6 +1764,17 @@ impl App {
         }
     }
 
+    fn set_command_palette_cursor_from_mouse(&mut self, column: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::Command { input, .. } => input,
+            _ => return,
+        };
+        if let PromptState::Command { input, cursor, .. } = &mut self.prompt {
+            let prefix_width = 2; // "> " or "/ "
+            *cursor = cursor_from_single_line_position(input, input_area, prefix_width, column);
+        }
+    }
+
     fn execute_selected_command_palette(&mut self) {
         let command = if let PromptState::Command {
             input, selected, ..
@@ -1634,6 +1824,32 @@ impl App {
         }
     }
 
+    fn set_browser_input_cursor_from_mouse(&mut self, column: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::BrowseProjects {
+                input: Some(input), ..
+            } => input,
+            _ => return,
+        };
+        if let PromptState::BrowseProjects {
+            filter,
+            filter_cursor,
+            searching,
+            editing_path,
+            path_input,
+            path_cursor,
+            ..
+        } = &mut self.prompt
+        {
+            if *editing_path {
+                *path_cursor = cursor_from_single_line_position(path_input, input_area, 4, column);
+            } else {
+                *filter_cursor = cursor_from_single_line_position(filter, input_area, 2, column);
+                *searching = true;
+            }
+        }
+    }
+
     fn open_selected_browser_entry(&mut self) {
         let visible = self.visible_browser_entries();
         let mut browse_to: Option<PathBuf> = None;
@@ -1643,6 +1859,7 @@ impl App {
             loading,
             selected,
             filter,
+            filter_cursor,
             ..
         } = &mut self.prompt
             && let Some(entry) = visible.get(*selected)
@@ -1653,6 +1870,7 @@ impl App {
             *loading = true;
             *selected = 0;
             filter.clear();
+            *filter_cursor = 0;
             browse_to = Some(new_dir);
         }
         if let Some(dir) = browse_to {
@@ -1747,8 +1965,7 @@ impl App {
             _ => return,
         };
         if let PromptState::RenameSession { input, cursor, .. } = &mut self.prompt {
-            let relative_col = usize::from(column.saturating_sub(input_area.x));
-            *cursor = relative_col.saturating_sub(1).min(input.len());
+            *cursor = cursor_from_single_line_position(input, input_area, 0, column);
         }
     }
 
@@ -1762,12 +1979,18 @@ impl App {
         };
 
         match target {
+            PromptMouseTarget::CommandInput => {
+                self.set_command_palette_cursor_from_mouse(mouse.column);
+            }
             PromptMouseTarget::CommandItem(index) => {
                 let double_click = self.register_mouse_click(MouseClickTarget::CommandItem(index));
                 self.set_command_palette_selection(index);
                 if double_click {
                     self.execute_selected_command_palette();
                 }
+            }
+            PromptMouseTarget::BrowseProjectInput => {
+                self.set_browser_input_cursor_from_mouse(mouse.column);
             }
             PromptMouseTarget::BrowseProjectItem(index) => {
                 let double_click =
@@ -2410,6 +2633,7 @@ mod tests {
 
     fn install_command_overlay(app: &mut App, items: usize) {
         app.overlay_layout.active = OverlayMouseLayout::Command {
+            input: Rect::new(15, 7, 70, 1),
             list: Rect::new(15, 9, 70, 6),
             items,
             offset: 0,
@@ -2418,6 +2642,7 @@ mod tests {
 
     fn install_browser_overlay(app: &mut App, items: usize) {
         app.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+            input: Some(Rect::new(15, 4, 70, 1)),
             list: Rect::new(15, 6, 70, 8),
             items,
             offset: 0,
@@ -3117,6 +3342,7 @@ mod tests {
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::Command {
             input: "help".to_string(),
+            cursor: 4,
             selected: 0,
             searching: false,
         };
@@ -3131,6 +3357,30 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 15, 9));
         assert!(matches!(app.prompt, PromptState::None));
         assert_eq!(app.help_scroll, Some(0));
+    }
+
+    #[test]
+    fn mouse_click_command_palette_input_moves_cursor_and_keyboard_inserts_there() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::Command {
+            input: "help".to_string(),
+            cursor: 4,
+            selected: 0,
+            searching: false,
+        };
+        install_command_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 19, 7));
+        app.handle_key(KeyEvent::new(KeyCode::Char('X'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::Command { input, cursor, .. } => {
+                assert_eq!(input, "heXlp");
+                assert_eq!(*cursor, 3);
+            }
+            other => panic!("expected command prompt, got {other:?}"),
+        }
     }
 
     #[test]
@@ -3149,9 +3399,11 @@ mod tests {
             loading: false,
             selected: 0,
             filter: String::new(),
+            filter_cursor: 0,
             searching: false,
             editing_path: false,
             path_input: String::new(),
+            path_cursor: 0,
             tab_completions: Vec::new(),
             tab_index: 0,
         };
@@ -3176,6 +3428,80 @@ mod tests {
                 assert_eq!(*selected, 0);
             }
             _ => panic!("expected browse projects prompt"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_browser_search_input_moves_cursor_and_edits_filter() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: PathBuf::from(&app.projects[0].path),
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: "child".to_string(),
+            filter_cursor: 5,
+            searching: false,
+            editing_path: false,
+            path_input: String::new(),
+            path_cursor: 0,
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+        install_browser_overlay(&mut app, 0);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 19, 4));
+        app.handle_key(KeyEvent::new(KeyCode::Char('X'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                filter,
+                filter_cursor,
+                searching,
+                ..
+            } => {
+                assert_eq!(filter, "chXild");
+                assert_eq!(*filter_cursor, 3);
+                assert!(*searching);
+            }
+            other => panic!("expected browse projects prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_browser_path_input_moves_cursor_and_edits_path() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: PathBuf::from(&app.projects[0].path),
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: String::new(),
+            filter_cursor: 0,
+            searching: false,
+            editing_path: true,
+            path_input: "abcd".to_string(),
+            path_cursor: 4,
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+        install_browser_overlay(&mut app, 0);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 20, 4));
+        app.handle_key(KeyEvent::new(KeyCode::Char('X'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                path_input,
+                path_cursor,
+                ..
+            } => {
+                assert_eq!(path_input, "aXbcd");
+                assert_eq!(*path_cursor, 2);
+            }
+            other => panic!("expected browse projects prompt, got {other:?}"),
         }
     }
 
@@ -3293,7 +3619,7 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 29, 10));
 
         match app.prompt {
-            PromptState::RenameSession { cursor, .. } => assert_eq!(cursor, 4),
+            PromptState::RenameSession { cursor, .. } => assert_eq!(cursor, 5),
             _ => panic!("expected rename prompt"),
         }
     }
@@ -3304,6 +3630,7 @@ mod tests {
         app.focus = FocusPane::Left;
         app.prompt = PromptState::Command {
             input: "help".to_string(),
+            cursor: 4,
             selected: 0,
             searching: false,
         };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -171,6 +171,7 @@ pub(crate) enum PromptState {
     None,
     Command {
         input: String,
+        cursor: usize,
         selected: usize,
         searching: bool,
     },
@@ -180,9 +181,11 @@ pub(crate) enum PromptState {
         loading: bool,
         selected: usize,
         filter: String,
+        filter_cursor: usize,
         searching: bool,
         editing_path: bool,
         path_input: String,
+        path_cursor: usize,
         tab_completions: Vec<String>,
         tab_index: usize,
     },
@@ -279,11 +282,13 @@ pub(crate) enum OverlayMouseLayout {
     None,
     Help,
     Command {
+        input: Rect,
         list: Rect,
         items: usize,
         offset: usize,
     },
     BrowseProjects {
+        input: Option<Rect>,
         list: Rect,
         items: usize,
         offset: usize,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -85,6 +85,7 @@ pub struct App {
     pub(crate) collapsed_projects: HashSet<String>,
     pub(crate) left_items_cache: Vec<LeftItem>,
     pub(crate) mouse_layout: MouseLayoutState,
+    pub(crate) overlay_layout: OverlayMouseLayoutState,
     pub(crate) mouse_drag: Option<ResizeDragState>,
     pub(crate) last_mouse_click: Option<RecentMouseClick>,
 }
@@ -261,6 +262,54 @@ impl MouseLayoutState {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct OverlayMouseLayoutState {
+    pub(crate) active: OverlayMouseLayout,
+}
+
+impl OverlayMouseLayoutState {
+    pub(crate) fn reset(&mut self) {
+        self.active = OverlayMouseLayout::None;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum OverlayMouseLayout {
+    #[default]
+    None,
+    Help,
+    Command {
+        list: Rect,
+        items: usize,
+        offset: usize,
+    },
+    BrowseProjects {
+        list: Rect,
+        items: usize,
+        offset: usize,
+    },
+    PickEditor {
+        list: Rect,
+        items: usize,
+        offset: usize,
+    },
+    ConfirmDeleteAgent {
+        cancel_button: Rect,
+        delete_button: Rect,
+    },
+    ConfirmQuit {
+        cancel_button: Rect,
+        quit_button: Rect,
+    },
+    ConfirmDiscardFile {
+        cancel_button: Rect,
+        discard_button: Rect,
+    },
+    RenameSession {
+        input: Rect,
+    },
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ResizeDragState {
     LeftDivider,
@@ -273,6 +322,9 @@ pub(crate) enum MouseClickTarget {
     CenterPane,
     UnstagedFile(usize),
     StagedFile(usize),
+    CommandItem(usize),
+    BrowseProjectItem(usize),
+    PickEditorItem(usize),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -389,6 +441,7 @@ impl App {
             collapsed_projects: HashSet::new(),
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
+            overlay_layout: OverlayMouseLayoutState::default(),
             mouse_drag: None,
             last_mouse_click: None,
         };
@@ -415,7 +468,11 @@ impl App {
                                 break;
                             }
                         }
-                        Event::Mouse(mouse) => self.handle_mouse(mouse),
+                        Event::Mouse(mouse) => {
+                            if self.handle_mouse(mouse) {
+                                break;
+                            }
+                        }
                         Event::Resize(_, _) => {}
                         _ => {}
                     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -57,6 +57,7 @@ impl App {
                 .areas(body)
         };
         self.mouse_layout.reset(body, left, center, right);
+        self.overlay_layout.reset();
         self.render_left(frame, left);
         self.render_center(frame, center);
         self.render_files(frame, right);
@@ -1033,6 +1034,7 @@ impl App {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(1), Constraint::Length(hint_height)])
             .areas(inner);
+        self.overlay_layout.active = OverlayMouseLayout::Help;
 
         // Build help content lines.
         let mut lines: Vec<Line> = Vec::new();
@@ -1179,7 +1181,7 @@ impl App {
         }
     }
 
-    fn render_prompt(&self, frame: &mut Frame) {
+    fn render_prompt(&mut self, frame: &mut Frame) {
         match &self.prompt {
             PromptState::Command {
                 input,
@@ -1282,19 +1284,24 @@ impl App {
                             .title_bottom(Line::from(bottom_spans)),
                     )
                     .render(input_area, frame.buffer_mut());
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_type(ratatui::widgets::BorderType::Rounded)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let list_inner = list_block.inner(list_area);
                 StatefulWidget::render(
                     List::new(items)
-                        .block(
-                            Block::default()
-                                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
-                                .border_type(ratatui::widgets::BorderType::Rounded)
-                                .border_style(Style::default().fg(self.theme.overlay_border)),
-                        )
+                        .block(list_block)
                         .highlight_style(self.theme.selection_style()),
                     list_area,
                     frame.buffer_mut(),
                     &mut state,
                 );
+                self.overlay_layout.active = OverlayMouseLayout::Command {
+                    list: list_inner,
+                    items: commands.len(),
+                    offset: state.offset(),
+                };
             }
             PromptState::BrowseProjects {
                 current_dir,
@@ -1441,19 +1448,24 @@ impl App {
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
                     }
+                    let list_block = Block::default()
+                        .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                        .border_style(Style::default().fg(self.theme.overlay_border))
+                        .title_bottom(Line::from(bottom_spans));
+                    let list_inner = list_block.inner(list_render_area);
                     StatefulWidget::render(
                         List::new(items)
-                            .block(
-                                Block::default()
-                                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
-                                    .border_style(Style::default().fg(self.theme.overlay_border))
-                                    .title_bottom(Line::from(bottom_spans)),
-                            )
+                            .block(list_block)
                             .highlight_style(self.theme.selection_style()),
                         list_render_area,
                         frame.buffer_mut(),
                         &mut state,
                     );
+                    self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+                        list: list_inner,
+                        items: visible.len(),
+                        offset: state.offset(),
+                    };
                 } else {
                     let search_key = self.bindings.label_for(Action::SearchToggle);
                     let open_key = self.bindings.label_for(Action::OpenEntry);
@@ -1486,20 +1498,24 @@ impl App {
                         " cancel",
                         Style::default().fg(self.theme.hint_desc_fg),
                     ));
+                    let title = format!("Add Project: {}", current_dir.display());
+                    let list_block = self
+                        .themed_overlay_block(&title)
+                        .title_bottom(Line::from(bottom_spans));
+                    let list_inner = list_block.inner(list_render_area);
                     StatefulWidget::render(
                         List::new(items)
-                            .block(
-                                self.themed_overlay_block(&format!(
-                                    "Add Project: {}",
-                                    current_dir.display()
-                                ))
-                                .title_bottom(Line::from(bottom_spans)),
-                            )
+                            .block(list_block)
                             .highlight_style(self.theme.selection_style()),
                         list_render_area,
                         frame.buffer_mut(),
                         &mut state,
                     );
+                    self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+                        list: list_inner,
+                        items: visible.len(),
+                        offset: state.offset(),
+                    };
                 }
             }
             PromptState::PickEditor {
@@ -1588,18 +1604,23 @@ impl App {
                     .collect::<Vec<_>>();
                 let mut state = ListState::default()
                     .with_selected(Some((*selected).min(editors.len().saturating_sub(1))));
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let list_inner = list_block.inner(list_area);
                 StatefulWidget::render(
                     List::new(items)
-                        .block(
-                            Block::default()
-                                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
-                                .border_style(Style::default().fg(self.theme.overlay_border)),
-                        )
+                        .block(list_block)
                         .highlight_style(self.theme.selection_style()),
                     list_area,
                     frame.buffer_mut(),
                     &mut state,
                 );
+                self.overlay_layout.active = OverlayMouseLayout::PickEditor {
+                    list: list_inner,
+                    items: editors.len(),
+                    offset: state.offset(),
+                };
             }
             PromptState::ConfirmDeleteAgent {
                 branch_name,
@@ -1703,6 +1724,10 @@ impl App {
                         .border_style(Style::default().fg(delete_border)),
                 )
                 .render(delete_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
+                    cancel_button: cancel_area,
+                    delete_button: delete_area,
+                };
             }
             PromptState::ConfirmQuit {
                 active_count,
@@ -1807,6 +1832,10 @@ impl App {
                         .border_style(Style::default().fg(quit_border)),
                 )
                 .render(quit_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmQuit {
+                    cancel_button: cancel_area,
+                    quit_button: quit_area,
+                };
             }
             PromptState::ConfirmDiscardFile {
                 file_path,
@@ -1906,6 +1935,10 @@ impl App {
                         .border_style(Style::default().fg(discard_border)),
                 )
                 .render(discard_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmDiscardFile {
+                    cancel_button: cancel_area,
+                    discard_button: discard_area,
+                };
             }
             PromptState::RenameSession { input, cursor, .. } => {
                 self.render_dim_overlay(frame);
@@ -1949,13 +1982,13 @@ impl App {
                         Span::styled(" ", Style::default().fg(Color::Black).bg(Color::White)),
                     ])
                 };
+                let input_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(Color::Cyan));
+                let input_inner = input_block.inner(input_area);
                 Paragraph::new(display)
-                    .block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .border_set(border::ROUNDED)
-                            .border_style(Style::default().fg(Color::Cyan)),
-                    )
+                    .block(input_block)
                     .render(input_area, frame.buffer_mut());
 
                 let confirm_key = self.bindings.label_for(Action::Confirm);
@@ -1972,6 +2005,8 @@ impl App {
                     Style::default().fg(self.theme.hint_desc_fg),
                 ));
                 Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                self.overlay_layout.active =
+                    OverlayMouseLayout::RenameSession { input: input_inner };
             }
             PromptState::None => {}
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1185,6 +1185,7 @@ impl App {
         match &self.prompt {
             PromptState::Command {
                 input,
+                cursor,
                 selected,
                 searching,
             } => {
@@ -1278,12 +1279,17 @@ impl App {
                     ));
                 }
                 let prompt_prefix = if *searching { "/ " } else { "> " };
-                Paragraph::new(format!("{prompt_prefix}{input}"))
-                    .block(
-                        self.themed_overlay_block(title)
-                            .title_bottom(Line::from(bottom_spans)),
-                    )
-                    .render(input_area, frame.buffer_mut());
+                let input_block = self
+                    .themed_overlay_block(title)
+                    .title_bottom(Line::from(bottom_spans));
+                let input_inner = input_block.inner(input_area);
+                Paragraph::new(render_single_line_cursor_input(
+                    prompt_prefix,
+                    input,
+                    *cursor,
+                ))
+                .block(input_block)
+                .render(input_area, frame.buffer_mut());
                 let list_block = Block::default()
                     .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
                     .border_type(ratatui::widgets::BorderType::Rounded)
@@ -1298,6 +1304,7 @@ impl App {
                     &mut state,
                 );
                 self.overlay_layout.active = OverlayMouseLayout::Command {
+                    input: input_inner,
                     list: list_inner,
                     items: commands.len(),
                     offset: state.offset(),
@@ -1309,9 +1316,11 @@ impl App {
                 loading,
                 selected,
                 filter,
+                filter_cursor,
                 searching,
                 editing_path,
                 path_input,
+                path_cursor,
                 ..
             } => {
                 self.render_dim_overlay(frame);
@@ -1384,13 +1393,15 @@ impl App {
                 };
                 if let Some(filter_area) = top_areas {
                     let title = format!("Add Project: {}", current_dir.display());
-                    let input_text = if *editing_path {
-                        format!("go: {path_input}█")
+                    let (prefix, text, cursor) = if *editing_path {
+                        ("go: ", path_input.as_str(), *path_cursor)
                     } else {
-                        format!("/ {filter}")
+                        ("/ ", filter.as_str(), *filter_cursor)
                     };
-                    Paragraph::new(input_text)
-                        .block(self.themed_overlay_block(&title))
+                    let input_block = self.themed_overlay_block(&title);
+                    let input_inner = input_block.inner(filter_area);
+                    Paragraph::new(render_single_line_cursor_input(prefix, text, cursor))
+                        .block(input_block)
                         .render(filter_area, frame.buffer_mut());
                     let confirm_key = self.bindings.label_for(Action::Confirm);
                     let close_key = self.bindings.label_for(Action::CloseOverlay);
@@ -1462,6 +1473,7 @@ impl App {
                         &mut state,
                     );
                     self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+                        input: Some(input_inner),
                         list: list_inner,
                         items: visible.len(),
                         offset: state.offset(),
@@ -1512,6 +1524,7 @@ impl App {
                         &mut state,
                     );
                     self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
+                        input: None,
                         list: list_inner,
                         items: visible.len(),
                         offset: state.offset(),
@@ -2136,6 +2149,30 @@ pub(crate) fn centered_rect_exact(width: u16, height: u16, area: Rect) -> Rect {
     let x = area.x + area.width.saturating_sub(width) / 2;
     let y = area.y + area.height.saturating_sub(height) / 2;
     Rect::new(x, y, width, height)
+}
+
+fn render_single_line_cursor_input(prefix: &str, text: &str, cursor: usize) -> Line<'static> {
+    let cursor = cursor.min(text.len());
+    if cursor < text.len() {
+        let (before, after) = text.split_at(cursor);
+        let cursor_char = after.chars().next().expect("cursor within text");
+        let cursor_len = cursor_char.len_utf8();
+        let rest = &after[cursor_len..];
+        Line::from(vec![
+            Span::raw(prefix.to_string()),
+            Span::raw(before.to_string()),
+            Span::styled(
+                cursor_char.to_string(),
+                Style::default().fg(Color::Black).bg(Color::White),
+            ),
+            Span::raw(rest.to_string()),
+        ])
+    } else {
+        Line::from(vec![
+            Span::raw(format!("{prefix}{text}")),
+            Span::styled(" ", Style::default().fg(Color::Black).bg(Color::White)),
+        ])
+    }
 }
 
 fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -23,9 +23,11 @@ impl App {
             loading: true,
             selected: 0,
             filter: String::new(),
+            filter_cursor: 0,
             searching: false,
             editing_path: false,
             path_input: String::new(),
+            path_cursor: 0,
             tab_completions: Vec::new(),
             tab_index: 0,
         };


### PR DESCRIPTION
## Summary
- add render-time hitbox tracking for floating overlays and dialogs
- route mouse input to overlays before underlying panes
- support single-click buttons plus single-click select / double-click activate for overlay lists
- add mouse cursor placement and cursor-aware editing for overlay text inputs

## Why
The main TUI panes already had strong mouse support, but floating UI like the command palette and confirmation dialogs ignored mouse clicks. After fixing overlay list/button interactions, the remaining gap was that command/browser text boxes still behaved like append-only keyboard fields.

## User impact
Users can now interact with the command palette, project browser, editor picker, confirmation dialogs, and rename dialog using the mouse in a way that matches the existing pane behavior. They can also click inside the command palette and project browser text inputs to reposition the cursor and edit in place.

## Root cause
Mouse handling short-circuited whenever a prompt overlay was open, overlay render code did not persist hitboxes for click routing, and command/browser prompt state did not track cursor positions for text editing.

## Validation
- `cargo fmt --check`
- `cargo check --quiet`
- `cargo test --quiet`
