### PR TITLE
Fix double-click on changed file list not opening diff

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3483,6 +3483,52 @@ mod tests {
         assert!(matches!(app.center_mode, CenterMode::Diff { .. }));
     }
 
+    /// Regression test: double-clicking a file when focus starts on Center
+    /// must open the diff even though focus changes (and the mouse layout
+    /// shifts due to the hint bar appearing) between the two clicks.
+    #[test]
+    fn mouse_double_click_unstaged_file_opens_diff_from_center_focus() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        init_git_repo_with_modified_file(
+            &app,
+            "src/main.rs",
+            "fn main() {}\n",
+            "fn main() { println!(\"hi\"); }\n",
+        );
+        app.unstaged_files = vec![ChangedFile {
+            path: "src/main.rs".into(),
+            status: "M".into(),
+            additions: 1,
+            deletions: 1,
+            binary: false,
+        }];
+        app.selected_left = 1;
+
+        // Focus starts on the center pane (agent output), NOT on Files.
+        app.focus = FocusPane::Center;
+        app.right_section = RightSection::Unstaged;
+
+        // Layout before first click: full inner area (no hint bar because
+        // the pane is not focused).  unstaged_list rows 1..19 (height 18).
+        app.mouse_layout.unstaged_list = Some(Rect::new(78, 1, 21, 18));
+
+        // First click selects the file and moves focus to Files.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
+        assert_eq!(app.focus, FocusPane::Files);
+        assert!(!matches!(app.center_mode, CenterMode::Diff { .. }));
+
+        // Simulate the render cycle that happens between clicks: the pane is
+        // now focused so the hint bar appears, shrinking the list area by 2
+        // rows at the bottom (height 18 → 16).
+        app.mouse_layout.unstaged_list = Some(Rect::new(78, 1, 21, 16));
+
+        // Second click at the same position must still detect the double-click.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 79, 1));
+        assert_eq!(app.focus, FocusPane::Center);
+        assert!(matches!(app.center_mode, CenterMode::Diff { .. }));
+    }
+
     #[test]
     fn mouse_wheel_center_diff_scrolls_lines() {
         let mut app = test_app(default_bindings());

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -853,8 +853,7 @@ impl App {
                     Constraint::Percentage(pct),          // Staged Changes (with commit input)
                 ])
                 .split(area);
-            self.mouse_layout.unstaged_list = Some(self.file_list_area(chunks[0], true));
-            self.render_file_list(
+            let list_rect = self.render_file_list(
                 frame,
                 chunks[0],
                 "Changes",
@@ -862,10 +861,10 @@ impl App {
                 RightSection::Unstaged,
                 true,
             );
+            self.mouse_layout.unstaged_list = Some(list_rect);
             self.render_staged_with_commit(frame, chunks[1], focused);
         } else {
-            self.mouse_layout.unstaged_list = Some(self.file_list_area(area, true));
-            self.render_file_list(
+            let list_rect = self.render_file_list(
                 frame,
                 area,
                 "Changes",
@@ -873,6 +872,7 @@ impl App {
                 RightSection::Unstaged,
                 true,
             );
+            self.mouse_layout.unstaged_list = Some(list_rect);
         }
     }
 
@@ -890,8 +890,7 @@ impl App {
             .areas(area);
 
         // Staged files — normal titled block.
-        self.mouse_layout.staged_list = Some(self.file_list_area(files_area, false));
-        self.render_file_list(
+        let list_rect = self.render_file_list(
             frame,
             files_area,
             "Staged Changes",
@@ -899,25 +898,15 @@ impl App {
             RightSection::Staged,
             false,
         );
+        self.mouse_layout.staged_list = Some(list_rect);
 
         // Commit input block.
         self.render_commit_input_inner(frame, commit_area, pane_focused);
     }
 
-    fn file_list_area(&self, area: Rect, show_hint: bool) -> Rect {
-        let inner = self.themed_block("", false).inner(area);
-        let pane_focused = self.focus == FocusPane::Files;
-        if show_hint && pane_focused && inner.height >= 4 {
-            let [list_area, _] = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(1), Constraint::Length(2)])
-                .areas(inner);
-            list_area
-        } else {
-            inner
-        }
-    }
-
+    /// Render a file list inside a bordered block and return the inner `Rect`
+    /// where file rows were actually placed.  Callers store this in
+    /// `mouse_layout` so that mouse-hit detection matches the real rendering.
     fn render_file_list(
         &self,
         frame: &mut Frame,
@@ -926,7 +915,7 @@ impl App {
         files: &[ChangedFile],
         section: RightSection,
         show_hint: bool,
-    ) {
+    ) -> Rect {
         let pane_focused = self.focus == FocusPane::Files;
         let is_active_section = pane_focused && self.right_section == section;
         let title = format!("{title_prefix} ({})", files.len());
@@ -1070,6 +1059,8 @@ impl App {
                 )
                 .render(ha, frame.buffer_mut());
         }
+
+        list_area
     }
 
     /// Render the commit input as its own bordered block.


### PR DESCRIPTION
The mouse layout for the right-pane file list was computed by a separate `file_list_area()` helper that tried to approximate where files were rendered, rather than using the actual layout from `render_file_list()`. This caused two mismatches: the search bar (2 rows at top when active) was never accounted for, so mouse clicks mapped to wrong file indices; and the hint bar reservation depended on `self.focus`, which changes between the first and second click of a double-click — the first click moves focus to `FocusPane::Files`, causing the next render to shrink the clickable area and making the second click miss for files near the bottom of the list.

The fix removes `file_list_area()` entirely and instead has `render_file_list()` return the actual `Rect` where file rows were drawn. Callers (`render_files`, `render_staged_with_commit`) store this directly in `mouse_layout`, guaranteeing that mouse hit-detection always matches the real rendering regardless of focus state or search bar visibility. The existing test masked the issue by pre-setting `focus = FocusPane::Files` before both clicks.

A new regression test (`mouse_double_click_unstaged_file_opens_diff_from_center_focus`) verifies the realistic scenario: focus starts on Center, the first click moves focus to Files (triggering a layout shift from the hint bar), and the second click at the same position still correctly opens the diff.