### PR TITLE
Add worktree forks and harden Git parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,13 @@ When shelling out to git, **always ensure the command output is immune to user-s
 
 - **Prefer plumbing commands** (`cat-file`, `rev-parse`, `for-each-ref`) over porcelain when you need machine-readable output. Plumbing commands are guaranteed stable.
 - **Use `--porcelain`** for `git status`. Never use `--short` — it is affected by user config (`status.branch`, `status.relativePaths`, etc.).
+- **Prefer `--porcelain=v1 -z` when parsing status paths.** Parse NUL-delimited records instead of line-based output so spaces, quotes, Unicode, and embedded newlines in paths are handled safely.
 - **Use `--numstat`** for line-level diff statistics. It outputs tab-separated values unaffected by config.
+- **Prefer `--numstat -z` when parsing file paths from diff stats.** Rename and copy records should be parsed from NUL-delimited output, not from whitespace- or newline-delimited text.
 - **Override config with `-c`** when a porcelain/plumbing alternative doesn't exist (e.g., `git -c color.diff=false diff`).
 - **Imperative commands** that aren't parsed (`worktree add`, `branch -D`, `pull`) are fine as-is.
+- **For imperative git commands, rely on exit status rather than parsing stdout.** Treat stdout/stderr as user-facing diagnostics only unless Git explicitly documents the format as machine-stable.
+- **Do not parse human-facing commands like `git branch --show-current` when a plumbing-style alternative exists.** Prefer commands such as `symbolic-ref --quiet --short HEAD` or `rev-parse`.
 - **Avoid shelling out to `git diff` for display** — the project computes diffs in-process using the `similar` crate and applies syntax highlighting with `syntect`. Use `git::file_at_head()` to get the base version and read the working copy from disk.
 
 ## Recommendations For Editing

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This means:
 ## Features
 
 - Left pane for projects and worktree sessions
+- Fork an existing agent session into a new worktree with the current files copied over
 - Center pane for live agent terminal output or file diffs
 - Right pane for changed files and diffs
 - Resizable panes with keyboard shortcuts and mouse drag

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -469,6 +469,7 @@ impl App {
                     self.open_project_browser()?;
                 }
                 Action::NewAgent => self.create_agent_for_selected_project()?,
+                Action::ForkAgent => self.fork_selected_session()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
                 Action::ShowTerminal => self.show_companion_terminal()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
