### PR TITLE
Add vertical resize for the right pane staged/unstaged split

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This means:
 - Left pane for projects and worktree sessions
 - Center pane for live agent terminal output or file diffs
 - Right pane for changed files and diffs
-- Resizable panes with keyboard shortcuts
+- Resizable panes with keyboard shortcuts and mouse drag
 - Collapsible project sidebar
 - Command palette with fuzzy search
 - Config written to `~/.config/dux/config.toml` (Linux) or `~/.dux/config.toml` (macOS)

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1827,21 +1827,27 @@ impl App {
             }
         }
 
-        // Horizontal divider between Unstaged and Staged sections on the right.
-        // The unstaged_list and staged_list rects represent the inner content
-        // areas. The border row sits between them — it is the row just after
-        // the bottom of unstaged_list's outer block and just before staged_list's
-        // outer block. We detect the single row that belongs to neither list.
+        // Horizontal dividers inside the right pane.
+        //
+        // The inner content rects (unstaged_list, staged_list) exclude the
+        // surrounding block borders, so the gap between two adjacent rects is
+        // typically only 1-2 rows of border chrome.  We extend the hit zone
+        // outward from each content rect by 1 row to cover the border that
+        // belongs to each block, making the target at least 3 rows wide
+        // (bottom border + gap + top border) without overlapping the content.
+
+        // Between Unstaged and Staged.
         if let (Some(unstaged), Some(staged)) = (
             self.mouse_layout.unstaged_list,
             self.mouse_layout.staged_list,
         ) {
             let right = self.mouse_layout.right;
-            // The gap between the two inner rects contains the border row(s).
-            let gap_top = unstaged.y + unstaged.height; // first row after unstaged content
-            let gap_bottom = staged.y; // first row of staged content
-            if row >= gap_top
-                && row < gap_bottom
+            // The content rects don't include their enclosing block borders.
+            // Extend one row past each content edge to cover the border row.
+            let hit_top = unstaged.y + unstaged.height; // first row after unstaged content (border)
+            let hit_bottom = staged.y.saturating_sub(1); // last row before staged content (border)
+            if row >= hit_top
+                && row <= hit_bottom
                 && column >= right.x
                 && column < right.x + right.width
             {
@@ -1849,15 +1855,16 @@ impl App {
             }
         }
 
-        // Horizontal divider between Staged Changes and Commit Message on the right.
+        // Between Staged Changes and Commit Message.
+        // staged_list is an inner rect; commit_area is an outer rect (includes border).
         if let (Some(staged), Some(commit)) =
             (self.mouse_layout.staged_list, self.mouse_layout.commit_area)
         {
             let right = self.mouse_layout.right;
-            let gap_top = staged.y + staged.height;
-            let gap_bottom = commit.y;
-            if row >= gap_top
-                && row < gap_bottom
+            let hit_top = staged.y + staged.height; // first row after staged content (border)
+            let hit_bottom = commit.y; // top border row of commit block
+            if row >= hit_top
+                && row <= hit_bottom
                 && column >= right.x
                 && column < right.x + right.width
             {
@@ -2463,13 +2470,17 @@ impl App {
             }
             Some(ResizeDragState::CommitDivider) => {
                 // The commit divider resizes the split between "Staged Changes"
-                // and "Commit Message" within the staged sub-area.  We derive
-                // the sub-area span from the staged_list and commit_area rects.
-                if let (Some(staged), Some(commit)) =
-                    (self.mouse_layout.staged_list, self.mouse_layout.commit_area)
-                {
+                // and "Commit Message".  We compute relative to the staged
+                // sub-area of the right pane.  The sub-area spans from where
+                // the staged section starts to the bottom of the right pane.
+                // Using the right pane bottom as reference keeps the
+                // calculation stable even when layout rects are stale during
+                // multi-frame drags.
+                if let Some(staged) = self.mouse_layout.staged_list {
+                    let right = self.mouse_layout.right;
+                    // Sub-area = staged block top to right pane bottom.
                     let sub_top = staged.y.saturating_sub(1); // include staged border
-                    let sub_bottom = commit.y + commit.height;
+                    let sub_bottom = right.y + right.height;
                     let sub_height = sub_bottom.saturating_sub(sub_top);
                     if sub_height > 0 {
                         let commit_rows = sub_bottom.saturating_sub(row).clamp(1, sub_height);
@@ -3520,12 +3531,14 @@ mod tests {
         app.commit_input = "hello".to_string();
         app.focus = FocusPane::Center;
 
-        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 14));
+        // Click inside the commit block (below the border row that the divider
+        // occupies) so that the first click focuses the commit section.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 15));
         assert_eq!(app.focus, FocusPane::Files);
         assert_eq!(app.right_section, RightSection::CommitInput);
         assert_eq!(app.input_target, InputTarget::None);
 
-        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 15));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 16));
         assert_eq!(app.input_target, InputTarget::CommitMessage);
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -147,6 +147,8 @@ fn clamp_right_width_pct(right_width_pct: u16, left_width_pct: u16) -> u16 {
 
 const MIN_TERMINAL_PANE_HEIGHT_PCT: u16 = 10;
 const MAX_TERMINAL_PANE_HEIGHT_PCT: u16 = 80;
+const MIN_STAGED_PANE_HEIGHT_PCT: u16 = 10;
+const MAX_STAGED_PANE_HEIGHT_PCT: u16 = 80;
 
 fn pct_from_columns(columns: u16, total_width: u16) -> u16 {
     if total_width == 0 {
@@ -1823,6 +1825,28 @@ impl App {
             }
         }
 
+        // Horizontal divider between Unstaged and Staged sections on the right.
+        // The unstaged_list and staged_list rects represent the inner content
+        // areas. The border row sits between them — it is the row just after
+        // the bottom of unstaged_list's outer block and just before staged_list's
+        // outer block. We detect the single row that belongs to neither list.
+        if let (Some(unstaged), Some(staged)) = (
+            self.mouse_layout.unstaged_list,
+            self.mouse_layout.staged_list,
+        ) {
+            let right = self.mouse_layout.right;
+            // The gap between the two inner rects contains the border row(s).
+            let gap_top = unstaged.y + unstaged.height; // first row after unstaged content
+            let gap_bottom = staged.y; // first row of staged content
+            if row >= gap_top
+                && row < gap_bottom
+                && column >= right.x
+                && column < right.x + right.width
+            {
+                return Some(ResizeDragState::StagedDivider);
+            }
+        }
+
         None
     }
 
@@ -2408,6 +2432,17 @@ impl App {
                         pct.clamp(MIN_TERMINAL_PANE_HEIGHT_PCT, MAX_TERMINAL_PANE_HEIGHT_PCT);
                 }
             }
+            Some(ResizeDragState::StagedDivider) => {
+                let right = self.mouse_layout.right;
+                if right.height > 0 {
+                    // Staged height = distance from mouse row to bottom of right pane.
+                    let right_bottom = right.y + right.height;
+                    let staged_rows = right_bottom.saturating_sub(row).clamp(1, right.height);
+                    let pct = pct_from_columns(staged_rows, right.height);
+                    self.staged_pane_height_pct =
+                        pct.clamp(MIN_STAGED_PANE_HEIGHT_PCT, MAX_STAGED_PANE_HEIGHT_PCT);
+                }
+            }
             None => {}
         }
     }
