### PR TITLE
Companion terminal as floating overlay with multi-terminal support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ The current app provides:
 - User state lives under `~/.dux/` on macOS and `$XDG_CONFIG_HOME/dux/` (or `~/.config/dux/`) on Linux.
 - Worktrees are user data and should not be removed or mutated casually.
 - Git operations should be explicit and conservative, especially around the source checkout.
+- **Target platforms are macOS and Linux only.** Windows users run dux through WSL2, which is Linux. Do not add `#[cfg(windows)]` branches, `cfg!(windows)` checks, or Windows-specific code paths. Assume Unix throughout.
 
 ## App Module Structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "rusqlite",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.140"
 toml = "0.8.20"
 uuid = { version = "1.17.0", features = ["v4"] }
 portable-pty = "0.9"
+rustix = { version = "1.1", features = ["termios", "process"] }
 alacritty_terminal = "0.25.1"
 petname = { version = "2.0.2", default-features = false, features = ["default-rng", "default-words"] }
 similar = "2"

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -21,6 +21,8 @@ enum AgentWheelRoute {
 enum MouseTarget {
     LeftPane,
     LeftRow(usize),
+    TerminalRow(usize),
+    TerminalPane,
     Center,
     FilesPane,
     UnstagedFile(Option<usize>),
@@ -143,6 +145,9 @@ fn clamp_right_width_pct(right_width_pct: u16, left_width_pct: u16) -> u16 {
     right_width_pct.clamp(MIN_RIGHT_WIDTH_PCT, max_right.max(MIN_RIGHT_WIDTH_PCT))
 }
 
+const MIN_TERMINAL_PANE_HEIGHT_PCT: u16 = 10;
+const MAX_TERMINAL_PANE_HEIGHT_PCT: u16 = 80;
+
 fn pct_from_columns(columns: u16, total_width: u16) -> u16 {
     if total_width == 0 {
         return 0;
@@ -243,7 +248,10 @@ impl App {
         // (ExitInteractive, handled inside handle_agent_input). This must
         // happen before global bindings so CloseOverlay / Escape do not
         // intercept agent input during interactive mode.
-        if self.input_target == InputTarget::Agent {
+        if matches!(
+            self.input_target,
+            InputTarget::Agent | InputTarget::Terminal
+        ) {
             return self.handle_agent_input(key);
         }
         if self.bindings.lookup(&key, BindingScope::Global) == Some(Action::CloseOverlay)
@@ -288,10 +296,12 @@ impl App {
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Global) {
             match action {
                 Action::Quit => {
-                    let active_count = self.providers.len();
-                    if active_count > 0 {
+                    let agent_count = self.providers.len();
+                    let terminal_count = self.running_companion_terminal_count();
+                    if agent_count + terminal_count > 0 {
                         self.prompt = PromptState::ConfirmQuit {
-                            active_count,
+                            agent_count,
+                            terminal_count,
                             confirm_selected: false,
                         };
                         return Ok(false);
@@ -316,7 +326,18 @@ impl App {
                 }
                 Action::FocusNext => {
                     let has_staged = !self.staged_files.is_empty();
-                    if self.focus == FocusPane::Files {
+                    if self.focus == FocusPane::Left
+                        && self.left_section == LeftSection::Projects
+                        && self.has_terminal_items()
+                    {
+                        self.left_section = LeftSection::Terminals;
+                        self.clamp_terminal_cursor();
+                    } else if self.focus == FocusPane::Left
+                        && self.left_section == LeftSection::Terminals
+                    {
+                        self.left_section = LeftSection::Projects;
+                        self.focus = self.focus.next();
+                    } else if self.focus == FocusPane::Files {
                         match self.right_section.next(has_staged) {
                             Some(next) => {
                                 self.right_section = next;
@@ -324,6 +345,7 @@ impl App {
                             }
                             None => {
                                 self.focus = self.focus.next();
+                                self.left_section = LeftSection::Projects;
                             }
                         }
                     } else {
@@ -331,14 +353,27 @@ impl App {
                         if self.focus == FocusPane::Files {
                             self.right_section = RightSection::first();
                             self.clamp_files_cursor();
+                        } else if self.focus == FocusPane::Left {
+                            self.left_section = LeftSection::Projects;
                         }
                     }
                     self.input_target = InputTarget::None;
-                    self.fullscreen_agent = false;
+                    self.fullscreen_overlay = FullscreenOverlay::None;
                 }
                 Action::FocusPrev => {
                     let has_staged = !self.staged_files.is_empty();
-                    if self.focus == FocusPane::Files {
+                    if self.focus == FocusPane::Left && self.left_section == LeftSection::Terminals
+                    {
+                        self.left_section = LeftSection::Projects;
+                    } else if self.focus == FocusPane::Left
+                        && self.left_section == LeftSection::Projects
+                    {
+                        self.focus = self.focus.previous();
+                        if self.focus == FocusPane::Files {
+                            self.right_section = RightSection::last(has_staged);
+                            self.clamp_files_cursor();
+                        }
+                    } else if self.focus == FocusPane::Files {
                         match self.right_section.previous() {
                             Some(prev) => {
                                 self.right_section = prev;
@@ -353,10 +388,17 @@ impl App {
                         if self.focus == FocusPane::Files {
                             self.right_section = RightSection::last(has_staged);
                             self.clamp_files_cursor();
+                        } else if self.focus == FocusPane::Left {
+                            if self.has_terminal_items() {
+                                self.left_section = LeftSection::Terminals;
+                                self.clamp_terminal_cursor();
+                            } else {
+                                self.left_section = LeftSection::Projects;
+                            }
                         }
                     }
                     self.input_target = InputTarget::None;
-                    self.fullscreen_agent = false;
+                    self.fullscreen_overlay = FullscreenOverlay::None;
                 }
                 Action::ToggleSidebar => {
                     self.left_collapsed = !self.left_collapsed;
@@ -392,6 +434,10 @@ impl App {
     }
 
     fn handle_left_key(&mut self, key: KeyEvent) -> Result<()> {
+        if self.left_section == LeftSection::Terminals {
+            return self.handle_left_terminal_key(key);
+        }
+
         let item_count = self.left_items().len();
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Left) {
             match action {
@@ -399,6 +445,10 @@ impl App {
                     if self.selected_left + 1 < item_count {
                         self.selected_left += 1;
                         self.reload_changed_files();
+                    } else if self.has_terminal_items() {
+                        // Jump to terminals section.
+                        self.left_section = LeftSection::Terminals;
+                        self.selected_terminal_index = 0;
                     }
                 }
                 Action::MoveUp => {
@@ -413,6 +463,7 @@ impl App {
                 }
                 Action::NewAgent => self.create_agent_for_selected_project()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
+                Action::ShowTerminal => self.show_companion_terminal()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
                 Action::RenameSession => self.open_rename_session()?,
                 Action::CycleProvider => self.cycle_selected_project_provider()?,
@@ -430,7 +481,7 @@ impl App {
                         self.focus = FocusPane::Center;
                         self.center_mode = CenterMode::Agent;
                         self.input_target = InputTarget::Agent;
-                        self.fullscreen_agent = true;
+                        self.fullscreen_overlay = FullscreenOverlay::Agent;
                         let exit_key = self.bindings.label_for(Action::ExitInteractive);
                         self.set_info(format!(
                             "Interactive mode. Keys forwarded to agent. {exit_key} exits."
@@ -449,11 +500,46 @@ impl App {
         Ok(())
     }
 
+    fn handle_left_terminal_key(&mut self, key: KeyEvent) -> Result<()> {
+        let term_count = self.terminal_items().len();
+        if let Some(action) = self.bindings.lookup(&key, BindingScope::Left) {
+            match action {
+                Action::MoveDown => {
+                    if self.selected_terminal_index + 1 < term_count {
+                        self.selected_terminal_index += 1;
+                    }
+                }
+                Action::MoveUp => {
+                    if self.selected_terminal_index > 0 {
+                        self.selected_terminal_index -= 1;
+                    } else {
+                        // Jump back to projects section.
+                        self.left_section = LeftSection::Projects;
+                        let item_count = self.left_items().len();
+                        if item_count > 0 {
+                            self.selected_left = item_count - 1;
+                        }
+                    }
+                }
+                Action::FocusAgent => {
+                    // Open terminal overlay for the selected terminal item.
+                    self.open_terminal_from_terminal_list()?;
+                }
+                Action::ShowTerminal => {
+                    self.open_terminal_from_terminal_list()?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
     fn handle_center_key(&mut self, key: KeyEvent) -> Result<()> {
         let in_diff = matches!(self.center_mode, CenterMode::Diff { .. });
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Center) {
             match action {
                 Action::FocusAgent if !in_diff => self.activate_center_agent()?,
+                Action::ShowTerminal if !in_diff => self.show_companion_terminal()?,
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.
@@ -464,7 +550,7 @@ impl App {
                     if has_provider {
                         self.reset_pty_scrollback();
                         self.input_target = InputTarget::Agent;
-                        self.fullscreen_agent = true;
+                        self.fullscreen_overlay = FullscreenOverlay::Agent;
                     } else if self.selected_session().is_some() {
                         self.reconnect_selected_session()?;
                     }
@@ -512,12 +598,8 @@ impl App {
     }
 
     fn scroll_pty(&mut self, direction: ScrollDirection, amount: usize) {
-        let sid = match self.selected_session() {
-            Some(s) => s.id.clone(),
-            None => return,
-        };
-        let provider = match self.providers.get(&sid) {
-            Some(p) => p,
+        let provider = match self.selected_terminal_surface_client() {
+            Some(provider) => provider,
             None => return,
         };
         let up = matches!(direction, ScrollDirection::Up);
@@ -525,9 +607,7 @@ impl App {
     }
 
     fn reset_pty_scrollback(&self) {
-        if let Some(session) = self.selected_session()
-            && let Some(provider) = self.providers.get(&session.id)
-        {
+        if let Some(provider) = self.selected_terminal_surface_client() {
             provider.set_scrollback(0);
         }
     }
@@ -826,18 +906,20 @@ impl App {
     }
 
     fn handle_agent_input(&mut self, key: KeyEvent) -> Result<bool> {
-        let session_id = match self.selected_session() {
-            Some(s) => s.id.clone(),
-            None => {
-                self.input_target = InputTarget::None;
-                return Ok(false);
-            }
-        };
-        let provider = match self.providers.get(&session_id) {
+        if self.selected_session().is_none() {
+            self.input_target = InputTarget::None;
+            return Ok(false);
+        }
+        let surface = self.session_surface;
+        let provider = match self.selected_terminal_surface_client() {
             Some(p) => p,
             None => {
                 self.input_target = InputTarget::None;
-                self.set_error("Agent disconnected.");
+                let label = match surface {
+                    SessionSurface::Agent => "Agent",
+                    SessionSurface::Terminal => "Companion terminal",
+                };
+                self.set_error(format!("{label} disconnected."));
                 return Ok(false);
             }
         };
@@ -846,11 +928,9 @@ impl App {
         if let Some(Action::ExitInteractive) = self.bindings.lookup(&key, BindingScope::Interactive)
         {
             self.input_target = InputTarget::None;
-            self.fullscreen_agent = false;
-            let reenter_key = self.bindings.label_for(Action::FocusAgent);
-            self.set_info(format!(
-                "Exited interactive mode. Press {reenter_key} to re-enter."
-            ));
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.session_surface = SessionSurface::Agent;
+            self.set_info("Exited interactive mode.");
             return Ok(false);
         }
 
@@ -1638,7 +1718,7 @@ impl App {
     }
 
     fn mouse_target(&self, column: u16, row: u16) -> Option<MouseTarget> {
-        if self.fullscreen_agent {
+        if !matches!(self.fullscreen_overlay, FullscreenOverlay::None) {
             return self
                 .mouse_layout
                 .agent_term
@@ -1655,6 +1735,18 @@ impl App {
                 return Some(MouseTarget::LeftRow(index));
             }
             return Some(MouseTarget::LeftPane);
+        }
+
+        {
+            let tl = self.mouse_layout.terminal_list;
+            if tl.width > 0 && tl.height > 0 && contains_point(tl, column, row) {
+                let index = usize::from(row.saturating_sub(tl.y));
+                let term_count = self.terminal_items().len();
+                if index < term_count {
+                    return Some(MouseTarget::TerminalRow(index));
+                }
+                return Some(MouseTarget::TerminalPane);
+            }
         }
 
         if contains_point(self.mouse_layout.left, column, row) {
@@ -1721,6 +1813,16 @@ impl App {
             return Some(ResizeDragState::RightDivider);
         }
 
+        // Horizontal divider between Projects and Terminals sections.
+        let tl = self.mouse_layout.terminal_list;
+        if tl.width > 0 && tl.height > 0 {
+            let left = self.mouse_layout.left;
+            let divider_row = tl.y.saturating_sub(1);
+            if row == divider_row && column >= left.x && column < left.x + left.width {
+                return Some(ResizeDragState::TerminalDivider);
+            }
+        }
+
         None
     }
 
@@ -1730,7 +1832,7 @@ impl App {
         }
         self.focus = FocusPane::Left;
         self.input_target = InputTarget::None;
-        self.fullscreen_agent = false;
+        self.fullscreen_overlay = FullscreenOverlay::None;
         if self.selected_left != index {
             self.selected_left = index;
             self.reload_changed_files();
@@ -2053,7 +2155,7 @@ impl App {
                             .unwrap_or(false)
                         {
                             self.input_target = InputTarget::Agent;
-                            self.fullscreen_agent = true;
+                            self.fullscreen_overlay = FullscreenOverlay::Agent;
                         } else if self.selected_session().is_some() {
                             self.reconnect_selected_session()?;
                         }
@@ -2072,7 +2174,7 @@ impl App {
                     .unwrap_or(false)
                 {
                     self.input_target = InputTarget::Agent;
-                    self.fullscreen_agent = true;
+                    self.fullscreen_overlay = FullscreenOverlay::Agent;
                 } else if self.selected_session().is_some() {
                     self.reconnect_selected_session()?;
                 }
@@ -2088,7 +2190,7 @@ impl App {
         }
     }
 
-    fn activate_center_agent(&mut self) -> Result<()> {
+    pub(crate) fn activate_center_agent(&mut self) -> Result<()> {
         if !matches!(self.center_mode, CenterMode::Agent) {
             return Ok(());
         }
@@ -2100,7 +2202,7 @@ impl App {
         {
             self.reset_pty_scrollback();
             self.input_target = InputTarget::Agent;
-            self.fullscreen_agent = true;
+            self.fullscreen_overlay = FullscreenOverlay::Agent;
             let exit_key = self.bindings.label_for(Action::ExitInteractive);
             self.set_info(format!(
                 "Interactive mode. Keys forwarded to agent. {exit_key} exits."
@@ -2131,7 +2233,7 @@ impl App {
     fn set_file_selection(&mut self, section: RightSection, index: Option<usize>) {
         self.focus = FocusPane::Files;
         self.input_target = InputTarget::None;
-        self.fullscreen_agent = false;
+        self.fullscreen_overlay = FullscreenOverlay::None;
         self.right_section = section;
         if let Some(index) = index {
             self.files_index = index;
@@ -2143,7 +2245,7 @@ impl App {
         self.focus = FocusPane::Files;
         self.right_section = RightSection::CommitInput;
         self.input_target = InputTarget::CommitMessage;
-        self.fullscreen_agent = false;
+        self.fullscreen_overlay = FullscreenOverlay::None;
     }
 
     fn commit_scroll_max(&self) -> u16 {
@@ -2244,10 +2346,10 @@ impl App {
         let Some(area) = self.mouse_layout.agent_term else {
             return;
         };
-        let Some(session_id) = self.selected_session().map(|session| session.id.clone()) else {
+        let Some(_session_id) = self.selected_session().map(|session| session.id.clone()) else {
             return;
         };
-        let Some(provider) = self.providers.get(&session_id) else {
+        let Some(provider) = self.selected_terminal_surface_client() else {
             return;
         };
 
@@ -2276,7 +2378,7 @@ impl App {
         }
     }
 
-    fn update_dragged_widths(&mut self, column: u16) {
+    fn update_dragged_panes(&mut self, column: u16, row: u16) {
         let body = self.mouse_layout.body;
         if body.width == 0 {
             return;
@@ -2295,6 +2397,17 @@ impl App {
                 let columns = body_right.saturating_sub(column).clamp(1, body.width);
                 self.set_right_width_pct(pct_from_columns(columns, body.width));
             }
+            Some(ResizeDragState::TerminalDivider) => {
+                let left = self.mouse_layout.left;
+                if left.height > 0 {
+                    // Terminal height = distance from mouse row to bottom of left pane.
+                    let left_bottom = left.y + left.height;
+                    let term_rows = left_bottom.saturating_sub(row).clamp(1, left.height);
+                    let pct = pct_from_columns(term_rows, left.height); // reuse same % helper
+                    self.terminal_pane_height_pct =
+                        pct.clamp(MIN_TERMINAL_PANE_HEIGHT_PCT, MAX_TERMINAL_PANE_HEIGHT_PCT);
+                }
+            }
             None => {}
         }
     }
@@ -2302,9 +2415,11 @@ impl App {
     fn persist_pane_widths(&mut self) {
         if self.config.ui.left_width_pct != self.left_width_pct
             || self.config.ui.right_width_pct != self.right_width_pct
+            || self.config.ui.terminal_pane_height_pct != self.terminal_pane_height_pct
         {
             self.config.ui.left_width_pct = self.left_width_pct;
             self.config.ui.right_width_pct = self.right_width_pct;
+            self.config.ui.terminal_pane_height_pct = self.terminal_pane_height_pct;
             let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
         }
     }
@@ -2334,7 +2449,7 @@ impl App {
             MouseEventKind::Down(MouseButton::Left) => {
                 if let Some(drag) = self.resize_drag_at_mouse(mouse.column, mouse.row) {
                     self.mouse_drag = Some(drag);
-                    self.update_dragged_widths(mouse.column);
+                    self.update_dragged_panes(mouse.column, mouse.row);
                     return false;
                 }
 
@@ -2342,11 +2457,12 @@ impl App {
                     Some(MouseTarget::LeftPane) => {
                         self.focus = FocusPane::Left;
                         self.input_target = InputTarget::None;
-                        self.fullscreen_agent = false;
+                        self.fullscreen_overlay = FullscreenOverlay::None;
                     }
                     Some(MouseTarget::LeftRow(index)) => {
                         let double_click =
                             self.register_mouse_click(MouseClickTarget::LeftRow(index));
+                        self.left_section = LeftSection::Projects;
                         self.set_left_selection(index);
                         if double_click {
                             match self.left_items().get(self.selected_left) {
@@ -2360,6 +2476,24 @@ impl App {
                             }
                         }
                     }
+                    Some(MouseTarget::TerminalRow(index)) => {
+                        let double_click =
+                            self.register_mouse_click(MouseClickTarget::TerminalRow(index));
+                        self.focus = FocusPane::Left;
+                        self.left_section = LeftSection::Terminals;
+                        self.selected_terminal_index = index;
+                        self.input_target = InputTarget::None;
+                        self.fullscreen_overlay = FullscreenOverlay::None;
+                        if double_click {
+                            let _ = self.open_terminal_from_terminal_list();
+                        }
+                    }
+                    Some(MouseTarget::TerminalPane) => {
+                        self.focus = FocusPane::Left;
+                        self.left_section = LeftSection::Terminals;
+                        self.input_target = InputTarget::None;
+                        self.fullscreen_overlay = FullscreenOverlay::None;
+                    }
                     Some(MouseTarget::Center) => {
                         let double_click = self.register_mouse_click(MouseClickTarget::CenterPane);
                         self.focus = FocusPane::Center;
@@ -2370,7 +2504,7 @@ impl App {
                     Some(MouseTarget::FilesPane) => {
                         self.focus = FocusPane::Files;
                         self.input_target = InputTarget::None;
-                        self.fullscreen_agent = false;
+                        self.fullscreen_overlay = FullscreenOverlay::None;
                     }
                     Some(MouseTarget::UnstagedFile(index)) => {
                         let double_click = index
@@ -2407,7 +2541,7 @@ impl App {
             }
             MouseEventKind::Drag(MouseButton::Left) => {
                 if self.mouse_drag.is_some() {
-                    self.update_dragged_widths(mouse.column);
+                    self.update_dragged_panes(mouse.column, mouse.row);
                 }
             }
             MouseEventKind::Up(MouseButton::Left) => {
@@ -2464,13 +2598,16 @@ mod tests {
     use std::sync::{Arc, Mutex, mpsc};
 
     use crate::app::{
-        App, CenterMode, FocusPane, InputTarget, MouseLayoutState, OverlayMouseLayout,
-        OverlayMouseLayoutState, PromptState, RightSection,
+        App, CenterMode, FocusPane, FullscreenOverlay, InputTarget, LeftSection, MouseLayoutState,
+        OverlayMouseLayout, OverlayMouseLayoutState, PromptState, RightSection,
     };
     use crate::config::{Config, DuxPaths};
     use crate::editor::{DetectedEditor, EditorKind};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
-    use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
+    use crate::model::{
+        AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
+        SessionSurface,
+    };
     use crate::pty::PtyClient;
     use crate::statusline::StatusLine;
     use crate::storage::SessionStore;
@@ -2563,6 +2700,8 @@ mod tests {
             staged_files: Vec::new(),
             unstaged_files: Vec::new(),
             selected_left: 0,
+            left_section: crate::app::LeftSection::Projects,
+            selected_terminal_index: 0,
             right_section: RightSection::Unstaged,
             files_index: 0,
             files_search_query: String::new(),
@@ -2573,6 +2712,7 @@ mod tests {
             commit_generating: false,
             left_width_pct: 20,
             right_width_pct: 23,
+            terminal_pane_height_pct: 35,
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             left_collapsed: false,
@@ -2580,13 +2720,17 @@ mod tests {
             help_scroll: None,
             last_help_height: 0,
             last_help_lines: 0,
-            fullscreen_agent: false,
+            fullscreen_overlay: FullscreenOverlay::None,
             status: StatusLine::new("ready"),
             prompt: PromptState::None,
             input_target: InputTarget::None,
+            session_surface: crate::model::SessionSurface::Agent,
             worker_tx,
             worker_rx,
             providers: std::collections::HashMap::new(),
+            companion_terminals: std::collections::HashMap::new(),
+            active_terminal_id: None,
+            terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
             last_diff_height: 0,
@@ -2594,7 +2738,7 @@ mod tests {
             theme: Theme::default_dark(),
             tick_count: 0,
             watched_worktree: Arc::new(Mutex::new(None::<PathBuf>)),
-            has_active_agent: Arc::new(AtomicBool::new(false)),
+            has_active_processes: Arc::new(AtomicBool::new(false)),
             collapsed_projects: std::collections::HashSet::new(),
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
@@ -2623,6 +2767,7 @@ mod tests {
             center: Rect::new(20, 0, 57, 20),
             right: Rect::new(77, 0, 23, 20),
             left_list: Rect::new(1, 1, 18, 10),
+            terminal_list: Rect::default(),
             agent_term: Some(Rect::new(21, 1, 55, 16)),
             unstaged_list: Some(Rect::new(78, 1, 21, 8)),
             staged_list: Some(Rect::new(78, 9, 21, 5)),
@@ -2795,13 +2940,13 @@ mod tests {
     fn open_rename_session_clears_interactive_target() {
         let mut app = test_app(default_bindings());
         app.input_target = InputTarget::Agent;
-        app.fullscreen_agent = true;
+        app.fullscreen_overlay = FullscreenOverlay::Agent;
 
         app.open_rename_session().unwrap();
 
         assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
         assert_eq!(app.input_target, InputTarget::None);
-        assert!(!app.fullscreen_agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
     }
 
     #[test]
@@ -3096,7 +3241,7 @@ mod tests {
         assert!(app.collapsed_projects.contains(&project_id));
         assert_eq!(app.selected_left, 0);
         assert_eq!(app.input_target, InputTarget::None);
-        assert!(!app.fullscreen_agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
     }
 
     #[test]
@@ -3125,7 +3270,7 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 9));
 
         assert_eq!(app.focus, FocusPane::Left);
-        assert!(!app.fullscreen_agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
         assert_eq!(app.input_target, InputTarget::None);
         assert!(matches!(app.center_mode, CenterMode::Agent));
         assert_eq!(app.selected_left, 1);
@@ -3156,7 +3301,7 @@ mod tests {
 
         assert_eq!(app.focus, FocusPane::Center);
         assert_eq!(app.input_target, InputTarget::Agent);
-        assert!(app.fullscreen_agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
     }
 
     #[test]
@@ -3537,7 +3682,8 @@ mod tests {
     fn mouse_click_quit_dialog_buttons_cancel_or_exit() {
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::ConfirmQuit {
-            active_count: 1,
+            agent_count: 1,
+            terminal_count: 0,
             confirm_selected: false,
         };
         install_confirm_quit_overlay(&mut app);
@@ -3547,13 +3693,205 @@ mod tests {
 
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::ConfirmQuit {
-            active_count: 1,
+            agent_count: 1,
+            terminal_count: 0,
             confirm_selected: true,
         };
         install_confirm_quit_overlay(&mut app);
         let should_quit = app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 53, 10));
         assert!(should_quit);
         assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn quit_prompt_counts_running_companion_terminals_and_agents() {
+        let mut app = test_app(default_bindings());
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let (command, args) = ("/bin/sh", vec!["-c".to_string(), "sleep 5".to_string()]);
+        let provider =
+            PtyClient::spawn(command, &args, worktree, 24, 80, 1_000).expect("spawn test agent");
+        let session_id = app.sessions[0].id.clone();
+        app.providers.insert(session_id.clone(), provider);
+        // Insert a companion terminal to simulate a running terminal.
+        let term_client =
+            PtyClient::spawn(command, &args, worktree, 24, 80, 1_000).expect("spawn test terminal");
+        app.companion_terminals.insert(
+            "term-test".to_string(),
+            crate::app::CompanionTerminal {
+                session_id,
+                label: "test".to_string(),
+                foreground_cmd: None,
+                client: term_client,
+            },
+        );
+
+        let should_quit = app
+            .handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE))
+            .expect("handle quit");
+
+        assert!(!should_quit);
+        match app.prompt {
+            PromptState::ConfirmQuit {
+                agent_count,
+                terminal_count,
+                ..
+            } => {
+                assert_eq!(agent_count, 1);
+                assert_eq!(terminal_count, 1);
+            }
+            _ => panic!("expected quit confirmation"),
+        }
+    }
+
+    #[test]
+    fn launch_companion_terminal_sets_runtime_state_and_overlay() {
+        let mut app = test_app(default_bindings());
+
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(
+            app.selected_companion_terminal_status(),
+            CompanionTerminalStatus::Running
+        );
+        assert_eq!(app.companion_terminals.len(), 1);
+        assert!(app.active_terminal_id.is_some());
+        assert_eq!(app.session_surface, SessionSurface::Terminal);
+        assert_eq!(app.input_target, InputTarget::Terminal);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Terminal);
+    }
+
+    #[test]
+    fn multiple_terminals_per_session() {
+        let mut app = test_app(default_bindings());
+
+        app.show_companion_terminal().expect("first terminal");
+        let first_id = app.active_terminal_id.clone().unwrap();
+
+        // Close overlay, launch another.
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.input_target = InputTarget::None;
+        app.session_surface = SessionSurface::Agent;
+
+        app.show_companion_terminal().expect("second terminal");
+        let second_id = app.active_terminal_id.clone().unwrap();
+
+        assert_ne!(first_id, second_id);
+        assert_eq!(app.companion_terminals.len(), 2);
+        assert_eq!(app.terminal_items().len(), 2);
+    }
+
+    #[test]
+    fn exit_interactive_from_terminal_overlay_resets_state() {
+        let mut app = test_app(default_bindings());
+
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Terminal);
+        assert_eq!(app.input_target, InputTarget::Terminal);
+
+        // Simulate Ctrl-G (ExitInteractive).
+        let ctrl_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
+        app.handle_key(ctrl_g).unwrap();
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        assert_eq!(app.session_surface, SessionSurface::Agent);
+        assert_eq!(app.input_target, InputTarget::None);
+    }
+
+    #[test]
+    fn close_top_overlay_closes_terminal_overlay() {
+        let mut app = test_app(default_bindings());
+
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Terminal);
+
+        let closed = app.close_top_overlay();
+        assert!(closed);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        assert_eq!(app.session_surface, SessionSurface::Agent);
+        // Terminal PTY should still be alive in the map.
+        assert_eq!(app.companion_terminals.len(), 1);
+    }
+
+    #[test]
+    fn session_switch_closes_terminal_overlay_but_keeps_pty() {
+        let mut app = test_app(default_bindings());
+
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Terminal);
+
+        // Switch to project row (index 0) — simulates user clicking a different item.
+        app.set_left_selection(0);
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        // Terminal PTY should still be alive.
+        assert_eq!(app.companion_terminals.len(), 1);
+    }
+
+    #[test]
+    fn terminal_items_returns_running_terminals() {
+        let mut app = test_app(default_bindings());
+
+        // No terminals launched yet.
+        assert!(app.terminal_items().is_empty());
+
+        // Launch a terminal.
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.terminal_items().len(), 1);
+    }
+
+    #[test]
+    fn left_section_navigation_crosses_to_terminals() {
+        let mut app = test_app(default_bindings());
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+        // Close overlay and go back to projects section.
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.input_target = InputTarget::None;
+        app.session_surface = SessionSurface::Agent;
+        app.left_section = LeftSection::Projects;
+        app.focus = FocusPane::Left;
+
+        // Navigate down past the last project item.
+        let item_count = app.left_items().len();
+        app.selected_left = item_count - 1;
+
+        let down = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        app.handle_key(down).unwrap();
+
+        assert_eq!(app.left_section, LeftSection::Terminals);
+        assert_eq!(app.selected_terminal_index, 0);
+    }
+
+    #[test]
+    fn header_running_terminal_count() {
+        let mut app = test_app(default_bindings());
+
+        assert_eq!(app.running_companion_terminal_count(), 0);
+
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let (command, args) = ("/bin/sh", vec!["-c".to_string(), "sleep 2".to_string()]);
+        let client = PtyClient::spawn(command, &args, worktree, 24, 80, 1_000).expect("spawn");
+        app.companion_terminals.insert(
+            "term-1".to_string(),
+            crate::app::CompanionTerminal {
+                session_id,
+                label: "test".to_string(),
+                foreground_cmd: None,
+                client,
+            },
+        );
+
+        assert_eq!(app.running_companion_terminal_count(), 1);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,7 +33,10 @@ use crate::editor::DetectedEditor;
 use crate::git;
 use crate::keybindings::{Action, BindingScope, HintContext, RuntimeBindings};
 use crate::logger;
-use crate::model::{AgentSession, ChangedFile, Project, ProviderKind, SessionStatus};
+use crate::model::{
+    AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
+    SessionSurface,
+};
 use crate::provider;
 use crate::pty::PtyClient;
 use crate::statusline::{StatusLine, StatusTone};
@@ -50,6 +53,8 @@ pub struct App {
     pub(crate) staged_files: Vec<ChangedFile>,
     pub(crate) unstaged_files: Vec<ChangedFile>,
     pub(crate) selected_left: usize,
+    pub(crate) left_section: LeftSection,
+    pub(crate) selected_terminal_index: usize,
     pub(crate) right_section: RightSection,
     pub(crate) files_index: usize,
     pub(crate) files_search_query: String,
@@ -60,6 +65,7 @@ pub struct App {
     pub(crate) commit_generating: bool,
     pub(crate) left_width_pct: u16,
     pub(crate) right_width_pct: u16,
+    pub(crate) terminal_pane_height_pct: u16,
     pub(crate) focus: FocusPane,
     pub(crate) center_mode: CenterMode,
     pub(crate) left_collapsed: bool,
@@ -67,13 +73,17 @@ pub struct App {
     pub(crate) help_scroll: Option<u16>,
     pub(crate) last_help_height: u16,
     pub(crate) last_help_lines: u16,
-    pub(crate) fullscreen_agent: bool,
+    pub(crate) fullscreen_overlay: FullscreenOverlay,
     pub(crate) status: StatusLine,
     pub(crate) prompt: PromptState,
     pub(crate) input_target: InputTarget,
+    pub(crate) session_surface: SessionSurface,
     pub(crate) worker_tx: Sender<WorkerEvent>,
     pub(crate) worker_rx: Receiver<WorkerEvent>,
     pub(crate) providers: HashMap<String, PtyClient>,
+    pub(crate) companion_terminals: HashMap<String, CompanionTerminal>,
+    pub(crate) active_terminal_id: Option<String>,
+    pub(crate) terminal_counter: usize,
     pub(crate) create_agent_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
     pub(crate) last_diff_height: u16,
@@ -81,7 +91,7 @@ pub struct App {
     pub(crate) theme: Theme,
     pub(crate) tick_count: u64,
     pub(crate) watched_worktree: Arc<Mutex<Option<PathBuf>>>,
-    pub(crate) has_active_agent: Arc<AtomicBool>,
+    pub(crate) has_active_processes: Arc<AtomicBool>,
     pub(crate) collapsed_projects: HashSet<String>,
     pub(crate) left_items_cache: Vec<LeftItem>,
     pub(crate) mouse_layout: MouseLayoutState,
@@ -157,6 +167,13 @@ impl RightSection {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FullscreenOverlay {
+    None,
+    Agent,
+    Terminal,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum CenterMode {
     Agent,
@@ -195,7 +212,8 @@ pub(crate) enum PromptState {
         confirm_selected: bool, // false = Cancel (default), true = Delete
     },
     ConfirmQuit {
-        active_count: usize,
+        agent_count: usize,
+        terminal_count: usize,
         confirm_selected: bool, // false = Cancel (default), true = Quit
     },
     ConfirmDiscardFile {
@@ -227,6 +245,7 @@ pub(crate) struct BrowserEntry {
 pub(crate) enum InputTarget {
     None,
     Agent,
+    Terminal,
     CommitMessage,
 }
 
@@ -243,6 +262,7 @@ pub(crate) struct MouseLayoutState {
     pub(crate) center: Rect,
     pub(crate) right: Rect,
     pub(crate) left_list: Rect,
+    pub(crate) terminal_list: Rect,
     pub(crate) agent_term: Option<Rect>,
     pub(crate) unstaged_list: Option<Rect>,
     pub(crate) staged_list: Option<Rect>,
@@ -257,6 +277,7 @@ impl MouseLayoutState {
         self.center = center;
         self.right = right;
         self.left_list = Rect::default();
+        self.terminal_list = Rect::default();
         self.agent_term = None;
         self.unstaged_list = None;
         self.staged_list = None;
@@ -316,14 +337,17 @@ pub(crate) enum OverlayMouseLayout {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum ResizeDragState {
     LeftDivider,
     RightDivider,
+    TerminalDivider,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MouseClickTarget {
     LeftRow(usize),
+    TerminalRow(usize),
     CenterPane,
     UnstagedFile(usize),
     StagedFile(usize),
@@ -338,10 +362,23 @@ pub(crate) struct RecentMouseClick {
     pub(crate) at: Instant,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LeftSection {
+    Projects,
+    Terminals,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LeftItem {
     Project(usize),
     Session(usize),
+}
+
+pub(crate) struct CompanionTerminal {
+    pub(crate) session_id: String,
+    pub(crate) label: String,
+    pub(crate) foreground_cmd: Option<String>,
+    pub(crate) client: PtyClient,
 }
 
 pub(crate) struct AgentReadyData {
@@ -404,6 +441,7 @@ impl App {
         let mut app = Self {
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
+            terminal_pane_height_pct: config.ui.terminal_pane_height_pct,
             bindings,
             config,
             paths,
@@ -413,6 +451,8 @@ impl App {
             staged_files: Vec::new(),
             unstaged_files: Vec::new(),
             selected_left: 0,
+            left_section: LeftSection::Projects,
+            selected_terminal_index: 0,
             right_section: RightSection::Unstaged,
             files_index: 0,
             files_search_query: String::new(),
@@ -428,13 +468,17 @@ impl App {
             help_scroll: None,
             last_help_height: 0,
             last_help_lines: 0,
-            fullscreen_agent: false,
+            fullscreen_overlay: FullscreenOverlay::None,
             status: StatusLine::new(initial_status),
             prompt: PromptState::None,
             input_target: InputTarget::None,
+            session_surface: SessionSurface::Agent,
             worker_tx,
             worker_rx,
             providers: HashMap::new(),
+            companion_terminals: HashMap::new(),
+            active_terminal_id: None,
+            terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
             last_diff_height: 0,
@@ -442,7 +486,7 @@ impl App {
             theme: Theme::default_dark(),
             tick_count: 0,
             watched_worktree: Arc::clone(&watched_worktree),
-            has_active_agent: Arc::new(AtomicBool::new(false)),
+            has_active_processes: Arc::new(AtomicBool::new(false)),
             collapsed_projects: HashSet::new(),
             left_items_cache: Vec::new(),
             mouse_layout: MouseLayoutState::default(),
@@ -511,6 +555,13 @@ impl App {
     }
 
     pub(crate) fn close_top_overlay(&mut self) -> bool {
+        if matches!(self.fullscreen_overlay, FullscreenOverlay::Terminal) {
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.session_surface = SessionSurface::Agent;
+            self.input_target = InputTarget::None;
+            self.set_info("Closed terminal overlay.");
+            return true;
+        }
         if !matches!(self.prompt, PromptState::None) {
             self.prompt = PromptState::None;
             self.set_info("Closed overlay.");
@@ -553,6 +604,8 @@ impl App {
             "delete-agent" => self.confirm_delete_selected_session(),
             "rename-agent" => self.open_rename_session(),
             "reconnect-agent" => self.reconnect_selected_session(),
+            "show-agent" => self.activate_center_agent(),
+            "show-terminal" => self.show_companion_terminal(),
             "add-project" => self.open_project_browser(),
             "copy-path" => self.copy_selected_path(),
             "open-worktree" => self.open_selected_worktree_in_default_editor(),
@@ -768,7 +821,7 @@ impl App {
             let current_name = session.title.unwrap_or_else(|| session.branch_name.clone());
             let cursor = current_name.len();
             self.input_target = InputTarget::None;
-            self.fullscreen_agent = false;
+            self.fullscreen_overlay = FullscreenOverlay::None;
             self.prompt = PromptState::RenameSession {
                 session_id: session.id,
                 input: current_name,
@@ -824,6 +877,90 @@ impl App {
             session.status = status;
             session.updated_at = Utc::now();
             let _ = self.session_store.upsert_session(session);
+        }
+    }
+
+    /// Derives a companion terminal status for a session from the multi-terminal map.
+    /// Running if any terminal exists for this session, NotLaunched otherwise.
+    pub(crate) fn companion_terminal_status(&self, session_id: &str) -> CompanionTerminalStatus {
+        if self.session_terminal_count(session_id) > 0 {
+            CompanionTerminalStatus::Running
+        } else {
+            CompanionTerminalStatus::NotLaunched
+        }
+    }
+
+    pub(crate) fn selected_companion_terminal_status(&self) -> CompanionTerminalStatus {
+        self.selected_session()
+            .map(|session| self.companion_terminal_status(&session.id))
+            .unwrap_or(CompanionTerminalStatus::NotLaunched)
+    }
+
+    pub(crate) fn clear_companion_terminals_for_session(&mut self, session_id: &str) {
+        self.companion_terminals
+            .retain(|_, t| t.session_id != session_id);
+        if let Some(ref id) = self.active_terminal_id
+            && !self.companion_terminals.contains_key(id)
+        {
+            self.active_terminal_id = None;
+        }
+    }
+
+    pub(crate) fn running_process_count(&self) -> usize {
+        self.providers.len() + self.companion_terminals.len()
+    }
+
+    pub(crate) fn running_companion_terminal_count(&self) -> usize {
+        self.companion_terminals.len()
+    }
+
+    /// Returns all running companion terminals as (terminal_id, terminal) pairs,
+    /// sorted by creation order (terminal_id encodes the counter).
+    pub(crate) fn terminal_items(&self) -> Vec<(&String, &CompanionTerminal)> {
+        let mut items: Vec<_> = self.companion_terminals.iter().collect();
+        items.sort_by_key(|(id, _)| (*id).clone());
+        items
+    }
+
+    pub(crate) fn has_terminal_items(&self) -> bool {
+        !self.companion_terminals.is_empty()
+    }
+
+    pub(crate) fn clamp_terminal_cursor(&mut self) {
+        let count = self.terminal_items().len();
+        if count == 0 {
+            self.selected_terminal_index = 0;
+            if self.left_section == LeftSection::Terminals {
+                self.left_section = LeftSection::Projects;
+            }
+        } else if self.selected_terminal_index >= count {
+            self.selected_terminal_index = count.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn next_terminal_id(&mut self) -> String {
+        self.terminal_counter += 1;
+        format!("term-{}", self.terminal_counter)
+    }
+
+    /// Returns the number of running companion terminals for a given session.
+    pub(crate) fn session_terminal_count(&self, session_id: &str) -> usize {
+        self.companion_terminals
+            .values()
+            .filter(|t| t.session_id == session_id)
+            .count()
+    }
+
+    pub(crate) fn selected_terminal_surface_client(&self) -> Option<&PtyClient> {
+        match self.session_surface {
+            SessionSurface::Agent => {
+                let session_id = self.selected_session()?.id.as_str();
+                self.providers.get(session_id)
+            }
+            SessionSurface::Terminal => {
+                let id = self.active_terminal_id.as_ref()?;
+                self.companion_terminals.get(id).map(|t| &t.client)
+            }
         }
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -104,6 +104,19 @@ impl App {
                 project.default_provider.as_str().to_string(),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
+            let running_terminals = self.running_companion_terminal_count();
+            if running_terminals > 0 {
+                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                let label = if running_terminals == 1 {
+                    "● 1 terminal".to_string()
+                } else {
+                    format!("● {running_terminals} terminals")
+                };
+                spans.push(Span::styled(
+                    label,
+                    Style::default().fg(self.theme.session_active).bg(bg),
+                ));
+            }
         }
         Paragraph::new(Line::from(spans))
             .style(self.theme.header_style())
@@ -158,6 +171,32 @@ impl App {
             return;
         }
 
+        let terminal_items = self.terminal_items();
+        let has_terminals = !terminal_items.is_empty();
+
+        // Split area vertically: projects on top, terminals on bottom (if any).
+        let (projects_area, terminals_area) = if has_terminals {
+            let pct = self.terminal_pane_height_pct.clamp(10, 80);
+            let projects_pct = 100u16.saturating_sub(pct).max(20);
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Percentage(projects_pct),
+                    Constraint::Percentage(pct),
+                ])
+                .split(area);
+            (chunks[0], Some(chunks[1]))
+        } else {
+            (area, None)
+        };
+
+        // Collect terminal display info for rendering.
+        // Show the foreground command if one is running, otherwise the session label.
+        let terminal_render_data: Vec<(String, Option<String>)> = terminal_items
+            .iter()
+            .map(|(_, t)| (t.label.clone(), t.foreground_cmd.clone()))
+            .collect();
+
         let session_counts: HashMap<String, usize> = {
             let mut counts = HashMap::new();
             for session in &self.sessions {
@@ -166,6 +205,7 @@ impl App {
             counts
         };
         let left_items = self.left_items();
+        let projects_focused = focused && self.left_section == LeftSection::Projects;
         let items = left_items
             .iter()
             .enumerate()
@@ -201,29 +241,87 @@ impl App {
                         .clone()
                         .unwrap_or_else(|| session.branch_name.clone());
                     let (dot, dot_color) = self.theme.session_dot(&session.status);
-                    ListItem::new(Line::from(vec![
-                        Span::styled(connector, Style::default().fg(self.theme.project_icon)),
-                        Span::styled(format!("{dot} "), Style::default().fg(dot_color)),
-                        Span::styled(label, Style::default().fg(dot_color)),
-                        Span::styled(
-                            format!(" ({})", session.provider.as_str()),
-                            Style::default().fg(self.theme.provider_label_fg),
-                        ),
-                    ]))
+                    ListItem::new(Line::from(
+                        vec![
+                            Span::styled(connector, Style::default().fg(self.theme.project_icon)),
+                            Span::styled(format!("{dot} "), Style::default().fg(dot_color)),
+                            Span::styled(label, Style::default().fg(dot_color)),
+                            Span::styled(
+                                format!(" ({})", session.provider.as_str()),
+                                Style::default().fg(self.theme.provider_label_fg),
+                            ),
+                        ]
+                        .into_iter()
+                        .chain(companion_terminal_row_badge(
+                            self.companion_terminal_status(&session.id),
+                            &self.theme,
+                        ))
+                        .collect::<Vec<_>>(),
+                    ))
                 }
             })
             .collect::<Vec<_>>();
         let title = format!("Projects ({})", self.projects.len());
-        self.mouse_layout.left_list = self.themed_block(&title, focused).inner(area);
-        let mut state = ListState::default().with_selected(Some(self.selected_left));
+        self.mouse_layout.left_list = self
+            .themed_block(&title, projects_focused)
+            .inner(projects_area);
+        let mut state =
+            ListState::default().with_selected(if self.left_section == LeftSection::Projects {
+                Some(self.selected_left)
+            } else {
+                None
+            });
         StatefulWidget::render(
             List::new(items)
-                .block(self.themed_block(&title, focused))
+                .block(self.themed_block(&title, projects_focused))
                 .highlight_style(self.theme.selection_style()),
-            area,
+            projects_area,
             frame.buffer_mut(),
             &mut state,
         );
+
+        // Render terminals section if any terminals exist.
+        if let Some(term_area) = terminals_area {
+            let terminals_focused = focused && self.left_section == LeftSection::Terminals;
+            let term_title = format!("Terminals ({})", terminal_render_data.len());
+            self.mouse_layout.terminal_list = self
+                .themed_block(&term_title, terminals_focused)
+                .inner(term_area);
+            let term_items: Vec<ListItem> = terminal_render_data
+                .iter()
+                .map(|(label, fg_cmd)| {
+                    let color = self.theme.session_active;
+                    let mut spans = vec![Span::styled("● ", Style::default().fg(color))];
+                    if let Some(cmd) = fg_cmd {
+                        spans.push(Span::styled(cmd.clone(), Style::default().fg(color)));
+                        spans.push(Span::styled(
+                            format!(" · {label}"),
+                            Style::default().fg(self.theme.provider_label_fg),
+                        ));
+                    } else {
+                        spans.push(Span::styled(label.clone(), Style::default().fg(color)));
+                    }
+                    ListItem::new(Line::from(spans))
+                })
+                .collect();
+            let mut term_state = ListState::default().with_selected(
+                if self.left_section == LeftSection::Terminals {
+                    Some(self.selected_terminal_index)
+                } else {
+                    None
+                },
+            );
+            StatefulWidget::render(
+                List::new(term_items)
+                    .block(self.themed_block(&term_title, terminals_focused))
+                    .highlight_style(self.theme.selection_style()),
+                term_area,
+                frame.buffer_mut(),
+                &mut term_state,
+            );
+        } else {
+            self.mouse_layout.terminal_list = Rect::default();
+        }
     }
 
     fn render_center(&mut self, frame: &mut Frame, area: Rect) {
@@ -232,15 +330,21 @@ impl App {
             CenterMode::Diff { .. } => {
                 self.render_diff(frame, area, focused);
             }
-            CenterMode::Agent if self.fullscreen_agent => {
+            CenterMode::Agent if !matches!(self.fullscreen_overlay, FullscreenOverlay::None) => {
                 // Skip agent rendering here — fullscreen overlay handles it.
                 // Rendering in both places causes the PTY to be resized twice
                 // per frame (once to the small pane, once to the overlay).
-                self.themed_block("Agent", focused)
+                let title = self.center_pane_agent_title();
+                self.themed_block(&title, focused)
                     .render(area, frame.buffer_mut());
             }
             CenterMode::Agent => {
-                self.render_agent_terminal(frame, area, "Agent", focused);
+                let title = self.center_pane_agent_title();
+                // Center pane always renders the agent; terminal is an overlay.
+                let saved = self.session_surface;
+                self.session_surface = SessionSurface::Agent;
+                self.render_agent_terminal(frame, area, &title, focused);
+                self.session_surface = saved;
             }
         }
     }
@@ -347,6 +451,64 @@ impl App {
         );
     }
 
+    fn render_terminal_placeholder(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        status: CompanionTerminalStatus,
+        command_name: Option<&str>,
+    ) {
+        if area.width < 4 || area.height < 3 {
+            return;
+        }
+
+        let (icon, label) = companion_terminal_status_meta(status);
+        let command_name = command_name.unwrap_or("terminal");
+        let lines = match status {
+            CompanionTerminalStatus::NotLaunched => vec![
+                Line::from(Span::styled(
+                    format!("{icon} Companion terminal not launched"),
+                    Style::default().fg(companion_terminal_status_color(&self.theme, status)),
+                )),
+                Line::from(Span::styled(
+                    format!(
+                        "Launch {command_name} explicitly when you need a shell in this worktree."
+                    ),
+                    Style::default().fg(self.theme.hint_dim_desc_fg),
+                )),
+            ],
+            CompanionTerminalStatus::Running => vec![
+                Line::from(Span::styled(
+                    format!("{icon} Companion terminal {label}"),
+                    Style::default().fg(companion_terminal_status_color(&self.theme, status)),
+                )),
+                Line::from(Span::styled(
+                    "The PTY is alive even when hidden from the center pane.",
+                    Style::default().fg(self.theme.hint_dim_desc_fg),
+                )),
+            ],
+            CompanionTerminalStatus::Exited => vec![
+                Line::from(Span::styled(
+                    format!("{icon} Companion terminal exited"),
+                    Style::default().fg(companion_terminal_status_color(&self.theme, status)),
+                )),
+                Line::from(Span::styled(
+                    "Relaunch it explicitly to start a fresh shell.",
+                    Style::default().fg(self.theme.hint_dim_desc_fg),
+                )),
+            ],
+        };
+
+        let height = lines.len() as u16;
+        let y = area.y + area.height.saturating_sub(height) / 2;
+        Paragraph::new(lines)
+            .alignment(ratatui::layout::Alignment::Center)
+            .render(
+                Rect::new(area.x, y, area.width, height.max(1)),
+                frame.buffer_mut(),
+            );
+    }
+
     fn render_agent_terminal(&mut self, frame: &mut Frame, area: Rect, title: &str, focused: bool) {
         let outer_block = self.themed_block(title, focused);
         let inner = outer_block.inner(area);
@@ -356,7 +518,13 @@ impl App {
             return;
         }
 
-        let is_input = self.input_target == InputTarget::Agent;
+        let active_surface = self.session_surface;
+        let terminal_status = self.selected_companion_terminal_status();
+        let is_input = matches!(
+            (self.input_target, active_surface),
+            (InputTarget::Agent, SessionSurface::Agent)
+                | (InputTarget::Terminal, SessionSurface::Terminal)
+        );
         let mut scrollback_offset: usize = 0;
         let mut rendered_content = false;
 
@@ -370,23 +538,38 @@ impl App {
 
         // Get the selected session's PTY screen.
         let session_id = self.selected_session().map(|s| s.id.clone());
-        let session_provider_name = self
-            .selected_session()
-            .map(|s| s.provider.as_str().to_owned());
-        let session_active = session_id
-            .as_ref()
-            .map(|id| self.providers.contains_key(id))
-            .unwrap_or(false);
+        let session_provider_name = match active_surface {
+            SessionSurface::Agent => self
+                .selected_session()
+                .map(|s| s.provider.as_str().to_owned()),
+            SessionSurface::Terminal => Some(
+                self.config
+                    .terminal
+                    .command
+                    .rsplit(std::path::MAIN_SEPARATOR)
+                    .next()
+                    .unwrap_or(self.config.terminal.command.as_str())
+                    .to_string(),
+            ),
+        };
+        let session_active = match active_surface {
+            SessionSurface::Agent => session_id
+                .as_ref()
+                .map(|id| self.providers.contains_key(id))
+                .unwrap_or(false),
+            SessionSurface::Terminal => terminal_status.is_running(),
+        };
+        let new_size = (term_area.height, term_area.width);
+        let should_resize = new_size != self.last_pty_size && new_size.0 > 0 && new_size.1 > 0;
+        if should_resize {
+            self.last_pty_size = new_size;
+        }
 
-        if let Some(ref sid) = session_id
-            && let Some(provider) = self.providers.get(sid)
-        {
+        if let Some(provider) = self.selected_terminal_surface_client() {
             rendered_content = true;
             // Resize PTY if needed.
-            let new_size = (term_area.height, term_area.width);
-            if new_size != self.last_pty_size && new_size.0 > 0 && new_size.1 > 0 {
+            if should_resize {
                 let _ = provider.resize(new_size.0, new_size.1);
-                self.last_pty_size = new_size;
             }
 
             if !provider.has_output() {
@@ -396,9 +579,13 @@ impl App {
                 let spinner = spinner_chars[idx];
                 let (label_spans, label_len) = match session_provider_name.as_deref() {
                     Some(name) => {
-                        let text_len = "Starting ".len() + name.len() + "...".len();
+                        let prefix = match active_surface {
+                            SessionSurface::Agent => "Starting ",
+                            SessionSurface::Terminal => "Launching ",
+                        };
+                        let text_len = prefix.len() + name.len() + "...".len();
                         let spans = vec![
-                            Span::styled("Starting ", Style::default().fg(self.theme.hint_desc_fg)),
+                            Span::styled(prefix, Style::default().fg(self.theme.hint_desc_fg)),
                             Span::styled(
                                 name.to_owned(),
                                 Style::default().fg(self.theme.branch_fg),
@@ -408,7 +595,10 @@ impl App {
                         (spans, text_len)
                     }
                     None => {
-                        let text = "Starting agent...";
+                        let text = match active_surface {
+                            SessionSurface::Agent => "Starting agent...",
+                            SessionSurface::Terminal => "Launching terminal...",
+                        };
                         let spans = vec![Span::styled(
                             text,
                             Style::default().fg(self.theme.hint_desc_fg),
@@ -527,7 +717,15 @@ impl App {
         }
 
         if !rendered_content {
-            self.render_ascii_logo(frame, term_area);
+            match active_surface {
+                SessionSurface::Agent => self.render_ascii_logo(frame, term_area),
+                SessionSurface::Terminal => self.render_terminal_placeholder(
+                    frame,
+                    term_area,
+                    terminal_status,
+                    session_provider_name.as_deref(),
+                ),
+            }
         }
 
         // Hint bar with top border.
@@ -543,7 +741,12 @@ impl App {
             let hint_line = if is_input {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
-                let cli_name = session_provider_name.as_deref().unwrap_or("agent");
+                let cli_name = session_provider_name
+                    .as_deref()
+                    .unwrap_or(match active_surface {
+                        SessionSurface::Agent => "agent",
+                        SessionSurface::Terminal => "terminal",
+                    });
                 let capitalized = {
                     let mut c = cli_name.chars();
                     match c.next() {
@@ -585,7 +788,28 @@ impl App {
             } else {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
-                if session_active {
+                if matches!(active_surface, SessionSurface::Terminal) {
+                    match terminal_status {
+                        CompanionTerminalStatus::Running => {
+                            spans.push(Span::styled(
+                                "Companion terminal is running. Hidden terminals stay alive in this worktree.",
+                                desc_style,
+                            ));
+                        }
+                        CompanionTerminalStatus::Exited => {
+                            spans.push(Span::styled(
+                                "Companion terminal exited. Relaunch it explicitly to start a fresh shell.",
+                                desc_style,
+                            ));
+                        }
+                        CompanionTerminalStatus::NotLaunched => {
+                            spans.push(Span::styled(
+                                "Companion terminal is not launched yet. Launch it explicitly when needed.",
+                                desc_style,
+                            ));
+                        }
+                    }
+                } else if session_active {
                     spans.extend(self.theme.dim_key_badge(&focus_agent, Color::Reset));
                     spans.push(Span::styled(" to interact. ", desc_style));
                     spans.extend(self.theme.dim_key_badge(&scroll_up, Color::Reset));
@@ -1123,6 +1347,43 @@ impl App {
                 Span::raw("  "),
                 Span::styled(
                     desc.to_string(),
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ),
+            ]));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Companion terminal states",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )));
+        for status in [
+            CompanionTerminalStatus::NotLaunched,
+            CompanionTerminalStatus::Running,
+            CompanionTerminalStatus::Exited,
+        ] {
+            let (icon, label) = companion_terminal_status_meta(status);
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    icon,
+                    Style::default().fg(companion_terminal_status_color(&self.theme, status)),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    match status {
+                        CompanionTerminalStatus::NotLaunched => {
+                            format!("{label} — shell has not been started")
+                        }
+                        CompanionTerminalStatus::Running => {
+                            format!("{label} — companion shell is alive")
+                        }
+                        CompanionTerminalStatus::Exited => {
+                            format!("{label} — shell finished and awaits relaunch")
+                        }
+                    },
                     Style::default().fg(self.theme.hint_desc_fg),
                 ),
             ]));
@@ -1743,7 +2004,8 @@ impl App {
                 };
             }
             PromptState::ConfirmQuit {
-                active_count,
+                agent_count,
+                terminal_count,
                 confirm_selected,
             } => {
                 self.render_dim_overlay(frame);
@@ -1762,15 +2024,11 @@ impl App {
                     ])
                     .areas(inner);
 
-                let agent_word = if *active_count == 1 {
-                    "agent"
-                } else {
-                    "agents"
-                };
+                let process_desc = quit_process_description(*agent_count, *terminal_count);
                 let lines = vec![
                     Line::from(""),
                     Line::from(vec![
-                        Span::raw(format!(" {active_count} running {agent_word} will be ")),
+                        Span::raw(format!(" {process_desc} will be ")),
                         Span::styled(
                             "killed",
                             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
@@ -1779,7 +2037,7 @@ impl App {
                     ]),
                     Line::from(""),
                     Line::from(Span::styled(
-                        " Any in-progress work by those agents will be lost.",
+                        " Any in-progress work will be lost.",
                         Style::default().fg(Color::Yellow),
                     )),
                     Line::from(Span::styled(
@@ -2026,9 +2284,16 @@ impl App {
     }
 
     fn render_overlay(&mut self, frame: &mut Frame) {
-        if self.fullscreen_agent {
-            self.render_fullscreen_agent(frame);
-            return;
+        match self.fullscreen_overlay {
+            FullscreenOverlay::Agent => {
+                self.render_fullscreen_agent(frame);
+                return;
+            }
+            FullscreenOverlay::Terminal => {
+                self.render_fullscreen_terminal(frame);
+                return;
+            }
+            FullscreenOverlay::None => {}
         }
         if !matches!(self.prompt, PromptState::None) {
             self.render_prompt(frame);
@@ -2043,7 +2308,20 @@ impl App {
         self.render_dim_overlay(frame);
         let area = centered_rect(96, 94, frame.area());
         Clear.render(area, frame.buffer_mut());
+        let saved = self.session_surface;
+        self.session_surface = SessionSurface::Agent;
         self.render_agent_terminal(frame, area, " Agent (fullscreen) ", true);
+        self.session_surface = saved;
+    }
+
+    fn render_fullscreen_terminal(&mut self, frame: &mut Frame) {
+        self.render_dim_overlay(frame);
+        let area = centered_rect(96, 94, frame.area());
+        Clear.render(area, frame.buffer_mut());
+        let saved = self.session_surface;
+        self.session_surface = SessionSurface::Terminal;
+        self.render_agent_terminal(frame, area, " Terminal ", true);
+        self.session_surface = saved;
     }
 
     fn themed_block<'a>(&self, title: &'a str, focused: bool) -> Block<'a> {
@@ -2070,6 +2348,18 @@ impl App {
             .border_style(Style::default().fg(self.theme.overlay_border))
     }
 
+    fn center_pane_agent_title(&self) -> String {
+        if let Some(session) = self.selected_session() {
+            let count = self.session_terminal_count(&session.id);
+            if count == 1 {
+                return "Agent (+ 1 terminal)".to_string();
+            } else if count > 1 {
+                return format!("Agent (+ {count} terminals)");
+            }
+        }
+        "Agent".to_string()
+    }
+
     fn render_dim_overlay(&self, frame: &mut Frame) {
         let full = frame.area();
         // Keep the statusline (bottom rows) undimmed so errors stay visible.
@@ -2090,6 +2380,55 @@ impl App {
             }
         }
     }
+}
+
+fn quit_process_description(agents: usize, terminals: usize) -> String {
+    match (agents, terminals) {
+        (0, 1) => "1 running terminal".to_string(),
+        (0, t) => format!("{t} running terminals"),
+        (1, 0) => "1 running agent".to_string(),
+        (a, 0) => format!("{a} running agents"),
+        (a, t) => {
+            let agent_word = if a == 1 { "agent" } else { "agents" };
+            let term_word = if t == 1 { "terminal" } else { "terminals" };
+            format!("{a} running {agent_word} and {t} {term_word}")
+        }
+    }
+}
+
+fn companion_terminal_status_meta(status: CompanionTerminalStatus) -> (&'static str, &'static str) {
+    match status {
+        CompanionTerminalStatus::NotLaunched => ("○", "not launched"),
+        CompanionTerminalStatus::Running => ("●", "running"),
+        CompanionTerminalStatus::Exited => ("◐", "exited"),
+    }
+}
+
+fn companion_terminal_status_color(theme: &Theme, status: CompanionTerminalStatus) -> Color {
+    match status {
+        CompanionTerminalStatus::NotLaunched => theme.terminal_hint_fg,
+        CompanionTerminalStatus::Running => theme.session_active,
+        CompanionTerminalStatus::Exited => theme.session_detached,
+    }
+}
+
+fn companion_terminal_row_badge(
+    status: CompanionTerminalStatus,
+    theme: &Theme,
+) -> Vec<Span<'static>> {
+    if matches!(status, CompanionTerminalStatus::NotLaunched) {
+        return Vec::new();
+    }
+    let (icon, label) = companion_terminal_status_meta(status);
+    vec![
+        Span::raw(" "),
+        Span::styled("[", Style::default().fg(theme.provider_label_fg)),
+        Span::styled(
+            format!("{icon} term {label}"),
+            Style::default().fg(companion_terminal_status_color(theme, status)),
+        ),
+        Span::styled("]", Style::default().fg(theme.provider_label_fg)),
+    ]
 }
 
 /// Format additions/deletions as right-aligned colored spans.
@@ -2306,6 +2645,31 @@ mod tests {
     #[test]
     fn scrollback_indicator_hides_at_live_bottom() {
         assert_eq!(scrollback_indicator_label(0, 800), None);
+    }
+
+    #[test]
+    fn companion_terminal_status_meta_covers_v1_states() {
+        assert_eq!(
+            companion_terminal_status_meta(CompanionTerminalStatus::NotLaunched),
+            ("○", "not launched")
+        );
+        assert_eq!(
+            companion_terminal_status_meta(CompanionTerminalStatus::Running),
+            ("●", "running")
+        );
+        assert_eq!(
+            companion_terminal_status_meta(CompanionTerminalStatus::Exited),
+            ("◐", "exited")
+        );
+    }
+
+    #[test]
+    fn row_badge_hidden_until_terminal_is_launched() {
+        let theme = Theme::default_dark();
+        assert!(
+            companion_terminal_row_badge(CompanionTerminalStatus::NotLaunched, &theme).is_empty()
+        );
+        assert!(!companion_terminal_row_badge(CompanionTerminalStatus::Running, &theme).is_empty());
     }
 
     #[test]

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -148,6 +148,114 @@ impl App {
         )
     }
 
+    pub(crate) fn spawn_companion_terminal_for_session(
+        &self,
+        session: &AgentSession,
+    ) -> Result<PtyClient> {
+        let (rows, cols) = if self.last_pty_size != (0, 0) {
+            self.last_pty_size
+        } else {
+            (24, 80)
+        };
+        logger::debug(&format!(
+            "spawning companion terminal {:?} {:?} in {} ({}x{})",
+            self.config.terminal.command,
+            self.config.terminal.args,
+            session.worktree_path,
+            cols,
+            rows,
+        ));
+        PtyClient::spawn(
+            &self.config.terminal.command,
+            &self.config.terminal.args,
+            Path::new(&session.worktree_path),
+            rows,
+            cols,
+            self.config.ui.agent_scrollback_lines,
+        )
+    }
+
+    pub(crate) fn show_agent_surface(&mut self) {
+        self.focus = FocusPane::Center;
+        self.center_mode = CenterMode::Agent;
+        self.session_surface = SessionSurface::Agent;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+    }
+
+    pub(crate) fn show_companion_terminal_surface(&mut self) {
+        self.session_surface = SessionSurface::Terminal;
+        self.fullscreen_overlay = FullscreenOverlay::Terminal;
+    }
+
+    /// Always spawns a new companion terminal for the selected session.
+    pub(crate) fn show_companion_terminal(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent session first.");
+            return Ok(());
+        };
+
+        let client = self.spawn_companion_terminal_for_session(&session)?;
+        let terminal_id = self.next_terminal_id();
+        let count = self.session_terminal_count(&session.id) + 1;
+        let label = if count == 1 {
+            session
+                .title
+                .clone()
+                .unwrap_or_else(|| session.branch_name.clone())
+        } else {
+            let base = session
+                .title
+                .clone()
+                .unwrap_or_else(|| session.branch_name.clone());
+            format!("{base} ({count})")
+        };
+        self.companion_terminals.insert(
+            terminal_id.clone(),
+            CompanionTerminal {
+                session_id: session.id.clone(),
+                label,
+                foreground_cmd: None,
+                client,
+            },
+        );
+        self.active_terminal_id = Some(terminal_id);
+        self.show_companion_terminal_surface();
+        self.input_target = InputTarget::Terminal;
+        self.set_info(format!(
+            "Launched terminal for agent \"{}\".",
+            session.branch_name
+        ));
+        Ok(())
+    }
+
+    /// Opens the terminal overlay for the terminal selected in the terminals list.
+    pub(crate) fn open_terminal_from_terminal_list(&mut self) -> Result<()> {
+        let items = self.terminal_items();
+        let Some(&(terminal_id, terminal)) = items.get(self.selected_terminal_index) else {
+            return Ok(());
+        };
+        let terminal_id = terminal_id.clone();
+        let session_id = terminal.session_id.clone();
+        let label = terminal.label.clone();
+        drop(items);
+
+        // Select this terminal's session in the left pane.
+        if let Some(pos) = self
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(idx) if self.sessions.get(*idx).map(|s| s.id.as_str()) == Some(session_id.as_str())))
+        {
+            self.selected_left = pos;
+        }
+        self.reload_changed_files();
+
+        self.active_terminal_id = Some(terminal_id);
+        self.show_companion_terminal_surface();
+        self.input_target = InputTarget::Terminal;
+        self.set_info(format!("Opened terminal \"{label}\"."));
+        Ok(())
+    }
+
     pub(crate) fn refresh_selected_project(&mut self) -> Result<()> {
         let Some(project) = self.selected_project().cloned() else {
             self.set_error("Select a project first.");
@@ -211,6 +319,7 @@ impl App {
             &session.branch_name,
         )?;
         self.providers.remove(&session.id);
+        self.clear_companion_terminals_for_session(&session.id);
         self.sessions.retain(|candidate| candidate.id != session.id);
         self.session_store.delete_session(&session.id)?;
         self.rebuild_left_items();
@@ -365,10 +474,9 @@ impl App {
             Ok(client) => {
                 self.providers.insert(session.id.clone(), client);
                 self.mark_session_status(&session.id, SessionStatus::Active);
-                self.focus = FocusPane::Center;
-                self.center_mode = CenterMode::Agent;
+                self.show_agent_surface();
                 self.input_target = InputTarget::Agent;
-                self.fullscreen_agent = true;
+                self.fullscreen_overlay = FullscreenOverlay::Agent;
                 let proj_name = self.project_name_for_session(&session);
                 self.set_info(format!(
                     "Relaunched {} agent \"{}\" in project \"{}\"",

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -26,10 +26,9 @@ impl App {
                         .position(|item| matches!(item, LeftItem::Session(index) if self.sessions.get(*index).map(|candidate| candidate.id.as_str()) == Some(session.id.as_str())))
                         .unwrap_or(0);
                     self.reload_changed_files();
-                    self.focus = FocusPane::Center;
-                    self.center_mode = CenterMode::Agent;
+                    self.show_agent_surface();
                     self.input_target = InputTarget::Agent;
-                    self.fullscreen_agent = true;
+                    self.fullscreen_overlay = FullscreenOverlay::Agent;
                     let proj_name = self.project_name_for_session(&session);
                     self.set_info(format!(
                         "Created {} agent \"{}\" in project \"{}\"",
@@ -118,18 +117,57 @@ impl App {
             if let Some(current) = self.selected_session()
                 && exited.contains(&current.id)
             {
-                self.input_target = InputTarget::None;
-                self.fullscreen_agent = false;
-                self.focus = FocusPane::Left;
                 let key = self.bindings.label_for(Action::ReconnectAgent);
-                self.set_info(format!(
-                    "Agent CLI process has exited. Press \"{key}\" to relaunch."
-                ));
+                if self.session_surface == SessionSurface::Agent {
+                    self.input_target = InputTarget::None;
+                    self.fullscreen_overlay = FullscreenOverlay::None;
+                    self.focus = FocusPane::Left;
+                    self.set_info(format!(
+                        "Agent CLI process has exited. Press \"{key}\" to relaunch."
+                    ));
+                } else {
+                    self.set_info(format!(
+                        "Agent CLI process exited. Companion terminal is still available; press \"{key}\" to relaunch the agent."
+                    ));
+                }
             }
         }
-        // Keep the poller's interval flag in sync with whether any agent is running.
-        self.has_active_agent
-            .store(!self.providers.is_empty(), Ordering::Relaxed);
+
+        let mut exited_terminal_ids = Vec::new();
+        for (terminal_id, terminal) in &mut self.companion_terminals {
+            if terminal.client.is_exited() || terminal.client.try_wait().is_some() {
+                exited_terminal_ids.push(terminal_id.clone());
+            }
+        }
+        for terminal_id in &exited_terminal_ids {
+            self.companion_terminals.remove(terminal_id);
+        }
+        if !exited_terminal_ids.is_empty() {
+            // If the active terminal just exited, close the overlay.
+            if let Some(ref active_id) = self.active_terminal_id
+                && exited_terminal_ids.contains(active_id)
+            {
+                self.active_terminal_id = None;
+                if self.input_target == InputTarget::Terminal {
+                    self.input_target = InputTarget::None;
+                }
+                self.fullscreen_overlay = FullscreenOverlay::None;
+                self.session_surface = SessionSurface::Agent;
+                self.set_info("Terminal exited. Press the terminal key to launch a new one.");
+            }
+            self.clamp_terminal_cursor();
+        }
+
+        // Poll foreground process names every ~2 seconds (every 20 ticks).
+        if self.tick_count.is_multiple_of(20) {
+            for terminal in self.companion_terminals.values_mut() {
+                terminal.foreground_cmd = terminal.client.foreground_process_name();
+            }
+        }
+
+        // Keep the poller's interval flag in sync with whether any runtime PTY is alive.
+        self.has_active_processes
+            .store(self.running_process_count() > 0, Ordering::Relaxed);
     }
 
     pub(crate) fn spawn_browser_entries(&self, dir: &Path) {
@@ -152,7 +190,7 @@ impl App {
     pub(crate) fn spawn_changed_files_poller(&self) {
         let tx = self.worker_tx.clone();
         let watched = Arc::clone(&self.watched_worktree);
-        let has_agent = Arc::clone(&self.has_active_agent);
+        let has_agent = Arc::clone(&self.has_active_processes);
         thread::spawn(move || {
             loop {
                 let interval = if has_agent.load(Ordering::Relaxed) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ Rules:
 pub struct Config {
     pub defaults: Defaults,
     pub providers: ProvidersConfig,
+    pub terminal: TerminalConfig,
     pub logging: LoggingConfig,
     pub projects: Vec<ProjectConfig>,
     pub ui: UiConfig,
@@ -57,6 +58,13 @@ pub struct Defaults {
 pub struct ProvidersConfig {
     #[serde(flatten)]
     pub commands: IndexMap<String, ProviderCommandConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TerminalConfig {
+    pub command: String,
+    pub args: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -109,6 +117,7 @@ fn new_project_id() -> String {
 pub struct UiConfig {
     pub left_width_pct: u16,
     pub right_width_pct: u16,
+    pub terminal_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
 }
 
@@ -117,6 +126,7 @@ impl Default for Config {
         Self {
             defaults: Defaults::default(),
             providers: ProvidersConfig::default(),
+            terminal: TerminalConfig::default(),
             logging: LoggingConfig {
                 level: "info".to_string(),
                 path: "dux.log".to_string(),
@@ -125,6 +135,7 @@ impl Default for Config {
             ui: UiConfig {
                 left_width_pct: 20,
                 right_width_pct: 23,
+                terminal_pane_height_pct: 35,
                 agent_scrollback_lines: 10_000,
             },
             editor: EditorConfig::default(),
@@ -215,6 +226,15 @@ impl Default for LoggingConfig {
     }
 }
 
+impl Default for TerminalConfig {
+    fn default() -> Self {
+        Self {
+            command: default_terminal_command(),
+            args: default_terminal_args(),
+        }
+    }
+}
+
 impl Default for EditorConfig {
     fn default() -> Self {
         Self {
@@ -228,6 +248,7 @@ impl Default for UiConfig {
         Self {
             left_width_pct: 17,
             right_width_pct: 19,
+            terminal_pane_height_pct: 35,
             agent_scrollback_lines: 10_000,
         }
     }
@@ -361,6 +382,8 @@ enum ConfigEntry {
     },
     /// Renders all `[providers.*]` sub-tables dynamically.
     Providers,
+    /// Renders the `[terminal]` section.
+    Terminal,
     /// Renders the `[[projects]]` array.
     Projects,
     /// Renders the `[keys]` section with all keybindings.
@@ -401,6 +424,7 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
         },
         ConfigEntry::Blank,
         ConfigEntry::Providers,
+        ConfigEntry::Terminal,
         ConfigEntry::Section("logging"),
         ConfigEntry::Field {
             key: "level",
@@ -429,6 +453,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             key: "right_width_pct",
             comment: None,
             value_fn: |c| FieldValue::U16(c.ui.right_width_pct),
+        },
+        ConfigEntry::Field {
+            key: "terminal_pane_height_pct",
+            comment: Some(CommentSource::Static(
+                "# Maximum height percentage of the left pane used by the companion terminals list.",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.terminal_pane_height_pct),
         },
         ConfigEntry::Field {
             key: "agent_scrollback_lines",
@@ -504,6 +535,7 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
                 }
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
+            ConfigEntry::Terminal => render_terminal_config(&mut out, &config.terminal),
             ConfigEntry::Projects => render_projects(&mut out, &config.projects),
             ConfigEntry::Keys => render_keys_config(&mut out, &config.keys, bindings),
         }
@@ -655,6 +687,20 @@ fn render_string_list(values: &[String]) -> String {
     format!("[{rendered}]")
 }
 
+fn default_terminal_command() -> String {
+    env::var("SHELL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "/bin/sh".to_string())
+}
+
+fn default_terminal_args() -> Vec<String> {
+    // Launch as a login shell so the user's profile, aliases, and prompt
+    // are loaded. The -l flag is supported by bash, zsh, fish, dash, and
+    // all POSIX shells.
+    vec!["-l".to_string()]
+}
+
 fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
     [
         (
@@ -691,6 +737,24 @@ fn render_provider_configs(out: &mut String, providers: &ProvidersConfig) {
     for (name, config) in &providers.commands {
         render_provider_config(out, name, config);
     }
+}
+
+fn render_terminal_config(out: &mut String, terminal: &TerminalConfig) {
+    out.push_str("[terminal]\n");
+    out.push_str(
+        "# CLI command dux should use for the companion terminal bound to an agent session.\n",
+    );
+    out.push_str(&format!(
+        "command = \"{}\"\n",
+        escape_toml_string(&terminal.command)
+    ));
+    out.push_str(
+        "# Arguments for the companion terminal command. The default [\"-l\"] launches a login\n# shell so your profile, aliases, and prompt are loaded.\n",
+    );
+    out.push_str(&format!(
+        "args = {}\n\n",
+        render_string_list(&terminal.args)
+    ));
 }
 
 fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommandConfig) {
@@ -838,6 +902,9 @@ mod tests {
         assert!(rendered.contains("oneshot_args = "));
         assert!(rendered.contains("oneshot_output = "));
         assert!(rendered.contains("resume_args = "));
+        assert!(rendered.contains("[terminal]"));
+        assert!(rendered.contains("command = "));
+        assert!(rendered.contains("args = []"));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
         assert!(rendered.contains("[editor]"));
@@ -935,6 +1002,17 @@ mod tests {
         let rendered = render_config_default(&config);
         let parsed: Config = toml::from_str(&rendered).expect("config should parse");
         assert_eq!(parsed.editor.default, "zed");
+    }
+
+    #[test]
+    fn default_config_round_trips_terminal_command() {
+        let mut config = Config::default();
+        config.terminal.command = "fish".to_string();
+        config.terminal.args = vec!["-l".to_string()];
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("config should parse");
+        assert_eq!(parsed.terminal.command, "fish");
+        assert_eq!(parsed.terminal.args, vec!["-l"]);
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -13,9 +13,6 @@ enum DiffStat {
     Binary,
 }
 
-#[cfg(windows)]
-const NULL_DEVICE: &str = "NUL";
-#[cfg(not(windows))]
 const NULL_DEVICE: &str = "/dev/null";
 
 pub fn current_branch(repo_path: &Path) -> Result<String> {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -21,6 +21,7 @@ pub enum Action {
     DeleteSession,
     // Agent pane
     InteractAgent,
+    ShowTerminal,
     ExitInteractive,
     ToggleFullscreen,
     ScrollPageUp,
@@ -151,6 +152,7 @@ impl Action {
             Action::ReconnectAgent => "reconnect_agent",
             Action::DeleteSession => "delete_session",
             Action::InteractAgent => "interact_agent",
+            Action::ShowTerminal => "show_terminal",
             Action::ExitInteractive => "exit_interactive",
             Action::ToggleFullscreen => "toggle_fullscreen",
             Action::ScrollPageUp => "scroll_page_up",
@@ -211,6 +213,9 @@ impl Action {
             Action::ReconnectAgent => "Restart the CLI for the selected agent.",
             Action::DeleteSession => "Delete the selected session and worktree.",
             Action::InteractAgent => "Start a prompt turn for the agent.",
+            Action::ShowTerminal => {
+                "Launch, show, or relaunch the selected agent's companion terminal."
+            }
             Action::ExitInteractive => "Exit interactive mode (stop forwarding keys to agent).",
             Action::ToggleFullscreen => "Toggle fullscreen overlay for the agent terminal.",
             Action::ScrollPageUp => "Scroll up one page in the agent output.",
@@ -270,7 +275,8 @@ impl Action {
             Action::ExitInteractive
             | Action::ToggleFullscreen
             | Action::ScrollPageUp
-            | Action::ScrollPageDown => Some("Agent pane"),
+            | Action::ScrollPageDown
+            | Action::ShowTerminal => Some("Agent pane"),
             Action::ScrollLineUp | Action::ScrollLineDown => Some("Scrolling"),
             Action::OpenDiff
             | Action::StageUnstage
@@ -411,7 +417,10 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             (HintContext::LeftSession, "Focus"),
             (HintContext::Center, "Interact"),
         ],
-        palette: None,
+        palette: Some(PaletteEntry {
+            name: "show-agent",
+            description: "Show and focus the selected agent",
+        }),
     },
     BindingDef {
         action: Action::OpenProjectBrowser,
@@ -515,6 +524,23 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "reconnect-agent",
             description: "Restart the CLI for the selected agent",
+        }),
+    },
+    BindingDef {
+        action: Action::ShowTerminal,
+        default_keys: &[key!(t)],
+        scopes: &[BindingScope::Left, BindingScope::Center],
+        help: Some(HelpEntry {
+            section: "Agent pane",
+            description: "Launch/show companion terminal",
+        }),
+        hint_contexts: &[
+            (HintContext::LeftSession, "Terminal"),
+            (HintContext::Center, "Terminal"),
+        ],
+        palette: Some(PaletteEntry {
+            name: "show-terminal",
+            description: "Launch, show, or relaunch the selected companion terminal",
         }),
     },
     BindingDef {
@@ -1472,6 +1498,26 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn filtered_palette_includes_companion_terminal_commands() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("terminal");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"show-terminal"));
+    }
+
+    #[test]
+    fn left_scope_resolves_t_to_show_terminal() {
+        let bindings = default_bindings();
+        let t = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&t, BindingScope::Left),
+            Some(Action::ShowTerminal)
+        );
+    }
     #[test]
     fn every_action_has_config_name() {
         // Ensure no action panics when asked for config_name

--- a/src/model.rs
+++ b/src/model.rs
@@ -51,6 +51,25 @@ impl SessionStatus {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CompanionTerminalStatus {
+    NotLaunched,
+    Running,
+    Exited,
+}
+
+impl CompanionTerminalStatus {
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionSurface {
+    Agent,
+    Terminal,
+}
+
 #[derive(Clone, Debug)]
 pub struct AgentSession {
     pub id: String,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -231,12 +231,65 @@ impl PtyClient {
     pub fn try_wait(&mut self) -> Option<portable_pty::ExitStatus> {
         self.child.try_wait().ok().flatten()
     }
+
+    /// Returns the name of the foreground process running in this PTY, or
+    /// `None` if the shell itself is in the foreground (idle).
+    ///
+    /// Uses `tcgetpgrp()` via rustix to get the foreground process group and
+    /// compares it to the shell PID. If they differ, a child command is
+    /// running and its name is resolved via platform-specific APIs.
+    pub fn foreground_process_name(&self) -> Option<String> {
+        use std::os::unix::io::BorrowedFd;
+
+        let raw_fd = self.master.as_raw_fd()?;
+        // SAFETY: the master fd is valid for the lifetime of PtyClient.
+        let fd = unsafe { BorrowedFd::borrow_raw(raw_fd) };
+        let fg_pid = rustix::termios::tcgetpgrp(fd).ok()?;
+
+        let shell_pid = self.child.process_id()?;
+        if fg_pid.as_raw_nonzero().get() as u32 == shell_pid {
+            // Shell itself is in the foreground — no command running.
+            return None;
+        }
+
+        process_name(fg_pid.as_raw_nonzero().get() as u32)
+    }
 }
 
 impl Drop for PtyClient {
     fn drop(&mut self) {
         let _ = self.child.kill();
     }
+}
+
+/// Resolve a process name from its PID.
+///
+/// On Linux, reads `/proc/{pid}/comm` directly (fast, no subprocess).
+/// On macOS (no `/proc`), falls back to `ps -p {pid} -o comm=`.
+fn process_name(pid: u32) -> Option<String> {
+    // Fast path: try /proc/pid/comm (Linux).
+    if let Ok(name) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+
+    // Fallback: use ps (works on macOS and any POSIX system).
+    let output = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .ok()?;
+    let name = String::from_utf8_lossy(&output.stdout);
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // ps may return a full path; extract just the binary name.
+    std::path::Path::new(trimmed)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
 }
 
 struct TerminalState {


### PR DESCRIPTION
Reworks the companion terminal from an inline center-pane swap into a **floating overlay** that renders on top of the dimmed agent view — the same pattern used by agent fullscreen mode. The center pane now always shows the agent; pressing `t` opens a terminal overlay, `Ctrl-G` or `Esc` closes it. The old `fullscreen_agent: bool` is replaced by a `FullscreenOverlay` enum (`None`, `Agent`, `Terminal`) making overlays mutually exclusive by construction. Terminals are no longer 1:1 with sessions — each press of `t` **spawns a new terminal** in the session worktree, and multiple terminals per session are fully supported.

A new **Terminals section** appears in the left pane below Projects whenever running terminals exist. Each terminal is listed individually with its session label, and Enter or double-click opens that terminal's overlay. The section height is **mouse-draggable** (same pattern as the left/right pane dividers) and configurable via `terminal_pane_height_pct` in `[ui]`. The header shows a global `● N terminals` count, the center pane title shows `Agent (+ N terminals)` when applicable, and the quit confirmation now distinguishes between agents and terminals (e.g. *"1 running agent and 2 terminals will be killed"*).

Terminals now launch as **login shells** (`-l` flag by default) so the user's `.zshrc`/`.bash_profile`, aliases, and prompt load automatically. **Foreground process detection** via `rustix::termios::tcgetpgrp()` dynamically updates the terminal list to show the running command name (e.g. `npm · feature-branch`) or just the session label when the shell is idle. Process names resolve via `/proc/{pid}/comm` on Linux with a `ps` fallback on macOS. All `#[cfg(windows)]` branches have been removed — target platforms are macOS and Linux only (Windows via WSL2).