@@ -3054,6 +3055,33 @@ mod tests {
         assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
         assert_eq!(app.input_target, InputTarget::None);
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+    }
+
+    #[test]
+    fn fork_selected_session_sets_busy_state_and_keeps_fresh_create_flow() {
+        let mut app = test_app(default_bindings());
+
+        app.fork_selected_session().unwrap();
+
+        assert!(app.create_agent_in_flight);
+        assert!(app.status.text().contains("Forking agent"));
+        assert!(app.status.text().contains("fresh session"));
+    }
+
+    #[test]
+    fn fork_action_requires_selected_session() {
+        let mut app = test_app(default_bindings());
+        app.selected_left = 0;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(
+            app.status
+                .text()
+                .contains("Select an agent session first to fork.")
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -389,6 +389,19 @@ pub(crate) struct AgentReadyData {
     pub session: AgentSession,
     pub client: PtyClient,
     pub pty_size: (u16, u16), // (rows, cols) the PTY was spawned with
+    pub status_message: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum CreateAgentRequest {
+    NewProject {
+        project: Project,
+    },
+    ForkSession {
+        project: Project,
+        source_session: AgentSession,
+        source_label: String,
+    },
 }
 
 pub(crate) enum WorkerEvent {
@@ -607,6 +620,7 @@ impl App {
         let command = command.trim();
         match command {
             "new-agent" => self.create_agent_for_selected_project(),
+            "fork-agent" => self.fork_selected_session(),
             "provider" => self.cycle_selected_project_provider(),
             "refresh-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -97,26 +97,65 @@ impl App {
     }
 
     pub(crate) fn create_agent_for_selected_project(&mut self) -> Result<()> {
-        if self.create_agent_in_flight {
-            self.set_error("An agent is already being created.");
-            return Ok(());
-        }
         let Some(project) = self.selected_project().cloned() else {
             self.set_error("Select a project first.");
             return Ok(());
         };
         logger::info(&format!("creating agent for project {}", project.path));
-        self.create_agent_in_flight = true;
-        self.set_busy(format!(
-            "Creating worktree for project \"{}\"...",
-            project.name
+        self.dispatch_create_agent_request(
+            CreateAgentRequest::NewProject {
+                project: project.clone(),
+            },
+            format!(
+                "Creating a new agent worktree for project \"{}\" and launching a fresh session...",
+                project.name
+            ),
+        )
+    }
+
+    pub(crate) fn fork_selected_session(&mut self) -> Result<()> {
+        let Some(source_session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent session first to fork.");
+            return Ok(());
+        };
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select an agent session first to fork.");
+            return Ok(());
+        };
+        let source_label = self.session_label(&source_session);
+        logger::info(&format!(
+            "forking session {} from worktree {}",
+            source_session.id, source_session.worktree_path
         ));
+        self.dispatch_create_agent_request(
+            CreateAgentRequest::ForkSession {
+                project: project.clone(),
+                source_session,
+                source_label: source_label.clone(),
+            },
+            format!(
+                "Forking agent \"{source_label}\" by cloning its current worktree contents into a fresh session...",
+            ),
+        )
+    }
+
+    fn dispatch_create_agent_request(
+        &mut self,
+        request: CreateAgentRequest,
+        busy_message: String,
+    ) -> Result<()> {
+        if self.create_agent_in_flight {
+            self.set_error("An agent is already being created or forked.");
+            return Ok(());
+        }
+        self.create_agent_in_flight = true;
+        self.set_busy(busy_message);
         let paths = self.paths.clone();
         let config = self.config.clone();
         let worker_tx = self.worker_tx.clone();
         let term_size = crossterm::terminal::size().unwrap_or((80, 24));
         thread::spawn(move || {
-            super::workers::run_create_agent_job(project, paths, config, worker_tx, term_size);
+            super::workers::run_create_agent_job(request, paths, config, worker_tx, term_size);
         });
         Ok(())
     }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -6,7 +6,12 @@ impl App {
             match event {
                 WorkerEvent::CreateAgentProgress(message) => self.set_busy(message),
                 WorkerEvent::CreateAgentReady(boxed) => {
-                    let AgentReadyData { session, client, pty_size } = *boxed;
+                    let AgentReadyData {
+                        session,
+                        client,
+                        pty_size,
+                        status_message,
+                    } = *boxed;
                     self.create_agent_in_flight = false;
                     self.last_pty_size = pty_size;
                     if let Err(err) = self.session_store.upsert_session(&session) {
@@ -29,13 +34,7 @@ impl App {
                     self.show_agent_surface();
                     self.input_target = InputTarget::Agent;
                     self.fullscreen_overlay = FullscreenOverlay::Agent;
-                    let proj_name = self.project_name_for_session(&session);
-                    self.set_info(format!(
-                        "Created {} agent \"{}\" in project \"{}\"",
-                        session.provider.as_str(),
-                        session.branch_name,
-                        proj_name
-                    ));
+                    self.set_info(status_message);
                 }
                 WorkerEvent::CreateAgentFailed(message) => {
                     self.create_agent_in_flight = false;
@@ -214,31 +213,124 @@ impl App {
 }
 
 pub(crate) fn run_create_agent_job(
-    project: Project,
+    request: CreateAgentRequest,
     paths: DuxPaths,
     config: Config,
     worker_tx: Sender<WorkerEvent>,
     term_size: (u16, u16),
 ) {
-    let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-        "Creating worktree for project \"{}\"...",
-        project.name
-    )));
-    let repo_path = PathBuf::from(&project.path);
-    let (branch_name, worktree_path) =
-        match git::create_worktree(&repo_path, &paths.worktrees_root, &project.name) {
-            Ok(result) => result,
-            Err(err) => {
-                logger::error(&format!(
-                    "worktree creation failed for {}: {err}",
-                    project.path
-                ));
-                let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
-                    "Worktree creation failed: {err}"
+    let (project, provider, source_branch, status_message, branch_name, worktree_path) =
+        match request {
+            CreateAgentRequest::NewProject { project } => {
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                    "Creating a new worktree for project \"{}\"...",
+                    project.name
                 )));
-                return;
+                let repo_path = PathBuf::from(&project.path);
+                let (branch_name, worktree_path) =
+                    match git::create_worktree(&repo_path, &paths.worktrees_root, &project.name) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            logger::error(&format!(
+                                "worktree creation failed for {}: {err}",
+                                project.path
+                            ));
+                            let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                                "Failed to create a new worktree for project \"{}\": {err}",
+                                project.name
+                            )));
+                            return;
+                        }
+                    };
+                let status_message = format!(
+                    "Created {} agent \"{}\" in project \"{}\". The new worktree is ready in a fresh session.",
+                    project.default_provider.as_str(),
+                    branch_name,
+                    project.name
+                );
+                (
+                    project.clone(),
+                    project.default_provider.clone(),
+                    project.current_branch.clone(),
+                    status_message,
+                    branch_name,
+                    worktree_path,
+                )
+            }
+            CreateAgentRequest::ForkSession {
+                project,
+                source_session,
+                source_label,
+            } => {
+                let source_worktree = PathBuf::from(&source_session.worktree_path);
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                    "Creating a forked worktree from agent \"{source_label}\"...",
+                )));
+                let source_head = match git::head_commit(&source_worktree) {
+                    Ok(head) => head,
+                    Err(err) => {
+                        logger::error(&format!(
+                            "failed to resolve HEAD for {}: {err}",
+                            source_session.worktree_path
+                        ));
+                        let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to inspect the source worktree for agent \"{source_label}\": {err}",
+                    )));
+                        return;
+                    }
+                };
+                let repo_path = PathBuf::from(&project.path);
+                let (branch_name, worktree_path) = match git::create_worktree_from_start_point(
+                    &repo_path,
+                    &paths.worktrees_root,
+                    &project.name,
+                    Some(&source_head),
+                ) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        logger::error(&format!(
+                            "fork worktree creation failed for {}: {err}",
+                            project.path
+                        ));
+                        let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to create a forked worktree from agent \"{source_label}\": {err}",
+                    )));
+                        return;
+                    }
+                };
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                "Copying the current filesystem contents from agent \"{source_label}\" into the new fork...",
+            )));
+                if let Err(err) = git::mirror_worktree_contents(&source_worktree, &worktree_path) {
+                    logger::error(&format!(
+                        "failed to mirror worktree {} into {}: {err}",
+                        source_worktree.display(),
+                        worktree_path.display()
+                    ));
+                    let _ = git::remove_worktree(&repo_path, &worktree_path, &branch_name);
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                    "Failed to copy the source worktree contents for agent \"{source_label}\": {err}",
+                )));
+                    return;
+                }
+                let status_message = format!(
+                    "Forked {} agent \"{}\" from \"{}\" in project \"{}\". The new worktree starts with copied files and a fresh session.",
+                    source_session.provider.as_str(),
+                    branch_name,
+                    source_label,
+                    project.name
+                );
+                (
+                    project,
+                    source_session.provider,
+                    source_session.branch_name,
+                    status_message,
+                    branch_name,
+                    worktree_path,
+                )
             }
         };
