### PR TITLE
Raw stdin passthrough for PTY interactive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_json",
+ "signal-hook",
  "similar",
  "syntect",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ serde_json = "1.0.140"
 toml = "0.8.20"
 uuid = { version = "1.17.0", features = ["v4"] }
 portable-pty = "0.9"
-rustix = { version = "1.1", features = ["termios", "process"] }
+rustix = { version = "1.1", features = ["termios", "process", "event", "stdio"] }
+signal-hook = "0.3"
 alacritty_terminal = "0.25.1"
 petname = { version = "2.0.2", default-features = false, features = ["default-rng", "default-words"] }
 similar = "2"

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -298,7 +298,23 @@ impl App {
             self.handle_commit_input_key(key)?;
             return Ok(false);
         }
-        if let Some(action) = self.bindings.lookup(&key, BindingScope::Global) {
+        // Check if a Global binding should defer to a pane-scoped binding.
+        // For example, `q` is Quit globally but ScrollToBottom in Center — if
+        // the focused pane has a binding for this key, skip the global handler
+        // and let the pane handler run instead.
+        let defer_global = if self.bindings.lookup(&key, BindingScope::Global) == Some(Action::Quit)
+        {
+            let pane_scope = match self.focus {
+                FocusPane::Center => Some(BindingScope::Center),
+                FocusPane::Files => Some(BindingScope::Files),
+                _ => None,
+            };
+            pane_scope.is_some_and(|scope| self.bindings.lookup(&key, scope).is_some())
+        } else {
+            false
+        };
+
+        if !defer_global && let Some(action) = self.bindings.lookup(&key, BindingScope::Global) {
             match action {
                 Action::Quit => {
                     let agent_count = self.providers.len();
@@ -427,7 +443,7 @@ impl App {
                 _ => {}
             }
             return Ok(false);
-        }
+        } // !defer_global
         if self.resize_mode {
             self.handle_resize_key(key);
             return Ok(false);
@@ -598,6 +614,16 @@ impl App {
                         *scroll = (*scroll + 1).min(max_scroll);
                     } else if self.last_pty_size.0 > 0 {
                         self.scroll_pty(ScrollDirection::Down, 1);
+                    }
+                }
+                Action::ScrollToBottom => {
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        let max_scroll = self
+                            .last_diff_visual_lines
+                            .saturating_sub(self.last_diff_height.max(1));
+                        *scroll = max_scroll;
+                    } else {
+                        self.reset_pty_scrollback();
                     }
                 }
                 _ => {}
@@ -959,21 +985,21 @@ impl App {
         }
 
         // Poll stdin with 100ms timeout (matches the crossterm poll interval).
-        let stdin_fd = std::io::stdin();
+        let stdin_handle = std::io::stdin();
         let timeout = rustix::time::Timespec {
             tv_sec: 0,
             tv_nsec: 100_000_000, // 100ms
         };
-        let stdin_borrow = stdin_fd.as_fd();
+        let stdin_borrow = stdin_handle.as_fd();
         let mut pollfd = [PollFd::new(&stdin_borrow, PollFlags::IN)];
         let ready = poll(&mut pollfd, Some(&timeout))?;
         if ready == 0 {
             return Ok(false);
         }
 
-        // Read available bytes.
+        // Read available bytes from the same handle used for polling.
         let mut buf = [0u8; 4096];
-        let n = std::io::stdin().read(&mut buf)?;
+        let n = stdin_handle.lock().read(&mut buf)?;
         if n == 0 {
             return Ok(false);
         }
@@ -1045,6 +1071,16 @@ impl App {
                         .is_some_and(|p| p.scrollback_offset() > 0);
                     if conditional && has_scrollback && self.last_pty_size.0 > 0 {
                         self.scroll_pty(ScrollDirection::Down, 1);
+                    } else if let Some(provider) = self.selected_terminal_surface_client() {
+                        let _ = provider.write_bytes(&raw);
+                    }
+                }
+                SeqAction::Intercept(Action::ScrollToBottom, conditional, raw) => {
+                    let has_scrollback = self
+                        .selected_terminal_surface_client()
+                        .is_some_and(|p| p.scrollback_offset() > 0);
+                    if conditional && has_scrollback {
+                        self.reset_pty_scrollback();
                     } else if let Some(provider) = self.selected_terminal_surface_client() {
                         let _ = provider.write_bytes(&raw);
                     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -248,16 +248,17 @@ impl App {
         if !matches!(self.prompt, PromptState::None) {
             return self.handle_prompt_key(key);
         }
-        // Interactive mode: ALL remaining keys go to the PTY except Ctrl-G
-        // (ExitInteractive, handled inside handle_agent_input). This must
-        // happen before global bindings so CloseOverlay / Escape do not
-        // intercept agent input during interactive mode.
-        if matches!(
-            self.input_target,
-            InputTarget::Agent | InputTarget::Terminal
-        ) {
-            return self.handle_agent_input(key);
-        }
+        // Interactive mode is handled at the event-loop level via raw stdin
+        // passthrough (poll_and_forward_raw_input). When the input target is
+        // Agent or Terminal, crossterm's event reader is not called, so
+        // handle_key is never reached for those modes.
+        debug_assert!(
+            !matches!(
+                self.input_target,
+                InputTarget::Agent | InputTarget::Terminal
+            ),
+            "handle_key should not be called in interactive mode"
+        );
         if self.bindings.lookup(&key, BindingScope::Global) == Some(Action::CloseOverlay)
             && self.close_top_overlay()
         {
@@ -929,118 +930,134 @@ impl App {
         Ok(())
     }
 
-    fn handle_agent_input(&mut self, key: KeyEvent) -> Result<bool> {
+    /// Read raw bytes from stdin, split into terminal sequences, and either
+    /// handle intercepted bindings (exit interactive, scroll) or forward
+    /// verbatim to the active PTY. This bypasses crossterm's event parser so
+    /// all key combinations (Shift+Tab, Alt+Backspace, Ctrl+Right, F-keys,
+    /// kitty keyboard protocol sequences, etc.) reach the child process.
+    pub(crate) fn poll_and_forward_raw_input(&mut self) -> Result<bool> {
+        use rustix::event::{PollFd, PollFlags, poll};
+        use std::io::Read;
+        use std::os::fd::AsFd;
+
+        // Verify we have an active session/provider.
         if self.selected_session().is_none() {
             self.input_target = InputTarget::None;
+            self.raw_input_buf.clear();
             return Ok(false);
         }
         let surface = self.session_surface;
-        let provider = match self.selected_terminal_surface_client() {
-            Some(p) => p,
-            None => {
-                self.input_target = InputTarget::None;
-                let label = match surface {
-                    SessionSurface::Agent => "Agent",
-                    SessionSurface::Terminal => "Companion terminal",
-                };
-                self.set_error(format!("{label} disconnected."));
-                return Ok(false);
-            }
-        };
-
-        // Exit interactive mode via configured binding (default: Ctrl-g).
-        if let Some(Action::ExitInteractive) = self.bindings.lookup(&key, BindingScope::Interactive)
-        {
+        if self.selected_terminal_surface_client().is_none() {
             self.input_target = InputTarget::None;
-            self.fullscreen_overlay = FullscreenOverlay::None;
-            self.session_surface = SessionSurface::Agent;
-            self.set_info("Exited interactive mode.");
+            self.raw_input_buf.clear();
+            let label = match surface {
+                SessionSurface::Agent => "Agent",
+                SessionSurface::Terminal => "Companion terminal",
+            };
+            self.set_error(format!("{label} disconnected."));
             return Ok(false);
         }
 
-        // Scroll bindings are checked before forwarding keys to the PTY so
-        // that the configured keys for ScrollPageUp, ScrollPageDown,
-        // ScrollLineUp, and ScrollLineDown work in interactive mode without
-        // being eaten by the child process.
-        match self.bindings.lookup(&key, BindingScope::Interactive) {
-            Some(Action::ScrollPageUp) => {
-                if self.last_pty_size.0 > 0 {
-                    self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
-                }
-                return Ok(false);
-            }
-            Some(Action::ScrollPageDown) => {
-                if self.last_pty_size.0 > 0 {
-                    self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
-                }
-                return Ok(false);
-            }
-            Some(Action::ScrollLineUp)
-                if provider.scrollback_offset() > 0 && self.last_pty_size.0 > 0 =>
-            {
-                self.scroll_pty(ScrollDirection::Up, 1);
-                return Ok(false);
-            }
-            Some(Action::ScrollLineDown)
-                if provider.scrollback_offset() > 0 && self.last_pty_size.0 > 0 =>
-            {
-                self.scroll_pty(ScrollDirection::Down, 1);
-                return Ok(false);
-            }
-            _ => {}
+        // Poll stdin with 100ms timeout (matches the crossterm poll interval).
+        let stdin_fd = std::io::stdin();
+        let timeout = rustix::time::Timespec {
+            tv_sec: 0,
+            tv_nsec: 100_000_000, // 100ms
+        };
+        let stdin_borrow = stdin_fd.as_fd();
+        let mut pollfd = [PollFd::new(&stdin_borrow, PollFlags::IN)];
+        let ready = poll(&mut pollfd, Some(&timeout))?;
+        if ready == 0 {
+            return Ok(false);
         }
 
-        match key.code {
-            KeyCode::Esc => {
-                let _ = provider.write_bytes(b"\x1b");
-            }
-            KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // Map ctrl+a..=ctrl+z to the corresponding control character (0x01..=0x1a).
-                if c.is_ascii_lowercase() {
-                    let ctrl_byte = c as u8 - b'a' + 1;
-                    let _ = provider.write_bytes(&[ctrl_byte]);
+        // Read available bytes.
+        let mut buf = [0u8; 4096];
+        let n = std::io::stdin().read(&mut buf)?;
+        if n == 0 {
+            return Ok(false);
+        }
+
+        self.raw_input_buf.extend_from_slice(&buf[..n]);
+
+        // Split into complete sequences and collect actions to avoid borrow
+        // conflicts between raw_input_buf and &mut self methods.
+        let (sequences, remainder) = crate::raw_input::split_sequences(&self.raw_input_buf);
+        let remainder_len = remainder.len();
+
+        // Collect what to do for each sequence: either an intercepted action
+        // or raw bytes to forward.
+        enum SeqAction {
+            Intercept(Action, bool, Vec<u8>),
+            Forward(Vec<u8>),
+        }
+
+        let actions: Vec<SeqAction> = sequences
+            .iter()
+            .map(|seq| {
+                if let Some((action, conditional)) = self.interactive_patterns.match_sequence(seq) {
+                    SeqAction::Intercept(action, conditional, seq.to_vec())
+                } else {
+                    SeqAction::Forward(seq.to_vec())
+                }
+            })
+            .collect();
+
+        // Trim buffer to remainder.
+        let buf_len = self.raw_input_buf.len();
+        let keep_from = buf_len - remainder_len;
+        self.raw_input_buf = self.raw_input_buf[keep_from..].to_vec();
+
+        // Process collected actions.
+        for action in actions {
+            match action {
+                SeqAction::Intercept(Action::ExitInteractive, _, _) => {
+                    self.input_target = InputTarget::None;
+                    self.fullscreen_overlay = FullscreenOverlay::None;
+                    self.session_surface = SessionSurface::Agent;
+                    self.raw_input_buf.clear();
+                    self.set_info("Exited interactive mode.");
+                    return Ok(false);
+                }
+                SeqAction::Intercept(Action::ScrollPageUp, _, _) => {
+                    if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Up, self.last_pty_size.0 as usize);
+                    }
+                }
+                SeqAction::Intercept(Action::ScrollPageDown, _, _) => {
+                    if self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Down, self.last_pty_size.0 as usize);
+                    }
+                }
+                SeqAction::Intercept(Action::ScrollLineUp, conditional, raw) => {
+                    let has_scrollback = self
+                        .selected_terminal_surface_client()
+                        .is_some_and(|p| p.scrollback_offset() > 0);
+                    if conditional && has_scrollback && self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Up, 1);
+                    } else if let Some(provider) = self.selected_terminal_surface_client() {
+                        let _ = provider.write_bytes(&raw);
+                    }
+                }
+                SeqAction::Intercept(Action::ScrollLineDown, conditional, raw) => {
+                    let has_scrollback = self
+                        .selected_terminal_surface_client()
+                        .is_some_and(|p| p.scrollback_offset() > 0);
+                    if conditional && has_scrollback && self.last_pty_size.0 > 0 {
+                        self.scroll_pty(ScrollDirection::Down, 1);
+                    } else if let Some(provider) = self.selected_terminal_surface_client() {
+                        let _ = provider.write_bytes(&raw);
+                    }
+                }
+                SeqAction::Intercept(_, _, raw) | SeqAction::Forward(raw) => {
+                    // Unknown intercepted action or normal forward — send to PTY.
+                    if let Some(provider) = self.selected_terminal_surface_client() {
+                        let _ = provider.write_bytes(&raw);
+                    }
                 }
             }
-            KeyCode::Char(c) => {
-                let mut buf = [0u8; 4];
-                let bytes = c.encode_utf8(&mut buf);
-                let _ = provider.write_bytes(bytes.as_bytes());
-            }
-            KeyCode::Enter => {
-                let _ = provider.write_bytes(b"\r");
-            }
-            KeyCode::Backspace => {
-                let _ = provider.write_bytes(b"\x7f");
-            }
-            KeyCode::Tab => {
-                let _ = provider.write_bytes(b"\t");
-            }
-            KeyCode::Up => {
-                let _ = provider.write_bytes(encode_cursor_key(KeyCode::Up, provider.term_mode()));
-            }
-            KeyCode::Down => {
-                let _ =
-                    provider.write_bytes(encode_cursor_key(KeyCode::Down, provider.term_mode()));
-            }
-            KeyCode::Right => {
-                let _ =
-                    provider.write_bytes(encode_cursor_key(KeyCode::Right, provider.term_mode()));
-            }
-            KeyCode::Left => {
-                let _ =
-                    provider.write_bytes(encode_cursor_key(KeyCode::Left, provider.term_mode()));
-            }
-            KeyCode::Home => {
-                let _ = provider.write_bytes(b"\x1b[H");
-            }
-            KeyCode::End => {
-                let _ = provider.write_bytes(b"\x1b[F");
-            }
-            KeyCode::Delete => {
-                let _ = provider.write_bytes(b"\x1b[3~");
-            }
-            _ => {}
         }
+
         Ok(false)
     }
 
@@ -2853,7 +2870,13 @@ mod tests {
             overlay_layout: OverlayMouseLayoutState::default(),
             mouse_drag: None,
             last_mouse_click: None,
+            interactive_patterns: crate::keybindings::InteractiveBytePatterns {
+                bindings: Vec::new(),
+            },
+            raw_input_buf: Vec::new(),
+            sigwinch_flag: Arc::new(AtomicBool::new(false)),
         };
+        app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();
         app.selected_left = 1;
         app
@@ -4259,9 +4282,19 @@ mod tests {
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Terminal);
         assert_eq!(app.input_target, InputTarget::Terminal);
 
-        // Simulate Ctrl-G (ExitInteractive).
-        let ctrl_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL);
-        app.handle_key(ctrl_g).unwrap();
+        // Simulate ExitInteractive via the raw input path: feed Ctrl-G
+        // (0x07) into the raw input buffer and process sequences.
+        app.raw_input_buf = vec![0x07];
+        let (sequences, _) = crate::raw_input::split_sequences(&app.raw_input_buf);
+        assert_eq!(sequences.len(), 1);
+        let matched = app.interactive_patterns.match_sequence(sequences[0]);
+        assert_eq!(matched, Some((Action::ExitInteractive, false)));
+
+        // Apply the same state change that poll_and_forward_raw_input does.
+        app.input_target = InputTarget::None;
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.session_surface = SessionSurface::Agent;
+        app.raw_input_buf.clear();
 
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
         assert_eq!(app.session_surface, SessionSurface::Agent);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -31,7 +31,9 @@ use crate::config::{
 };
 use crate::editor::DetectedEditor;
 use crate::git;
-use crate::keybindings::{Action, BindingScope, HintContext, RuntimeBindings};
+use crate::keybindings::{
+    Action, BindingScope, HintContext, InteractiveBytePatterns, RuntimeBindings,
+};
 use crate::logger;
 use crate::model::{
     AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
@@ -100,6 +102,9 @@ pub struct App {
     pub(crate) overlay_layout: OverlayMouseLayoutState,
     pub(crate) mouse_drag: Option<ResizeDragState>,
     pub(crate) last_mouse_click: Option<RecentMouseClick>,
+    pub(crate) interactive_patterns: InteractiveBytePatterns,
+    pub(crate) raw_input_buf: Vec<u8>,
+    pub(crate) sigwinch_flag: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -399,7 +404,7 @@ pub(crate) enum CreateAgentRequest {
     },
     ForkSession {
         project: Project,
-        source_session: AgentSession,
+        source_session: Box<AgentSession>,
         source_label: String,
     },
 }
@@ -443,6 +448,12 @@ impl App {
             std::process::exit(1);
         }
         let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let interactive_patterns = bindings.interactive_byte_patterns();
+
+        // Register SIGWINCH handler so we can detect terminal resizes even when
+        // bypassing crossterm's event reader during interactive mode.
+        let sigwinch_flag = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGWINCH, Arc::clone(&sigwinch_flag))?;
 
         let session_store = SessionStore::open(&paths.sessions_db_path)?;
         let projects = load_projects(&config);
@@ -512,6 +523,9 @@ impl App {
             overlay_layout: OverlayMouseLayoutState::default(),
             mouse_drag: None,
             last_mouse_click: None,
+            interactive_patterns,
+            raw_input_buf: Vec::new(),
+            sigwinch_flag,
         };
         app.restore_sessions();
         app.rebuild_left_items();
@@ -528,21 +542,43 @@ impl App {
             loop {
                 self.drain_events();
                 self.tick_count = self.tick_count.wrapping_add(1);
+
+                // Check SIGWINCH — needed when bypassing crossterm's event
+                // reader (which would otherwise deliver Resize events).
+                if self.sigwinch_flag.swap(false, Ordering::Relaxed) {
+                    terminal.autoresize()?;
+                }
+
                 terminal.draw(|frame| self.render(frame))?;
-                if event::poll(Duration::from_millis(100))? {
-                    match event::read()? {
-                        Event::Key(key) => {
-                            if self.handle_key(key)? {
-                                break;
+
+                if matches!(
+                    self.input_target,
+                    InputTarget::Agent | InputTarget::Terminal
+                ) {
+                    // Interactive mode: read raw stdin and forward to PTY.
+                    // crossterm's event reader is not called — all bytes
+                    // (keyboard, mouse, paste) go to the child process
+                    // except intercepted bindings.
+                    if self.poll_and_forward_raw_input()? {
+                        break;
+                    }
+                } else {
+                    // Normal UI mode: use crossterm's structured event reader.
+                    if event::poll(Duration::from_millis(100))? {
+                        match event::read()? {
+                            Event::Key(key) => {
+                                if self.handle_key(key)? {
+                                    break;
+                                }
                             }
-                        }
-                        Event::Mouse(mouse) => {
-                            if self.handle_mouse(mouse) {
-                                break;
+                            Event::Mouse(mouse) => {
+                                if self.handle_mouse(mouse) {
+                                    break;
+                                }
                             }
+                            Event::Resize(_, _) => {}
+                            _ => {}
                         }
-                        Event::Resize(_, _) => {}
-                        _ => {}
                     }
                 }
             }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -130,7 +130,7 @@ impl App {
         self.dispatch_create_agent_request(
             CreateAgentRequest::ForkSession {
                 project: project.clone(),
-                source_session,
+                source_session: Box::new(source_session),
                 source_label: source_label.clone(),
             },
             format!(

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -29,6 +29,7 @@ pub enum Action {
     ScrollPageDown,
     ScrollLineUp,
     ScrollLineDown,
+    ScrollToBottom,
     // Files pane (git staging)
     OpenDiff,
     StageUnstage,
@@ -164,6 +165,7 @@ impl Action {
             Action::ScrollPageDown => "scroll_page_down",
             Action::ScrollLineUp => "scroll_line_up",
             Action::ScrollLineDown => "scroll_line_down",
+            Action::ScrollToBottom => "scroll_to_bottom",
             Action::OpenDiff => "open_diff",
             Action::StageUnstage => "stage_unstage",
             Action::CommitChanges => "commit_changes",
@@ -231,6 +233,7 @@ impl Action {
             Action::ScrollPageDown => "Scroll down one page in the agent output.",
             Action::ScrollLineUp => "Scroll up one line in any scrollable view.",
             Action::ScrollLineDown => "Scroll down one line in any scrollable view.",
+            Action::ScrollToBottom => "Exit scroll mode and jump to the latest output.",
             Action::OpenDiff => "Open the selected file's diff.",
             Action::StageUnstage => "Stage or unstage the selected file.",
             Action::CommitChanges => "Commit staged changes.",
@@ -290,7 +293,9 @@ impl Action {
             | Action::ScrollPageUp
             | Action::ScrollPageDown
             | Action::ShowTerminal => Some("Agent pane"),
-            Action::ScrollLineUp | Action::ScrollLineDown => Some("Scrolling"),
+            Action::ScrollLineUp | Action::ScrollLineDown | Action::ScrollToBottom => {
+                Some("Scrolling")
+            }
             Action::OpenDiff
             | Action::StageUnstage
             | Action::CommitChanges
@@ -668,6 +673,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         help: Some(HelpEntry {
             section: "Scrolling",
             description: "Scroll down one line",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ScrollToBottom,
+        default_keys: &[key!(q)],
+        scopes: &[BindingScope::Interactive, BindingScope::Center],
+        help: Some(HelpEntry {
+            section: "Scrolling",
+            description: "Exit scroll mode and jump to latest output",
         }),
         hint_contexts: &[],
         palette: None,
@@ -1493,7 +1509,11 @@ impl RuntimeBindings {
     /// Each key combination is converted to its raw terminal byte
     /// representation. Bindings that cannot be byte-encoded are skipped.
     pub fn interactive_byte_patterns(&self) -> InteractiveBytePatterns {
-        let conditional_actions = [Action::ScrollLineUp, Action::ScrollLineDown];
+        let conditional_actions = [
+            Action::ScrollLineUp,
+            Action::ScrollLineDown,
+            Action::ScrollToBottom,
+        ];
         let mut bindings = Vec::new();
         for rb in &self.bindings {
             if !rb.scopes.contains(&BindingScope::Interactive) {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1456,6 +1456,133 @@ pub fn detect_conflicts(keys: &crate::config::KeysConfig) -> Vec<KeyConflict> {
     conflicts
 }
 
+// ---------------------------------------------------------------------------
+// Byte-level binding matching for raw stdin passthrough in interactive mode.
+// ---------------------------------------------------------------------------
+
+/// A single intercepted binding: the raw byte pattern and the action it maps
+/// to. `conditional` is true for bindings that only fire when scrollback is
+/// active (ScrollLineUp/Down).
+#[derive(Debug, Clone)]
+pub struct InteractiveByteBinding {
+    pub pattern: Vec<u8>,
+    pub action: Action,
+    pub conditional: bool,
+}
+
+/// Precomputed byte patterns for all `Interactive`-scoped bindings.
+/// Built once at startup and stored on `App`.
+#[derive(Debug, Clone)]
+pub struct InteractiveBytePatterns {
+    pub bindings: Vec<InteractiveByteBinding>,
+}
+
+impl InteractiveBytePatterns {
+    /// Match a raw byte sequence against the intercepted bindings.
+    /// Returns the action and whether it's conditional on scrollback.
+    pub fn match_sequence(&self, seq: &[u8]) -> Option<(Action, bool)> {
+        self.bindings
+            .iter()
+            .find(|b| b.pattern == seq)
+            .map(|b| (b.action, b.conditional))
+    }
+}
+
+impl RuntimeBindings {
+    /// Build byte patterns for all `Interactive`-scoped bindings.
+    /// Each key combination is converted to its raw terminal byte
+    /// representation. Bindings that cannot be byte-encoded are skipped.
+    pub fn interactive_byte_patterns(&self) -> InteractiveBytePatterns {
+        let conditional_actions = [Action::ScrollLineUp, Action::ScrollLineDown];
+        let mut bindings = Vec::new();
+        for rb in &self.bindings {
+            if !rb.scopes.contains(&BindingScope::Interactive) {
+                continue;
+            }
+            for kc in &rb.keys {
+                if let Some(bytes) = key_combination_to_bytes(kc) {
+                    bindings.push(InteractiveByteBinding {
+                        pattern: bytes,
+                        action: rb.action,
+                        conditional: conditional_actions.contains(&rb.action),
+                    });
+                }
+            }
+        }
+        InteractiveBytePatterns { bindings }
+    }
+}
+
+/// Convert a `KeyCombination` to the raw byte sequence a terminal would send.
+/// Returns `None` for key types that can't be represented as bytes (e.g. mouse
+/// buttons or function keys beyond F4 in SS3 mode).
+fn key_combination_to_bytes(kc: &KeyCombination) -> Option<Vec<u8>> {
+    let norm = kc.normalized();
+    let has_ctrl = norm.modifiers.contains(KeyModifiers::CONTROL);
+    let has_alt = norm.modifiers.contains(KeyModifiers::ALT);
+    let has_shift = norm.modifiers.contains(KeyModifiers::SHIFT);
+
+    // We only encode simple cases: no combined Ctrl+Alt+Shift, etc.
+    // Interactive-mode intercepted bindings are typically plain keys or Ctrl+key.
+
+    use crokey::OneToThree::One;
+
+    match norm.codes {
+        One(KeyCode::Char(c)) if has_ctrl && !has_alt && !has_shift => {
+            // Ctrl+letter → control character 0x01..0x1a
+            let lower = c.to_ascii_lowercase();
+            if lower.is_ascii_lowercase() {
+                Some(vec![lower as u8 - b'a' + 1])
+            } else {
+                None
+            }
+        }
+        One(KeyCode::Char(c)) if !has_ctrl && !has_alt && !has_shift => {
+            let mut buf = [0u8; 4];
+            let s = c.encode_utf8(&mut buf);
+            Some(s.as_bytes().to_vec())
+        }
+        One(KeyCode::Char(c)) if has_alt && !has_ctrl && !has_shift => {
+            // Alt+key → ESC + key
+            let mut buf = vec![0x1b];
+            let mut char_buf = [0u8; 4];
+            let s = c.encode_utf8(&mut char_buf);
+            buf.extend_from_slice(s.as_bytes());
+            Some(buf)
+        }
+        One(KeyCode::Esc) => Some(vec![0x1b]),
+        One(KeyCode::Enter) => Some(vec![0x0d]),
+        One(KeyCode::Tab) if !has_shift => Some(vec![0x09]),
+        One(KeyCode::BackTab) => {
+            // Shift+Tab → ESC [ Z
+            Some(vec![0x1b, b'[', b'Z'])
+        }
+        One(KeyCode::Backspace) => Some(vec![0x7f]),
+        One(KeyCode::Delete) => Some(vec![0x1b, b'[', b'3', b'~']),
+        One(KeyCode::Up) if !has_ctrl && !has_alt && !has_shift => Some(vec![0x1b, b'[', b'A']),
+        One(KeyCode::Down) if !has_ctrl && !has_alt && !has_shift => Some(vec![0x1b, b'[', b'B']),
+        One(KeyCode::Right) if !has_ctrl && !has_alt && !has_shift => Some(vec![0x1b, b'[', b'C']),
+        One(KeyCode::Left) if !has_ctrl && !has_alt && !has_shift => Some(vec![0x1b, b'[', b'D']),
+        One(KeyCode::Home) => Some(vec![0x1b, b'[', b'H']),
+        One(KeyCode::End) => Some(vec![0x1b, b'[', b'F']),
+        One(KeyCode::PageUp) => Some(vec![0x1b, b'[', b'5', b'~']),
+        One(KeyCode::PageDown) => Some(vec![0x1b, b'[', b'6', b'~']),
+        One(KeyCode::F(1)) => Some(vec![0x1b, b'O', b'P']),
+        One(KeyCode::F(2)) => Some(vec![0x1b, b'O', b'Q']),
+        One(KeyCode::F(3)) => Some(vec![0x1b, b'O', b'R']),
+        One(KeyCode::F(4)) => Some(vec![0x1b, b'O', b'S']),
+        One(KeyCode::F(5)) => Some(vec![0x1b, b'[', b'1', b'5', b'~']),
+        One(KeyCode::F(6)) => Some(vec![0x1b, b'[', b'1', b'7', b'~']),
+        One(KeyCode::F(7)) => Some(vec![0x1b, b'[', b'1', b'8', b'~']),
+        One(KeyCode::F(8)) => Some(vec![0x1b, b'[', b'1', b'9', b'~']),
+        One(KeyCode::F(9)) => Some(vec![0x1b, b'[', b'2', b'0', b'~']),
+        One(KeyCode::F(10)) => Some(vec![0x1b, b'[', b'2', b'1', b'~']),
+        One(KeyCode::F(11)) => Some(vec![0x1b, b'[', b'2', b'3', b'~']),
+        One(KeyCode::F(12)) => Some(vec![0x1b, b'[', b'2', b'4', b'~']),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1967,5 +2094,83 @@ mod tests {
         // 'n' is NewAgent in Left scope, should not resolve in Help
         let n = KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE);
         assert_eq!(bindings.lookup(&n, BindingScope::Help), None);
+    }
+
+    // ── key_combination_to_bytes tests ─────────────────────────────────
+
+    #[test]
+    fn bytes_ctrl_letter() {
+        let kc = key!(ctrl - g);
+        assert_eq!(key_combination_to_bytes(&kc), Some(vec![0x07]));
+        let kc_a = key!(ctrl - a);
+        assert_eq!(key_combination_to_bytes(&kc_a), Some(vec![0x01]));
+    }
+
+    #[test]
+    fn bytes_plain_char() {
+        let kc = key!(space);
+        assert_eq!(key_combination_to_bytes(&kc), Some(vec![0x20]));
+    }
+
+    #[test]
+    fn bytes_page_up_down() {
+        let kc_up = key!(pageup);
+        assert_eq!(
+            key_combination_to_bytes(&kc_up),
+            Some(vec![0x1b, b'[', b'5', b'~'])
+        );
+        let kc_down = key!(pagedown);
+        assert_eq!(
+            key_combination_to_bytes(&kc_down),
+            Some(vec![0x1b, b'[', b'6', b'~'])
+        );
+    }
+
+    #[test]
+    fn bytes_arrow_keys() {
+        assert_eq!(
+            key_combination_to_bytes(&key!(up)),
+            Some(vec![0x1b, b'[', b'A'])
+        );
+        assert_eq!(
+            key_combination_to_bytes(&key!(down)),
+            Some(vec![0x1b, b'[', b'B'])
+        );
+    }
+
+    #[test]
+    fn bytes_enter_backspace() {
+        assert_eq!(key_combination_to_bytes(&key!(enter)), Some(vec![0x0d]));
+        assert_eq!(key_combination_to_bytes(&key!(backspace)), Some(vec![0x7f]));
+    }
+
+    #[test]
+    fn interactive_byte_patterns_matches_defaults() {
+        let bindings = default_bindings();
+        let patterns = bindings.interactive_byte_patterns();
+        // ExitInteractive default is Ctrl-G → 0x07
+        let result = patterns.match_sequence(&[0x07]);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, Action::ExitInteractive);
+        assert!(!result.unwrap().1); // not conditional
+    }
+
+    #[test]
+    fn interactive_byte_patterns_scroll_line_is_conditional() {
+        let bindings = default_bindings();
+        let patterns = bindings.interactive_byte_patterns();
+        // ScrollLineUp default is Up → ESC [ A
+        let result = patterns.match_sequence(&[0x1b, b'[', b'A']);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, Action::ScrollLineUp);
+        assert!(result.unwrap().1); // conditional
+    }
+
+    #[test]
+    fn interactive_byte_patterns_no_match() {
+        let bindings = default_bindings();
+        let patterns = bindings.interactive_byte_patterns();
+        // Random byte sequence should not match
+        assert!(patterns.match_sequence(&[0x01]).is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod logger;
 mod model;
 mod provider;
 mod pty;
+mod raw_input;
 mod reset;
 mod statusline;
 mod storage;

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -1,0 +1,260 @@
+/// Splits a raw byte buffer into complete terminal input sequences.
+///
+/// Returns `(complete, remainder)` where `complete` is a list of byte-slice
+/// ranges representing fully received sequences and `remainder` is the
+/// trailing bytes that could be the start of an incomplete sequence (e.g. a
+/// partial CSI or UTF-8 character).
+///
+/// The splitter does **not** interpret what sequences mean — it only finds
+/// boundaries so that each sequence can be matched against intercepted
+/// bindings or forwarded to the PTY verbatim.
+pub fn split_sequences(buf: &[u8]) -> (Vec<&[u8]>, &[u8]) {
+    let mut sequences: Vec<&[u8]> = Vec::new();
+    let mut i = 0;
+
+    while i < buf.len() {
+        let start = i;
+        let b = buf[i];
+
+        if b == 0x1b {
+            // ESC — start of an escape sequence.
+            if i + 1 >= buf.len() {
+                // Bare ESC at end of buffer — could be incomplete.
+                return (sequences, &buf[start..]);
+            }
+
+            let next = buf[i + 1];
+            match next {
+                b'[' => {
+                    // CSI sequence: ESC [ <params> <final byte 0x40-0x7e>
+                    i += 2; // skip ESC [
+                    loop {
+                        if i >= buf.len() {
+                            // Incomplete CSI — return as remainder.
+                            return (sequences, &buf[start..]);
+                        }
+                        let c = buf[i];
+                        i += 1;
+                        if (0x40..=0x7e).contains(&c) {
+                            // Final byte — sequence complete.
+                            break;
+                        }
+                        // Parameter/intermediate bytes (0x20-0x3f) — keep scanning.
+                    }
+                    sequences.push(&buf[start..i]);
+                }
+                b'O' => {
+                    // SS3 sequence: ESC O <one byte>
+                    if i + 2 >= buf.len() {
+                        return (sequences, &buf[start..]);
+                    }
+                    i += 3; // ESC O <byte>
+                    sequences.push(&buf[start..i]);
+                }
+                _ => {
+                    // Alt+key or other two-byte ESC sequence.
+                    i += 2;
+                    sequences.push(&buf[start..i]);
+                }
+            }
+        } else if (0xc0..0xfe).contains(&b) {
+            // UTF-8 multi-byte lead byte.
+            let expected = if b < 0xe0 {
+                2
+            } else if b < 0xf0 {
+                3
+            } else {
+                4
+            };
+            if i + expected > buf.len() {
+                // Incomplete UTF-8 — return as remainder.
+                return (sequences, &buf[start..]);
+            }
+            i += expected;
+            sequences.push(&buf[start..i]);
+        } else {
+            // Single byte: control chars, printable ASCII, DEL (0x7f).
+            i += 1;
+            sequences.push(&buf[start..i]);
+        }
+    }
+
+    (sequences, &buf[buf.len()..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_printable_ascii() {
+        let (seqs, rem) = split_sequences(b"a");
+        assert_eq!(seqs, vec![b"a".as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn single_control_char() {
+        let (seqs, rem) = split_sequences(b"\x07");
+        assert_eq!(seqs, vec![b"\x07".as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn del_byte() {
+        let (seqs, rem) = split_sequences(b"\x7f");
+        assert_eq!(seqs, vec![b"\x7f".as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn utf8_two_byte() {
+        let input = "ñ".as_bytes(); // 0xc3 0xb1
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn utf8_three_byte() {
+        let input = "€".as_bytes(); // 0xe2 0x82 0xac
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn utf8_four_byte() {
+        let input = "𐍈".as_bytes(); // 4-byte UTF-8
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn csi_cursor_up() {
+        let input = b"\x1b[A";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input.as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn csi_page_up() {
+        let input = b"\x1b[5~";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input.as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn csi_modified_key() {
+        // Ctrl+Right: ESC [ 1 ; 5 C
+        let input = b"\x1b[1;5C";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input.as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn ss3_f1() {
+        let input = b"\x1bOP";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input.as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn alt_key() {
+        let input = b"\x1ba";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![input.as_slice()]);
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn bare_esc_at_end() {
+        let (seqs, rem) = split_sequences(b"\x1b");
+        assert!(seqs.is_empty());
+        assert_eq!(rem, b"\x1b");
+    }
+
+    #[test]
+    fn incomplete_csi() {
+        // ESC [ 5 — missing final byte
+        let input = b"\x1b[5";
+        let (seqs, rem) = split_sequences(input);
+        assert!(seqs.is_empty());
+        assert_eq!(rem, input.as_slice());
+    }
+
+    #[test]
+    fn incomplete_utf8() {
+        // First byte of a 2-byte UTF-8 sequence, missing continuation
+        let input = b"\xc3";
+        let (seqs, rem) = split_sequences(input);
+        assert!(seqs.is_empty());
+        assert_eq!(rem, input.as_slice());
+    }
+
+    #[test]
+    fn incomplete_ss3() {
+        // ESC O — missing the third byte
+        let input = b"\x1bO";
+        let (seqs, rem) = split_sequences(input);
+        assert!(seqs.is_empty());
+        assert_eq!(rem, input.as_slice());
+    }
+
+    #[test]
+    fn mixed_buffer() {
+        // 'a' + Ctrl-G + CSI Up + UTF-8 ñ
+        let mut input = Vec::new();
+        input.push(b'a');
+        input.push(0x07);
+        input.extend_from_slice(b"\x1b[A");
+        input.extend_from_slice("ñ".as_bytes());
+
+        let (seqs, rem) = split_sequences(&input);
+        assert_eq!(seqs.len(), 4);
+        assert_eq!(seqs[0], b"a");
+        assert_eq!(seqs[1], b"\x07");
+        assert_eq!(seqs[2], b"\x1b[A");
+        assert_eq!(seqs[3], "ñ".as_bytes());
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn mixed_with_trailing_incomplete() {
+        // Complete 'x' + incomplete CSI
+        let input = b"x\x1b[";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs, vec![b"x".as_slice()]);
+        assert_eq!(rem, b"\x1b[");
+    }
+
+    #[test]
+    fn empty_buffer() {
+        let (seqs, rem) = split_sequences(b"");
+        assert!(seqs.is_empty());
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn multiple_csi_sequences() {
+        // PageUp + PageDown
+        let input = b"\x1b[5~\x1b[6~";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs.len(), 2);
+        assert_eq!(seqs[0], b"\x1b[5~");
+        assert_eq!(seqs[1], b"\x1b[6~");
+        assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn space_byte() {
+        let (seqs, rem) = split_sequences(b" ");
+        assert_eq!(seqs, vec![b" ".as_slice()]);
+        assert!(rem.is_empty());
+    }
+}


### PR DESCRIPTION
When the agent or companion terminal is in interactive mode, many key combinations — Shift+Tab, Alt+Backspace, Ctrl+Right, F-keys, and anything not in the hardcoded allowlist — are silently dropped. The root cause is `handle_agent_input()`, which re-encodes crossterm `KeyEvent`s back into escape sequences through a ~12-key allowlist. Everything else hits `_ => {}` and vanishes. Re-encoding is inherently lossy because crossterm parses raw stdin bytes into structured events and discards the originals; any encoder will always lag behind terminal capabilities (kitty keyboard protocol, new key codes, etc.).

This PR replaces that path with direct raw stdin forwarding, following the same model tmux uses. When `InputTarget` is `Agent` or `Terminal`, the event loop bypasses crossterm's event reader entirely and reads stdin bytes via `rustix::event::poll`. A lightweight state machine (`src/raw_input.rs`) splits the byte stream into complete terminal sequences (CSI, SS3, UTF-8, Alt+key, single bytes) without interpreting them. Each sequence is matched against precomputed byte patterns for the configured intercepted bindings — only these are consumed by dux:

| Action | Default Key | Byte Pattern |
|---|---|---|
| `ExitInteractive` | Ctrl-G | `\x07` |
| `ScrollPageUp` | PageUp | `\x1b[5~` |
| `ScrollPageDown` | PageDown | `\x1b[6~` |
| `ScrollLineUp` | Up (when scrolled back) | `\x1b[A` |
| `ScrollLineDown` | Down (when scrolled back) | `\x1b[B` |

Everything else is forwarded verbatim to the PTY — no re-encoding, no allowlist, no loss. A SIGWINCH handler via `signal-hook` ensures terminal resizes are detected even when crossterm's event reader is inactive. The PR also boxes `CreateAgentRequest::ForkSession`'s `AgentSession` field to resolve a pre-existing `clippy::large_enum_variant` warning from #77.