@@ -2416,10 +2451,12 @@ impl App {
         if self.config.ui.left_width_pct != self.left_width_pct
             || self.config.ui.right_width_pct != self.right_width_pct
             || self.config.ui.terminal_pane_height_pct != self.terminal_pane_height_pct
+            || self.config.ui.staged_pane_height_pct != self.staged_pane_height_pct
         {
             self.config.ui.left_width_pct = self.left_width_pct;
             self.config.ui.right_width_pct = self.right_width_pct;
             self.config.ui.terminal_pane_height_pct = self.terminal_pane_height_pct;
+            self.config.ui.staged_pane_height_pct = self.staged_pane_height_pct;
             let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
         }
     }
@@ -2713,6 +2750,7 @@ mod tests {
             left_width_pct: 20,
             right_width_pct: 23,
             terminal_pane_height_pct: 35,
+            staged_pane_height_pct: 50,
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             left_collapsed: false,
@@ -3480,6 +3518,93 @@ mod tests {
         assert_eq!(app.config.ui.left_width_pct, app.left_width_pct);
         assert_eq!(app.config.ui.right_width_pct, app.right_width_pct);
         assert_eq!(app.config.ui.right_width_pct, original_right);
+    }
+
+    #[test]
+    fn mouse_drag_staged_divider_updates_height() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        // Set up a layout with a gap between unstaged and staged content areas
+        // to represent the border row where the divider lives.
+        // unstaged inner content: rows 1..7 (y=1, height=6)
+        // border gap: row 7
+        // staged inner content: rows 8..12 (y=8, height=5)
+        app.mouse_layout.unstaged_list = Some(Rect::new(78, 1, 21, 6));
+        app.mouse_layout.staged_list = Some(Rect::new(78, 8, 21, 5));
+        app.unstaged_files = vec![ChangedFile {
+            path: "a.txt".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        app.staged_files = vec![ChangedFile {
+            path: "b.txt".into(),
+            status: "A".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        let original = app.staged_pane_height_pct;
+
+        // Click on the gap row (7), which is inside the divider zone.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 7));
+        assert!(app.mouse_drag.is_some());
+
+        // Drag downward to shrink the staged section.
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 12));
+        assert_ne!(app.staged_pane_height_pct, original);
+
+        // Release persists.
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 80, 12));
+        assert_eq!(
+            app.config.ui.staged_pane_height_pct,
+            app.staged_pane_height_pct
+        );
+    }
+
+    #[test]
+    fn mouse_staged_divider_not_detected_without_staged_files() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        // With no staged files, staged_list is None — divider must not appear.
+        app.mouse_layout.staged_list = None;
+        app.mouse_layout.unstaged_list = Some(Rect::new(78, 1, 21, 18));
+
+        // Click on a row that would be the divider if staged_list existed.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 9));
+        assert!(app.mouse_drag.is_none());
+    }
+
+    #[test]
+    fn mouse_drag_staged_divider_upward_grows_staged_section() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.mouse_layout.unstaged_list = Some(Rect::new(78, 1, 21, 6));
+        app.mouse_layout.staged_list = Some(Rect::new(78, 8, 21, 5));
+        app.unstaged_files = vec![ChangedFile {
+            path: "a.txt".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        app.staged_files = vec![ChangedFile {
+            path: "b.txt".into(),
+            status: "A".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        let original = app.staged_pane_height_pct;
+
+        // Click divider gap row.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 7));
+        assert!(app.mouse_drag.is_some());
+
+        // Drag upward to grow the staged section.
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 3));
+        assert!(app.staged_pane_height_pct > original);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -149,6 +149,8 @@ const MIN_TERMINAL_PANE_HEIGHT_PCT: u16 = 10;
 const MAX_TERMINAL_PANE_HEIGHT_PCT: u16 = 80;
 const MIN_STAGED_PANE_HEIGHT_PCT: u16 = 10;
 const MAX_STAGED_PANE_HEIGHT_PCT: u16 = 80;
+const MIN_COMMIT_PANE_HEIGHT_PCT: u16 = 10;
+const MAX_COMMIT_PANE_HEIGHT_PCT: u16 = 80;
 
 fn pct_from_columns(columns: u16, total_width: u16) -> u16 {
     if total_width == 0 {
@@ -1847,6 +1849,22 @@ impl App {
             }
         }
 
+        // Horizontal divider between Staged Changes and Commit Message on the right.
+        if let (Some(staged), Some(commit)) =
+            (self.mouse_layout.staged_list, self.mouse_layout.commit_area)
+        {
+            let right = self.mouse_layout.right;
+            let gap_top = staged.y + staged.height;
+            let gap_bottom = commit.y;
+            if row >= gap_top
+                && row < gap_bottom
+                && column >= right.x
+                && column < right.x + right.width
+            {
+                return Some(ResizeDragState::CommitDivider);
+            }
+        }
+
         None
     }
 
@@ -2443,6 +2461,24 @@ impl App {
                         pct.clamp(MIN_STAGED_PANE_HEIGHT_PCT, MAX_STAGED_PANE_HEIGHT_PCT);
                 }
             }
+            Some(ResizeDragState::CommitDivider) => {
+                // The commit divider resizes the split between "Staged Changes"
+                // and "Commit Message" within the staged sub-area.  We derive
+                // the sub-area span from the staged_list and commit_area rects.
+                if let (Some(staged), Some(commit)) =
+                    (self.mouse_layout.staged_list, self.mouse_layout.commit_area)
+                {
+                    let sub_top = staged.y.saturating_sub(1); // include staged border
+                    let sub_bottom = commit.y + commit.height;
+                    let sub_height = sub_bottom.saturating_sub(sub_top);
+                    if sub_height > 0 {
+                        let commit_rows = sub_bottom.saturating_sub(row).clamp(1, sub_height);
+                        let pct = pct_from_columns(commit_rows, sub_height);
+                        self.commit_pane_height_pct =
+                            pct.clamp(MIN_COMMIT_PANE_HEIGHT_PCT, MAX_COMMIT_PANE_HEIGHT_PCT);
+                    }
+                }
+            }
             None => {}
         }
     }