+    let repo_path = PathBuf::from(&project.path);
     logger::info(&format!(
         "created worktree {} on branch {}",
         worktree_path.display(),
@@ -248,8 +340,8 @@ pub(crate) fn run_create_agent_job(
         id: Uuid::new_v4().to_string(),
         project_id: project.id.clone(),
         project_path: Some(project.path.clone()),
-        provider: project.default_provider.clone(),
-        source_branch: project.current_branch.clone(),
+        provider,
+        source_branch,
         branch_name,
         worktree_path: worktree_path.to_string_lossy().to_string(),
         title: None,
@@ -269,7 +361,7 @@ pub(crate) fn run_create_agent_job(
         return;
     }
     let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-        "Launching {}...",
+        "Launching {} in a fresh session...",
         session.provider.as_str()
     )));
     // crossterm::terminal::size() returns (cols, rows).
@@ -302,6 +394,7 @@ pub(crate) fn run_create_agent_job(
         session,
         client,
         pty_size: (rows, cols),
+        status_message,
     })));
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -92,21 +93,35 @@ pub fn create_worktree(
     worktrees_root: &Path,
     project_name: &str,
 ) -> Result<(String, PathBuf)> {
+    create_worktree_from_start_point(repo_path, worktrees_root, project_name, None)
+}
+
+pub fn create_worktree_from_start_point(
+    repo_path: &Path,
+    worktrees_root: &Path,
+    project_name: &str,
+    start_point: Option<&str>,
+) -> Result<(String, PathBuf)> {
     let branch_name = docker_style_name();
     let project_root = worktrees_root.join(project_name);
     fs::create_dir_all(&project_root)?;
     let worktree_path = project_root.join(&branch_name);
-    let output = Command::new("git")
-        .args([
-            "-C",
-            repo_path.to_string_lossy().as_ref(),
-            "worktree",
-            "add",
-            "-b",
-            &branch_name,
-            worktree_path.to_string_lossy().as_ref(),
-        ])
-        .output()?;
+    let repo = repo_path.to_string_lossy();
+    let worktree = worktree_path.to_string_lossy();
+    let mut command = Command::new("git");
+    command.args([
+        "-C",
+        repo.as_ref(),
+        "worktree",
+        "add",
+        "-b",
+        &branch_name,
+        worktree.as_ref(),
+    ]);
+    if let Some(start_point) = start_point {
+        command.arg(start_point);
+    }
+    let output = command.output()?;
     if !output.status.success() {
         return Err(anyhow!(
             "git worktree add failed: {}",
@@ -115,6 +130,41 @@ pub fn create_worktree(
     }
     let canonical = worktree_path.canonicalize().unwrap_or(worktree_path);
     Ok((branch_name, canonical))
+}
+
+pub fn head_commit(repo_path: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_string_lossy().as_ref(),
+            "rev-parse",
+            "HEAD",
+        ])
+        .output()
+        .with_context(|| format!("failed to inspect HEAD for {}", repo_path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git rev-parse HEAD failed for {}: {}",
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+pub fn mirror_worktree_contents(source: &Path, destination: &Path) -> Result<()> {
+    let source = source
+        .canonicalize()
+        .with_context(|| format!("failed to resolve {}", source.display()))?;
+    let destination = destination
+        .canonicalize()
+        .with_context(|| format!("failed to resolve {}", destination.display()))?;
+    if source == destination {
+        return Err(anyhow!(
+            "source and destination worktrees must be different"
+        ));
+    }
+    sync_directory_contents(&source, &destination)
 }
 
 pub struct RemoveResult {
@@ -532,6 +582,94 @@ pub fn docker_style_name() -> String {
         .expect("petname generation should not fail")
 }
 
+fn sync_directory_contents(source: &Path, destination: &Path) -> Result<()> {
+    let mut source_entries = Vec::new();
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if is_git_admin_entry(&name) {
+            continue;
+        }
+        source_entries.push(name);
+        sync_entry(&entry.path(), &destination.join(entry.file_name()))?;
+    }
+
+    for entry in fs::read_dir(destination)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if is_git_admin_entry(&name) {
+            continue;
+        }
+        if !source_entries.iter().any(|candidate| candidate == &name) {
+            remove_path(&entry.path())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn sync_entry(source: &Path, destination: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        sync_symlink(source, destination)?;
+        return Ok(());
+    }
+
+    if file_type.is_dir() {
+        if destination.exists() {
+            let destination_meta = fs::symlink_metadata(destination)?;
+            if !destination_meta.file_type().is_dir() || destination_meta.file_type().is_symlink() {
+                remove_path(destination)?;
+            }
+        }
+        if !destination.exists() {
+            fs::create_dir(destination)?;
+        }
+        sync_directory_contents(source, destination)?;
+        fs::set_permissions(destination, metadata.permissions())?;
+        return Ok(());
+    }
+
+    if destination.exists() {
+        let destination_meta = fs::symlink_metadata(destination)?;
+        if destination_meta.file_type().is_dir() || destination_meta.file_type().is_symlink() {
+            remove_path(destination)?;
+        }
+    }
+    fs::copy(source, destination)?;
+    fs::set_permissions(destination, metadata.permissions())?;
+    Ok(())
+}
+
+fn sync_symlink(source: &Path, destination: &Path) -> Result<()> {
+    let target = fs::read_link(source)?;
+    if let Ok(existing_target) = fs::read_link(destination)
+        && existing_target == target
+    {
+        return Ok(());
+    }
+    if destination.exists() || fs::symlink_metadata(destination).is_ok() {
+        remove_path(destination)?;
+    }
+    symlink(&target, destination)?;
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn is_git_admin_entry(name: &std::ffi::OsStr) -> bool {
+    name == ".git"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -585,16 +723,9 @@ mod tests {
             );
         };
         run(&["init", "-b", "main"]);
-        run(&[
-            "-c",
-            "user.name=test",
-            "-c",
-            "user.email=t@t",
-            "commit",
-            "--allow-empty",
-            "-m",
-            "init",
-        ]);
+        run(&["config", "user.name", "test"]);
+        run(&["config", "user.email", "t@t"]);
+        run(&["commit", "--allow-empty", "-m", "init"]);
         dir
     }
 
@@ -619,6 +750,93 @@ mod tests {
             String::from_utf8_lossy(&out.stderr)
         );
         wt
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed in {}: {}",
+            args,
+            cwd.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fn commit_all(cwd: &Path, message: &str) {
+        run_git(cwd, &["add", "-A"]);
+        run_git(cwd, &["commit", "-m", message]);
+    }
+
+    #[test]
+    fn create_worktree_from_start_point_uses_explicit_head_commit() {
+        let repo = init_test_repo();
+        let source = add_worktree(repo.path(), "source-head");
+        fs::write(source.join("fork.txt"), "from source branch\n").unwrap();
+        commit_all(&source, "source commit");
+        let source_head = head_commit(&source).unwrap();
+
+        let worktrees_root = repo.path().join("forks");
+        let (_branch_name, forked) = create_worktree_from_start_point(
+            repo.path(),
+            &worktrees_root,
+            "demo",
+            Some(&source_head),
+        )
+        .unwrap();
+
+        assert_eq!(head_commit(&forked).unwrap(), source_head);
+        assert_eq!(
+            fs::read_to_string(forked.join("fork.txt")).unwrap(),
+            "from source branch\n"
+        );
+    }
+
+    #[test]
+    fn mirror_worktree_contents_copies_visible_tree_and_preserves_git_admin_state() {
+        let repo = init_test_repo();
+        fs::write(repo.path().join("tracked.txt"), "original tracked\n").unwrap();
+        fs::write(repo.path().join("delete-me.txt"), "delete me\n").unwrap();
+        commit_all(repo.path(), "tracked files");
+
+        let source = add_worktree(repo.path(), "mirror-source");
+        let destination = add_worktree(repo.path(), "mirror-destination");
+
+        fs::write(source.join("tracked.txt"), "modified tracked\n").unwrap();
+        fs::remove_file(source.join("delete-me.txt")).unwrap();
+        fs::write(source.join(".env"), "TOKEN=abc\n").unwrap();
+        fs::create_dir_all(source.join("scratch").join("nested")).unwrap();
+        fs::write(
+            source.join("scratch").join("nested").join("note.txt"),
+            "untracked\n",
+        )
+        .unwrap();
+
+        let destination_git_before = fs::read_to_string(destination.join(".git")).unwrap();
+        mirror_worktree_contents(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(destination.join("tracked.txt")).unwrap(),
+            "modified tracked\n"
+        );
+        assert!(!destination.join("delete-me.txt").exists());
+        assert_eq!(
+            fs::read_to_string(destination.join(".env")).unwrap(),
+            "TOKEN=abc\n"
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join("scratch").join("nested").join("note.txt"))
+                .unwrap(),
+            "untracked\n"
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join(".git")).unwrap(),
+            destination_git_before
+        );
     }
 
     // ── rename_branch tests ──────────────────────────────────────

--- a/src/git.rs
+++ b/src/git.rs
@@ -14,6 +14,12 @@ enum DiffStat {
     Binary,
 }
 
+struct StatusEntry {
+    index_status: char,
+    worktree_status: char,
+    path: String,
+}
+
 const NULL_DEVICE: &str = "/dev/null";
 
 pub fn current_branch(repo_path: &Path) -> Result<String> {
@@ -21,14 +27,16 @@ pub fn current_branch(repo_path: &Path) -> Result<String> {
         .args([
             "-C",
             repo_path.to_string_lossy().as_ref(),
-            "branch",
-            "--show-current",
+            "symbolic-ref",
+            "--quiet",
+            "--short",
+            "HEAD",
         ])
         .output()
         .with_context(|| format!("failed to inspect {}", repo_path.display()))?;
     if !output.status.success() {
         return Err(anyhow!(
-            "git branch failed for {}: {}",
+            "git symbolic-ref failed for {}: {}",
             repo_path.display(),
             String::from_utf8_lossy(&output.stderr)
         ));
@@ -55,7 +63,9 @@ pub fn is_dirty(repo_path: &Path) -> Result<bool> {
             "-C",
             repo_path.to_string_lossy().as_ref(),
             "status",
-            "--porcelain",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=no",
         ])
         .output()?;
     if !output.status.success() {
@@ -226,7 +236,8 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
             "-C",
             wt.as_ref(),
             "status",
-            "--porcelain",
+            "--porcelain=v1",
+            "-z",
             "--untracked-files=all",
         ])
         .output()?;
@@ -240,14 +251,10 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     let mut staged = Vec::new();
     let mut unstaged = Vec::new();
 
-    for line in String::from_utf8_lossy(&output.stdout).lines() {
-        if line.len() < 4 {
-            continue;
-        }
-        let bytes = line.as_bytes();
-        let index_status = bytes[0] as char;
-        let worktree_status = bytes[1] as char;
-        let path = line[3..].to_string();
+    for entry in parse_status_porcelain_z(&output.stdout) {
+        let index_status = entry.index_status;
+        let worktree_status = entry.worktree_status;
+        let path = entry.path;
 
         if index_status == '?' && worktree_status == '?' {
             unstaged.push(ChangedFile {
@@ -282,7 +289,7 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     }
 
     if let Ok(ns) = Command::new("git")
-        .args(["-C", wt.as_ref(), "diff", "--numstat"])
+        .args(["-C", wt.as_ref(), "diff", "--numstat", "-z"])
         .output()
         && ns.status.success()
     {
@@ -319,7 +326,7 @@ pub fn changed_files(worktree_path: &Path) -> Result<(Vec<ChangedFile>, Vec<Chan
     }
 
     if let Ok(ns) = Command::new("git")
-        .args(["-C", wt.as_ref(), "diff", "--cached", "--numstat"])
+        .args(["-C", wt.as_ref(), "diff", "--cached", "--numstat", "-z"])
         .output()
         && ns.status.success()
     {
@@ -350,6 +357,7 @@ fn untracked_file_diff_stat(worktree_path: &Path, rel_path: &str) -> Option<Diff
             "diff",
             "--no-index",
             "--numstat",
+            "-z",
             "--",
             NULL_DEVICE,
             rel_path,
@@ -361,7 +369,7 @@ fn untracked_file_diff_stat(worktree_path: &Path, rel_path: &str) -> Option<Diff
         return None;
     }
 
-    parse_numstat_line(String::from_utf8_lossy(&output.stdout).lines().next()?)
+    parse_numstat(&output.stdout).into_values().next()
 }
 
 fn classify_untracked_file_fallback(path: &Path) -> (usize, bool) {
@@ -378,16 +386,20 @@ fn classify_untracked_file_fallback(path: &Path) -> (usize, bool) {
 }
 
 fn parse_numstat(raw: &[u8]) -> HashMap<String, DiffStat> {
-    String::from_utf8_lossy(raw)
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.split('\t');
-            let _ = parts.next()?;
-            let _ = parts.next()?;
-            let path = parts.next()?.to_string();
-            Some((path, parse_numstat_line(line)?))
-        })
-        .collect()
+    let mut stats = HashMap::new();
+    let mut records = raw.split(|byte| *byte == 0).peekable();
+
+    while let Some(record) = records.next() {
+        if record.is_empty() {
+            continue;
+        }
+        let Some((path, stat)) = parse_numstat_record(record, &mut records) else {
+            continue;
+        };
+        stats.insert(path, stat);
+    }
+
+    stats
 }
 
 fn parse_numstat_line(line: &str) -> Option<DiffStat> {
@@ -399,6 +411,62 @@ fn parse_numstat_line(line: &str) -> Option<DiffStat> {
     } else {
         Some(DiffStat::Text(add.parse().ok()?, del.parse().ok()?))
     }
+}
+
+fn parse_status_porcelain_z(raw: &[u8]) -> Vec<StatusEntry> {
+    let mut entries = Vec::new();
+    let mut records = raw.split(|byte| *byte == 0).peekable();
+
+    while let Some(record) = records.next() {
+        if record.len() < 4 {
+            continue;
+        }
+
+        let index_status = record[0] as char;
+        let worktree_status = record[1] as char;
+        let path = String::from_utf8_lossy(&record[3..]).to_string();
+
+        if path.is_empty() {
+            continue;
+        }
+
+        if matches!(index_status, 'R' | 'C') || matches!(worktree_status, 'R' | 'C') {
+            let _ = records.next();
+        }
+
+        entries.push(StatusEntry {
+            index_status,
+            worktree_status,
+            path,
+        });
+    }
+
+    entries
+}
+
+fn parse_numstat_record<'a, I>(
+    record: &[u8],
+    records: &mut std::iter::Peekable<I>,
+) -> Option<(String, DiffStat)>
+where
+    I: Iterator<Item = &'a [u8]>,
+{
+    let first_tab = record.iter().position(|byte| *byte == b'\t')?;
+    let second_tab = record[first_tab + 1..]
+        .iter()
+        .position(|byte| *byte == b'\t')?
+        + first_tab
+        + 1;
+    let stat = parse_numstat_line(std::str::from_utf8(record).ok()?)?;
+    let path_bytes = &record[second_tab + 1..];
+
+    if !path_bytes.is_empty() {
+        return Some((String::from_utf8_lossy(path_bytes).to_string(), stat));
+    }
+
+    let _old_path = records.next()?;
+    let new_path = records.next()?;
+    Some((String::from_utf8_lossy(new_path).to_string(), stat))
 }
 
 pub fn stage_file(worktree_path: &Path, file_path: &str) -> Result<()> {
@@ -1015,5 +1083,84 @@ mod tests {
         assert_eq!(file.additions, 0);
         assert_eq!(file.deletions, 0);
         assert!(file.binary);
+    }
+
+    #[test]
+    fn parse_status_porcelain_z_handles_untracked_and_spaces() {
+        let raw = b"?? spaced name.txt\0";
+        let entries = parse_status_porcelain_z(raw);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].index_status, '?');
+        assert_eq!(entries[0].worktree_status, '?');
+        assert_eq!(entries[0].path, "spaced name.txt");
+    }
+
+    #[test]
+    fn parse_status_porcelain_z_uses_destination_path_for_renames() {
+        let raw = b"R  new name.txt\0old name.txt\0";
+        let entries = parse_status_porcelain_z(raw);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].index_status, 'R');
+        assert_eq!(entries[0].worktree_status, ' ');
+        assert_eq!(entries[0].path, "new name.txt");
+    }
+
+    #[test]
+    fn parse_status_porcelain_z_skips_empty_records() {
+        let raw = b"\0M  file.txt\0\0";
+        let entries = parse_status_porcelain_z(raw);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "file.txt");
+    }
+
+    #[test]
+    fn parse_numstat_handles_regular_path_with_spaces() {
+        let stats = parse_numstat(b"1\t2\tsp ace.txt\0");
+        let stat = stats.get("sp ace.txt").expect("stat present");
+        match stat {
+            DiffStat::Text(additions, deletions) => {
+                assert_eq!((*additions, *deletions), (1, 2));
+            }
+            DiffStat::Binary => panic!("expected text stat"),
+        }
+    }
+
+    #[test]
+    fn parse_numstat_handles_rename_records() {
+        let stats = parse_numstat(b"0\t0\t\0old name.txt\0new name.txt\0");
+        let stat = stats.get("new name.txt").expect("stat present");
+        match stat {
+            DiffStat::Text(additions, deletions) => {
+                assert_eq!((*additions, *deletions), (0, 0));
+            }
+            DiffStat::Binary => panic!("expected text stat"),
+        }
+    }
+
+    #[test]
+    fn parse_numstat_handles_binary_records() {
+        let stats = parse_numstat(b"-\t-\tbinary.bin\0");
+        assert!(matches!(stats.get("binary.bin"), Some(DiffStat::Binary)));
+    }
+
+    #[test]
+    fn changed_files_uses_destination_path_for_staged_rename() {
+        let repo = init_test_repo();
+        let wt = add_worktree(repo.path(), "rename-status");
+
+        fs::write(wt.join("old name.txt"), "hello\n").unwrap();
+        run_git(&wt, &["add", "old name.txt"]);
+        run_git(&wt, &["commit", "-m", "add file"]);
+        run_git(&wt, &["mv", "old name.txt", "new name.txt"]);
+
+        let (staged, unstaged) = changed_files(&wt).unwrap();
+
+        assert!(unstaged.is_empty());
+        assert_eq!(staged.len(), 1);
+        assert_eq!(staged[0].path, "new name.txt");
+        assert_eq!(staged[0].status, "R");
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -10,6 +10,7 @@ pub enum Action {
     // Projects pane
     ToggleProject,
     NewAgent,
+    ForkAgent,
     FocusAgent,
     OpenProjectBrowser,
     CopyPath,
@@ -145,6 +146,7 @@ impl Action {
             Action::MoveUp => "move_up",
             Action::ToggleProject => "toggle_project",
             Action::NewAgent => "new_agent",
+            Action::ForkAgent => "fork_agent",
             Action::FocusAgent => "focus_agent",
             Action::OpenProjectBrowser => "open_project_browser",
             Action::CopyPath => "copy_path",
@@ -205,6 +207,7 @@ impl Action {
             Action::MoveUp => "Navigate up through projects, sessions, files, and lists.",
             Action::ToggleProject => "Collapse or expand the selected project.",
             Action::NewAgent => "Create a new agent session (worktree).",
+            Action::ForkAgent => "Fork the selected agent into a fresh worktree and session.",
             Action::FocusAgent => "Focus the selected agent's output pane.",
             Action::OpenProjectBrowser => "Open the project browser.",
             Action::CopyPath => "Copy the selected agent's worktree path.",
@@ -271,6 +274,7 @@ impl Action {
             | Action::MoveUp
             | Action::ToggleProject
             | Action::NewAgent
+            | Action::ForkAgent
             | Action::FocusAgent
             | Action::OpenProjectBrowser
             | Action::CopyPath
@@ -417,6 +421,20 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "new-agent",
             description: "Create a new agent for the selected project",
+        }),
+    },
+    BindingDef {
+        action: Action::ForkAgent,
+        default_keys: &[key!(f)],
+        scopes: &[BindingScope::Left],
+        help: Some(HelpEntry {
+            section: "Projects pane",
+            description: "Fork selected agent into a fresh worktree",
+        }),
+        hint_contexts: &[(HintContext::LeftSession, "Fork")],
+        palette: Some(PaletteEntry {
+            name: "fork-agent",
+            description: "Fork the selected agent into a fresh worktree and session",
         }),
     },
     BindingDef {
@@ -1557,12 +1575,33 @@ mod tests {
     }
 
     #[test]
+    fn filtered_palette_includes_fork_agent_command() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("fork");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"fork-agent"));
+    }
+
+    #[test]
     fn left_scope_resolves_t_to_show_terminal() {
         let bindings = default_bindings();
         let t = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE);
         assert_eq!(
             bindings.lookup(&t, BindingScope::Left),
             Some(Action::ShowTerminal)
+        );
+    }
+
+    #[test]
+    fn left_scope_resolves_f_to_fork_agent() {
+        let bindings = default_bindings();
+        let f = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&f, BindingScope::Left),
+            Some(Action::ForkAgent)
         );
     }
     #[test]


### PR DESCRIPTION
This adds a session-level `fork` flow so an agent can branch from an existing worktree instead of always starting from the project root checkout. Forked agents begin from the selected session's current `HEAD`, copy the visible filesystem state into a new worktree, and launch the provider as a fresh session rather than resuming prior conversation state.

It also hardens the app's Git CLI reads so repo-state parsing is based on plumbing or documented machine-stable formats instead of user-config-sensitive output. In particular:
- branch detection now uses `symbolic-ref --quiet --short HEAD`
- status and changed-files parsing now uses `--porcelain=v1 -z`
- diff stats parsing now uses `--numstat -z`
- parser coverage now includes rename, binary, whitespace, and NUL-delimited path edge cases

Validated with `cargo fmt --check`, `CCACHE_DISABLE=1 cargo test git::tests`, and `CCACHE_DISABLE=1 cargo test`. `cargo run` was not exercised in a real TTY here because terminal initialization fails in a non-interactive environment.