### PR TITLE
Fix mouse events being swallowed during interactive mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1011,16 +1011,23 @@ impl App {
         let (sequences, remainder) = crate::raw_input::split_sequences(&self.raw_input_buf);
         let remainder_len = remainder.len();
 
-        // Collect what to do for each sequence: either an intercepted action
-        // or raw bytes to forward.
+        // Collect what to do for each sequence: an intercepted action, a
+        // mouse event to handle in the UI, or raw bytes to forward.
         enum SeqAction {
             Intercept(Action, bool, Vec<u8>),
+            Mouse(MouseEvent),
             Forward(Vec<u8>),
         }
 
         let actions: Vec<SeqAction> = sequences
             .iter()
             .map(|seq| {
+                // Mouse events must be handled by the UI, not forwarded to the
+                // PTY. crossterm's EnableMouseCapture uses SGR (1006) encoding,
+                // so terminal mouse events arrive as CSI `<…M` / `<…m`.
+                if let Some(mouse_ev) = crate::raw_input::parse_sgr_mouse(seq) {
+                    return SeqAction::Mouse(mouse_ev);
+                }
                 if let Some((action, conditional)) = self.interactive_patterns.match_sequence(seq) {
                     SeqAction::Intercept(action, conditional, seq.to_vec())
                 } else {
@@ -1083,6 +1090,13 @@ impl App {
                         self.reset_pty_scrollback();
                     } else if let Some(provider) = self.selected_terminal_surface_client() {
                         let _ = provider.write_bytes(&raw);
+                    }
+                }
+                SeqAction::Mouse(mouse_ev) => {
+                    // Route mouse events to the UI so clicks, double-clicks,
+                    // scroll, and drag work even during interactive mode.
+                    if self.handle_mouse(mouse_ev) {
+                        return Ok(true);
                     }
                 }
                 SeqAction::Intercept(_, _, raw) | SeqAction::Forward(raw) => {

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -1,3 +1,94 @@
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+/// Returns `true` if the byte sequence is an SGR mouse event (`\x1b[<…M` or
+/// `\x1b[<…m`).
+pub fn is_sgr_mouse(seq: &[u8]) -> bool {
+    seq.len() >= 6
+        && seq[0] == 0x1b
+        && seq[1] == b'['
+        && seq[2] == b'<'
+        && matches!(seq.last(), Some(b'M' | b'm'))
+}
+
+/// Parse an SGR mouse sequence into a crossterm `MouseEvent`.
+///
+/// SGR format: `ESC [ < Cb ; Cx ; Cy {M|m}`
+///   - Cb = button/modifier bits
+///   - Cx = column (1-based)
+///   - Cy = row (1-based)
+///   - M = press/motion, m = release
+pub fn parse_sgr_mouse(seq: &[u8]) -> Option<MouseEvent> {
+    if !is_sgr_mouse(seq) {
+        return None;
+    }
+
+    let final_byte = *seq.last()?;
+    // Extract the parameter string between '<' and the final byte.
+    let params = std::str::from_utf8(&seq[3..seq.len() - 1]).ok()?;
+    let mut parts = params.split(';');
+    let cb: u16 = parts.next()?.parse().ok()?;
+    let cx: u16 = parts.next()?.parse().ok()?;
+    let cy: u16 = parts.next()?.parse().ok()?;
+
+    // Convert 1-based to 0-based coordinates.
+    let column = cx.saturating_sub(1);
+    let row = cy.saturating_sub(1);
+
+    let is_release = final_byte == b'm';
+    let is_motion = cb & 32 != 0;
+    let button_bits = cb & 0b11000011; // mask out motion bit (bit 5) and modifier bits (4,3)
+
+    let kind = if cb & 64 != 0 {
+        // Scroll events.
+        match button_bits & 0x03 {
+            0 => MouseEventKind::ScrollUp,
+            1 => MouseEventKind::ScrollDown,
+            2 => MouseEventKind::ScrollLeft,
+            3 => MouseEventKind::ScrollRight,
+            _ => return None,
+        }
+    } else if is_release {
+        let button = match button_bits & 0x03 {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            _ => return None,
+        };
+        MouseEventKind::Up(button)
+    } else if is_motion {
+        let button = match button_bits & 0x03 {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            3 => {
+                return Some(MouseEvent {
+                    kind: MouseEventKind::Moved,
+                    column,
+                    row,
+                    modifiers: crossterm::event::KeyModifiers::empty(),
+                });
+            }
+            _ => return None,
+        };
+        MouseEventKind::Drag(button)
+    } else {
+        let button = match button_bits & 0x03 {
+            0 => MouseButton::Left,
+            1 => MouseButton::Middle,
+            2 => MouseButton::Right,
+            _ => return None,
+        };
+        MouseEventKind::Down(button)
+    };
+
+    Some(MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: crossterm::event::KeyModifiers::empty(),
+    })
+}
+
 /// Splits a raw byte buffer into complete terminal input sequences.
 ///
 /// Returns `(complete, remainder)` where `complete` is a list of byte-slice
@@ -256,5 +347,80 @@ mod tests {
         let (seqs, rem) = split_sequences(b" ");
         assert_eq!(seqs, vec![b" ".as_slice()]);
         assert!(rem.is_empty());
+    }
+
+    #[test]
+    fn sgr_mouse_left_press() {
+        let seq = b"\x1b[<0;50;10M";
+        assert!(is_sgr_mouse(seq));
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Left));
+        assert_eq!(ev.column, 49);
+        assert_eq!(ev.row, 9);
+    }
+
+    #[test]
+    fn sgr_mouse_left_release() {
+        let seq = b"\x1b[<0;50;10m";
+        assert!(is_sgr_mouse(seq));
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Up(MouseButton::Left));
+        assert_eq!(ev.column, 49);
+        assert_eq!(ev.row, 9);
+    }
+
+    #[test]
+    fn sgr_mouse_right_press() {
+        let seq = b"\x1b[<2;1;1M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Right));
+        assert_eq!(ev.column, 0);
+        assert_eq!(ev.row, 0);
+    }
+
+    #[test]
+    fn sgr_mouse_scroll_up() {
+        let seq = b"\x1b[<64;10;20M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::ScrollUp);
+    }
+
+    #[test]
+    fn sgr_mouse_scroll_down() {
+        let seq = b"\x1b[<65;10;20M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::ScrollDown);
+    }
+
+    #[test]
+    fn sgr_mouse_left_drag() {
+        let seq = b"\x1b[<32;5;5M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Drag(MouseButton::Left));
+    }
+
+    #[test]
+    fn sgr_mouse_motion_no_button() {
+        let seq = b"\x1b[<35;5;5M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Moved);
+    }
+
+    #[test]
+    fn sgr_mouse_split_and_parse() {
+        // Verify mouse sequences are correctly split as complete CSI sequences.
+        let input = b"\x1b[<0;50;10M\x1b[<0;50;10m";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs.len(), 2);
+        assert!(rem.is_empty());
+        assert!(is_sgr_mouse(seqs[0]));
+        assert!(is_sgr_mouse(seqs[1]));
+    }
+
+    #[test]
+    fn non_mouse_csi_not_detected() {
+        assert!(!is_sgr_mouse(b"\x1b[A"));
+        assert!(!is_sgr_mouse(b"\x1b[5~"));
+        assert!(parse_sgr_mouse(b"\x1b[A").is_none());
     }
 }


### PR DESCRIPTION
PR #80 introduced raw stdin passthrough for interactive mode so that all key combinations (Shift+Tab, Alt+Backspace, kitty keyboard protocol sequences, etc.) reach the child process faithfully. However, this change inadvertently broke all mouse interaction while in interactive mode. Since crossterm's `EnableMouseCapture` causes the terminal to encode mouse events as SGR escape sequences (`\x1b[<Cb;Cx;CyM/m`) on stdin, the raw input path treated them as opaque byte sequences and forwarded them to the PTY — meaning clicks, double-clicks, scroll wheel, and drag events were completely ignored by the UI.

The fix adds an SGR mouse sequence parser to `raw_input.rs` (`is_sgr_mouse` and `parse_sgr_mouse`) that detects these sequences and converts them into crossterm `MouseEvent` structs. In `poll_and_forward_raw_input`, each raw sequence is now checked for mouse events before forwarding; mouse sequences are routed to `handle_mouse()` instead of being sent to the PTY. This restores the pre-#80 behavior where mouse events are always handled by the UI regardless of input mode.

Eight new unit tests cover the SGR parser (press, release, drag, scroll, motion, integration with `split_sequences`, and negative cases). All 257 existing unit tests and 4 integration tests continue to pass.