### PR TITLE
Fix AI commit message returning agent commentary instead of commit text

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -827,7 +827,23 @@ impl App {
         };
         let worktree = PathBuf::from(&session.worktree_path);
         let project_path = session.project_path.as_deref().unwrap_or("");
-        let prompt = self.config.commit_prompt_for_project(project_path);
+        let base_prompt = self.config.commit_prompt_for_project(project_path);
+
+        // Capture the staged diff up-front so the provider does not need tool
+        // access to inspect it. The diff is appended after the prompt text.
+        let diff_text = match git::staged_diff_text(&worktree) {
+            Ok(d) if d.is_empty() => {
+                self.set_error("No staged diff found.");
+                return Ok(());
+            }
+            Ok(d) => d,
+            Err(e) => {
+                self.set_error(format!("Failed to read staged diff: {e}"));
+                return Ok(());
+            }
+        };
+        let prompt = format!("{base_prompt}\n\n{diff_text}");
+
         let cfg = provider_config(&self.config, &session.provider);
         let prov = provider::create_provider(session.provider.as_str(), cfg);
         let tx = self.worker_tx.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use crate::keybindings;
 use crate::model::ProviderKind;
 
 pub const DEFAULT_COMMIT_PROMPT: &str = "\
-You are a commit message generator. Look at the staged changes (git diff --cached) and write a commit message.
+Write a commit message for the following staged diff.
 
 Rules:
 - Subject line: use Conventional Commits (feat:, fix:, refactor:, docs:, test:, chore:, style:, perf:, ci:, build:). Imperative mood, max 72 chars, no period at the end.
@@ -22,7 +22,7 @@ Rules:
 - Larger changes (4+ files or multiple distinct logical concerns): subject line, blank line, then concise bullet points (one per logical change, each under 80 chars). Use \"- \" for bullets.
 - This is a plain text commit message, not markdown. NEVER use backticks, asterisks, code fences, or any markdown syntax. Refer to functions and files by name without formatting.
 - Focus on intent and impact, not mechanical description of lines added/removed.
-- Output ONLY the raw commit message text.";
+- Output ONLY the raw commit message. No preamble, no quotes, no explanation.";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -417,7 +417,7 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             key: "commit_prompt",
             comment: Some(CommentSource::Dynamic(format!(
                 "# Prompt sent to the AI provider when generating commit messages ({generate_commit_key}).\n\
-                 # The provider will inspect the staged diff on its own.\n\
+                 # The staged diff is appended automatically after the prompt text.\n\
                  # Override per-project by adding commit_prompt in a [[projects]] entry.",
             ))),
             value_fn: |c| FieldValue::MultilineStr(c.defaults.commit_prompt.clone()),
@@ -709,7 +709,15 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
                 command: "claude".to_string(),
                 args: Vec::new(),
                 resume_args: Some(vec!["--continue".to_string()]),
-                oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+                oneshot_args: vec![
+                    "--bare".to_string(),
+                    "-p".to_string(),
+                    "{prompt}".to_string(),
+                    "--tools".to_string(),
+                    String::new(),
+                    "--max-turns".to_string(),
+                    "1".to_string(),
+                ],
                 oneshot_output: OneshotOutput::Stdout,
                 install_hint: Some("npm install -g @anthropic-ai/claude-code".to_string()),
             },
@@ -722,6 +730,10 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
                 resume_args: Some(vec!["resume".to_string(), "--last".to_string()]),
                 oneshot_args: vec![
                     "exec".to_string(),
+                    "--ephemeral".to_string(),
+                    "--full-auto".to_string(),
+                    "--color".to_string(),
+                    "never".to_string(),
                     "-o".to_string(),
                     "{tempfile}".to_string(),
                     "{prompt}".to_string(),
@@ -1287,6 +1299,35 @@ oneshot_output = "stdout"
         assert!(
             !rendered.contains("(Ctrl+G)"),
             "config comment should NOT contain hardcoded Ctrl+G"
+        );
+    }
+
+    #[test]
+    fn default_claude_oneshot_uses_bare_and_no_tools() {
+        let providers = default_provider_commands();
+        let claude = &providers[0].1;
+        assert!(
+            claude.oneshot_args.contains(&"--bare".to_string()),
+            "claude oneshot_args should include --bare"
+        );
+        assert!(
+            claude.oneshot_args.contains(&"--tools".to_string()),
+            "claude oneshot_args should include --tools flag"
+        );
+        // --tools is followed by an empty string to disable all tools
+        let tools_idx = claude
+            .oneshot_args
+            .iter()
+            .position(|a| a == "--tools")
+            .unwrap();
+        assert_eq!(
+            claude.oneshot_args[tools_idx + 1],
+            "",
+            "--tools should be followed by empty string to disable tools"
+        );
+        assert!(
+            claude.oneshot_args.contains(&"--max-turns".to_string()),
+            "claude oneshot_args should include --max-turns"
         );
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -402,6 +402,29 @@ pub fn discard_file(worktree_path: &Path, file_path: &str, is_untracked: bool) -
     Ok(())
 }
 
+/// Return the text of `git diff --cached` for the given worktree.
+/// Uses `-c color.diff=false` to strip ANSI escapes regardless of user config.
+pub fn staged_diff_text(worktree_path: &Path) -> Result<String> {
+    let wt = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args([
+            "-C",
+            wt.as_ref(),
+            "-c",
+            "color.diff=false",
+            "diff",
+            "--cached",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git diff --cached failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 pub fn commit(worktree_path: &Path, message: &str) -> Result<String> {
     let wt = worktree_path.to_string_lossy();
     let output = Command::new("git")
@@ -719,6 +742,43 @@ mod tests {
                     false
                 ),
             ]
+        );
+    }
+
+    #[test]
+    fn staged_diff_text_returns_diff_for_staged_changes() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "staged-diff");
+        fs::write(wt.join("hello.txt"), "hello world\n").unwrap();
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&wt)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["add", "hello.txt"]);
+        let diff = staged_diff_text(&wt).unwrap();
+        assert!(diff.contains("hello.txt"), "diff should mention the file");
+        assert!(
+            diff.contains("+hello world"),
+            "diff should contain the added line"
+        );
+    }
+
+    #[test]
+    fn staged_diff_text_empty_when_nothing_staged() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "no-staged");
+        let diff = staged_diff_text(&wt).unwrap();
+        assert!(
+            diff.is_empty(),
+            "diff should be empty when nothing is staged"
         );
     }
 


### PR DESCRIPTION
## Summary

- Captures the staged diff in Rust via `git diff --cached` and embeds it directly in the prompt, so the AI provider no longer needs tool access to inspect changes
- Updates Claude default oneshot args with `--bare` (skip CLAUDE.md/hooks/MCP), `--tools ""` (disable all tool use), and `--max-turns 1` (single-turn response) to eliminate agent behavior
- Updates Codex default oneshot args with `--ephemeral`, `--full-auto`, and `--color never` for cleaner output
- Revises the default prompt to expect the diff inline and explicitly forbid preamble, quotes, or explanation

## Test plan

- [x] All 190 tests pass including 3 new tests
- [ ] Verify AI commit message generation with Claude produces only the commit message
- [ ] Verify AI commit message generation with Codex produces only the commit message
- [ ] Confirm existing users with custom `commit_prompt` in config still work (diff is appended after their prompt)