@@ -2452,11 +2488,13 @@ impl App {
             || self.config.ui.right_width_pct != self.right_width_pct
             || self.config.ui.terminal_pane_height_pct != self.terminal_pane_height_pct
             || self.config.ui.staged_pane_height_pct != self.staged_pane_height_pct
+            || self.config.ui.commit_pane_height_pct != self.commit_pane_height_pct
         {
             self.config.ui.left_width_pct = self.left_width_pct;
             self.config.ui.right_width_pct = self.right_width_pct;
             self.config.ui.terminal_pane_height_pct = self.terminal_pane_height_pct;
             self.config.ui.staged_pane_height_pct = self.staged_pane_height_pct;
+            self.config.ui.commit_pane_height_pct = self.commit_pane_height_pct;
             let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
         }
     }
@@ -2751,6 +2789,7 @@ mod tests {
             right_width_pct: 23,
             terminal_pane_height_pct: 35,
             staged_pane_height_pct: 50,
+            commit_pane_height_pct: 40,
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             left_collapsed: false,
@@ -3605,6 +3644,75 @@ mod tests {
         // Drag upward to grow the staged section.
         app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 3));
         assert!(app.staged_pane_height_pct > original);
+    }
+
+    #[test]
+    fn mouse_drag_commit_divider_updates_height() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        // staged inner content: rows 9..12 (y=9, height=3)
+        // border gap: row 12
+        // commit_area: rows 13..19 (y=13, height=6) — includes border
+        app.mouse_layout.staged_list = Some(Rect::new(78, 9, 21, 3));
+        app.mouse_layout.commit_area = Some(Rect::new(77, 13, 23, 6));
+        app.staged_files = vec![ChangedFile {
+            path: "b.txt".into(),
+            status: "A".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        let original = app.commit_pane_height_pct;
+
+        // Click on the gap row (12), which is inside the divider zone.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 12));
+        assert!(app.mouse_drag.is_some());
+
+        // Drag upward to grow the commit section.
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 10));
+        assert!(app.commit_pane_height_pct > original);
+
+        // Release persists.
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 80, 10));
+        assert_eq!(
+            app.config.ui.commit_pane_height_pct,
+            app.commit_pane_height_pct
+        );
+    }
+
+    #[test]
+    fn mouse_commit_divider_not_detected_without_staged_files() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        // No staged files means no staged_list and no commit_area.
+        app.mouse_layout.staged_list = None;
+        app.mouse_layout.commit_area = None;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 12));
+        assert!(app.mouse_drag.is_none());
+    }
+
+    #[test]
+    fn mouse_drag_commit_divider_downward_shrinks_commit_section() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.mouse_layout.staged_list = Some(Rect::new(78, 9, 21, 3));
+        app.mouse_layout.commit_area = Some(Rect::new(77, 13, 23, 6));
+        app.staged_files = vec![ChangedFile {
+            path: "b.txt".into(),
+            status: "A".into(),
+            additions: 1,
+            deletions: 0,
+            binary: false,
+        }];
+        let original = app.commit_pane_height_pct;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 80, 12));
+        assert!(app.mouse_drag.is_some());
+
+        // Drag downward to shrink the commit section.
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 80, 16));
+        assert!(app.commit_pane_height_pct < original);
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -67,6 +67,7 @@ pub struct App {
     pub(crate) right_width_pct: u16,
     pub(crate) terminal_pane_height_pct: u16,
     pub(crate) staged_pane_height_pct: u16,
+    pub(crate) commit_pane_height_pct: u16,
     pub(crate) focus: FocusPane,
     pub(crate) center_mode: CenterMode,
     pub(crate) left_collapsed: bool,
@@ -344,6 +345,7 @@ pub(crate) enum ResizeDragState {
     RightDivider,
     TerminalDivider,
     StagedDivider,
+    CommitDivider,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -445,6 +447,7 @@ impl App {
             right_width_pct: config.ui.right_width_pct,
             terminal_pane_height_pct: config.ui.terminal_pane_height_pct,
             staged_pane_height_pct: config.ui.staged_pane_height_pct,
+            commit_pane_height_pct: config.ui.commit_pane_height_pct,
             bindings,
             config,
             paths,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -66,6 +66,7 @@ pub struct App {
     pub(crate) left_width_pct: u16,
     pub(crate) right_width_pct: u16,
     pub(crate) terminal_pane_height_pct: u16,
+    pub(crate) staged_pane_height_pct: u16,
     pub(crate) focus: FocusPane,
     pub(crate) center_mode: CenterMode,
     pub(crate) left_collapsed: bool,
@@ -342,6 +343,7 @@ pub(crate) enum ResizeDragState {
     LeftDivider,
     RightDivider,
     TerminalDivider,
+    StagedDivider,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -442,6 +444,7 @@ impl App {
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
             terminal_pane_height_pct: config.ui.terminal_pane_height_pct,
+            staged_pane_height_pct: config.ui.staged_pane_height_pct,
             bindings,
             config,
             paths,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -879,10 +879,14 @@ impl App {
     /// Render the "Staged Changes" file list and the commit input as two
     /// separate bordered blocks (bubbles).
     fn render_staged_with_commit(&mut self, frame: &mut Frame, area: Rect, pane_focused: bool) {
-        let commit_height = 10u16;
+        let commit_pct = self.commit_pane_height_pct.clamp(10, 80);
+        let staged_pct = 100u16.saturating_sub(commit_pct).max(20);
         let [files_area, commit_area] = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Min(3), Constraint::Length(commit_height)])
+            .constraints([
+                Constraint::Percentage(staged_pct),
+                Constraint::Percentage(commit_pct),
+            ])
             .areas(area);
 
         // Staged files — normal titled block.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -844,11 +844,13 @@ impl App {
         let focused = self.focus == FocusPane::Files;
 
         if has_staged {
+            let pct = self.staged_pane_height_pct.clamp(10, 80);
+            let unstaged_pct = 100u16.saturating_sub(pct).max(20);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Min(3), // Changes (unstaged) — always on top
-                    Constraint::Min(3), // Staged Changes (with commit input)
+                    Constraint::Percentage(unstaged_pct), // Changes (unstaged) — always on top
+                    Constraint::Percentage(pct),          // Staged Changes (with commit input)
                 ])
                 .split(area);
             self.mouse_layout.unstaged_list = Some(self.file_list_area(chunks[0], true));

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,7 @@ pub struct UiConfig {
     pub left_width_pct: u16,
     pub right_width_pct: u16,
     pub terminal_pane_height_pct: u16,
+    pub staged_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
 }
 
@@ -136,6 +137,7 @@ impl Default for Config {
                 left_width_pct: 20,
                 right_width_pct: 23,
                 terminal_pane_height_pct: 35,
+                staged_pane_height_pct: 50,
                 agent_scrollback_lines: 10_000,
             },
             editor: EditorConfig::default(),
@@ -249,6 +251,7 @@ impl Default for UiConfig {
             left_width_pct: 17,
             right_width_pct: 19,
             terminal_pane_height_pct: 35,
+            staged_pane_height_pct: 50,
             agent_scrollback_lines: 10_000,
         }
     }
@@ -460,6 +463,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
                 "# Maximum height percentage of the left pane used by the companion terminals list.",
             )),
             value_fn: |c| FieldValue::U16(c.ui.terminal_pane_height_pct),
+        },
+        ConfigEntry::Field {
+            key: "staged_pane_height_pct",
+            comment: Some(CommentSource::Static(
+                "# Height percentage of the right pane used by the staged changes and commit sections.\n# The remaining space goes to the unstaged changes list.",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.staged_pane_height_pct),
         },
         ConfigEntry::Field {
             key: "agent_scrollback_lines",
@@ -907,6 +917,7 @@ mod tests {
         assert!(rendered.contains("args = []"));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
+        assert!(rendered.contains("staged_pane_height_pct = "));
         assert!(rendered.contains("[editor]"));
         assert!(rendered.contains("default = \"cursor\""));
         assert!(rendered.contains("[keys]"));
@@ -1013,6 +1024,28 @@ mod tests {
         let parsed: Config = toml::from_str(&rendered).expect("config should parse");
         assert_eq!(parsed.terminal.command, "fish");
         assert_eq!(parsed.terminal.args, vec!["-l"]);
+    }
+
+    #[test]
+    fn default_config_round_trips_staged_pane_height() {
+        let mut config = Config::default();
+        config.ui.staged_pane_height_pct = 65;
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("config should parse");
+        assert_eq!(parsed.ui.staged_pane_height_pct, 65);
+    }
+
+    #[test]
+    fn old_config_missing_staged_pane_height_defaults_to_50() {
+        let toml_str = r#"
+[ui]
+left_width_pct = 20
+right_width_pct = 23
+terminal_pane_height_pct = 35
+agent_scrollback_lines = 10000
+"#;
+        let parsed: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(parsed.ui.staged_pane_height_pct, 50);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,7 @@ pub struct UiConfig {
     pub right_width_pct: u16,
     pub terminal_pane_height_pct: u16,
     pub staged_pane_height_pct: u16,
+    pub commit_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
 }
 
@@ -138,6 +139,7 @@ impl Default for Config {
                 right_width_pct: 23,
                 terminal_pane_height_pct: 35,
                 staged_pane_height_pct: 50,
+                commit_pane_height_pct: 40,
                 agent_scrollback_lines: 10_000,
             },
             editor: EditorConfig::default(),
@@ -252,6 +254,7 @@ impl Default for UiConfig {
             right_width_pct: 19,
             terminal_pane_height_pct: 35,
             staged_pane_height_pct: 50,
+            commit_pane_height_pct: 40,
             agent_scrollback_lines: 10_000,
         }
     }
@@ -470,6 +473,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
                 "# Height percentage of the right pane used by the staged changes and commit sections.\n# The remaining space goes to the unstaged changes list.",
             )),
             value_fn: |c| FieldValue::U16(c.ui.staged_pane_height_pct),
+        },
+        ConfigEntry::Field {
+            key: "commit_pane_height_pct",
+            comment: Some(CommentSource::Static(
+                "# Height percentage of the staged section used by the commit message input.\n# The remaining space goes to the staged changes list.",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.commit_pane_height_pct),
         },
         ConfigEntry::Field {
             key: "agent_scrollback_lines",
@@ -918,6 +928,7 @@ mod tests {
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
         assert!(rendered.contains("staged_pane_height_pct = "));
+        assert!(rendered.contains("commit_pane_height_pct = "));
         assert!(rendered.contains("[editor]"));
         assert!(rendered.contains("default = \"cursor\""));
         assert!(rendered.contains("[keys]"));
@@ -1046,6 +1057,16 @@ agent_scrollback_lines = 10000
 "#;
         let parsed: Config = toml::from_str(toml_str).expect("should parse");
         assert_eq!(parsed.ui.staged_pane_height_pct, 50);
+        assert_eq!(parsed.ui.commit_pane_height_pct, 40);
+    }
+
+    #[test]
+    fn default_config_round_trips_commit_pane_height() {
+        let mut config = Config::default();
+        config.ui.commit_pane_height_pct = 30;
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("config should parse");
+        assert_eq!(parsed.ui.commit_pane_height_pct, 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `staged_pane_height_pct` config option controlling the vertical split between unstaged and staged sections in the right pane, mirroring the left pane's `terminal_pane_height_pct` for its projects/terminals split.
- Support mouse drag on the divider between the two right-pane sections to resize them interactively, with automatic persistence to config on release.
- Replace fixed `Min(3)` layout constraints with percentage-based constraints driven by the new setting.

## Test plan

- [x] `cargo fmt && cargo test` — 192 tests pass
- [ ] Launch the app with staged and unstaged files, drag the divider between "Changes" and "Staged Changes" up and down, verify it resizes smoothly
- [ ] Quit and relaunch — verify the resized proportion persists
- [ ] Test with no staged files — verify the right pane shows only unstaged without a phantom divider
- [ ] Verify an existing config without `staged_pane_height_pct` loads cleanly with the 50% default