### PR TITLE
Add a kill-running modal for active runtimes

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3231,7 +3231,7 @@ mod tests {
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
                     .expect("agent runtime");
                 assert_eq!(agent.label, "Codex agent-branch");
-                assert_eq!(agent.context, "under project demo");
+                assert_eq!(agent.context, "under project \"demo\"");
 
                 let terminal = prompt
                     .runtimes
@@ -3239,7 +3239,10 @@ mod tests {
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
                     .expect("terminal runtime");
                 assert_eq!(terminal.label, "TERM python");
-                assert_eq!(terminal.context, "on agent agent-branch under project demo");
+                assert_eq!(
+                    terminal.context,
+                    "on agent \"agent-branch\" under project \"demo\""
+                );
             }
             other => panic!("expected kill-running prompt, got {other:?}"),
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2135,10 +2135,13 @@ impl App {
         }
 
         self.prompt = PromptState::None;
+        let requested = confirm_prompt.target_ids.len();
         let (agents, terminals) = self.kill_runtime_targets(&confirm_prompt.target_ids);
-        if agents + terminals == 0 {
-            self.set_error(
-                "None of the selected runtimes were still running. Reopen Kill Running to refresh the list and try again.",
+        let killed = agents + terminals;
+        let already_gone = requested.saturating_sub(killed);
+        if killed == 0 {
+            self.set_warning(
+                "The selected agents or terminals were already gone, so there was nothing left to kill. Refresh Kill Running if you want to review the current runtime list.",
             );
             return false;
         }
@@ -2156,10 +2159,19 @@ impl App {
                 if terminals == 1 { "" } else { "s" }
             ));
         }
-        self.set_info(format!(
-            "Killed {}. In-progress CLI work was stopped, but the worktree files are still available for review or relaunch.",
-            pieces.join(" and ")
-        ));
+        if already_gone > 0 {
+            self.set_warning(format!(
+                "Killed {}. {} selected runtime{} were already gone. In-progress CLI work was stopped, but the worktree files are still available for review or relaunch.",
+                pieces.join(" and "),
+                already_gone,
+                if already_gone == 1 { "" } else { "s" }
+            ));
+        } else {
+            self.set_info(format!(
+                "Killed {}. In-progress CLI work was stopped, but the worktree files are still available for review or relaunch.",
+                pieces.join(" and ")
+            ));
+        }
         false
     }
 
@@ -3412,6 +3424,36 @@ mod tests {
         assert_eq!(app.session_surface, SessionSurface::Agent);
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
         assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn kill_selected_warns_when_targets_are_already_gone() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfirmKillRunning(ConfirmKillRunningPrompt {
+            previous: KillRunningPrompt {
+                runtimes: vec![sample_runtime(
+                    RuntimeTargetId::Agent("session-1".to_string()),
+                    KillableRuntimeKind::Agent,
+                    "agent-branch",
+                    "demo / codex / agent-branch",
+                )],
+                filter: String::new(),
+                filter_cursor: 0,
+                searching: false,
+                hovered_visible_index: 0,
+                selected_ids: std::iter::once(RuntimeTargetId::Agent("session-1".to_string()))
+                    .collect(),
+                focus: KillRunningFocus::Footer(KillRunningFooterAction::Selected),
+            },
+            action: KillRunningAction::Selected,
+            target_ids: vec![RuntimeTargetId::Agent("session-1".to_string())],
+            confirm_selected: true,
+        });
+
+        app.resolve_confirm_kill_running(true);
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Warning);
+        assert!(app.status.text().contains("already gone"));
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3214,7 +3214,7 @@ mod tests {
             crate::app::CompanionTerminal {
                 session_id: app.sessions[0].id.clone(),
                 label: "shell".to_string(),
-                foreground_cmd: None,
+                foreground_cmd: Some("python".to_string()),
                 client: PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000)
                     .expect("spawn terminal"),
             },
@@ -3230,19 +3230,16 @@ mod tests {
                     .iter()
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
                     .expect("agent runtime");
-                assert_eq!(agent.label, "agent-branch");
-                assert!(agent.context.contains("project: demo"));
-                assert!(agent.context.contains("provider: codex"));
-                assert!(agent.context.contains("agent: agent-branch"));
+                assert_eq!(agent.label, "Codex agent-branch");
+                assert_eq!(agent.context, "under project demo");
 
                 let terminal = prompt
                     .runtimes
                     .iter()
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
                     .expect("terminal runtime");
-                assert_eq!(terminal.label, "shell");
-                assert!(terminal.context.contains("project: demo"));
-                assert!(terminal.context.contains("agent: agent-branch"));
+                assert_eq!(terminal.label, "TERM python");
+                assert_eq!(terminal.context, "on agent agent-branch under project demo");
             }
             other => panic!("expected kill-running prompt, got {other:?}"),
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -29,6 +29,14 @@ enum PromptMouseTarget {
     BrowseProjectInput,
     BrowseProjectItem(usize),
     PickEditorItem(usize),
+    RuntimeKillInput,
+    RuntimeKillItem(usize),
+    RuntimeKillCancel,
+    RuntimeKillHovered,
+    RuntimeKillSelected,
+    RuntimeKillVisible,
+    ConfirmKillCancel,
+    ConfirmKillConfirm,
     ConfirmDeleteCancel,
     ConfirmDeleteConfirm,
     ConfirmQuitCancel,
@@ -1025,6 +1033,124 @@ impl App {
             return Ok(false);
         }
 
+        if matches!(self.prompt, PromptState::KillRunning(..)) {
+            let is_searching = matches!(
+                self.prompt,
+                PromptState::KillRunning(KillRunningPrompt {
+                    searching: true,
+                    ..
+                })
+            );
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
+            let action = if is_searching && is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::RuntimeKill)
+            };
+
+            match action {
+                Some(Action::CloseOverlay) => {
+                    let mut closed = false;
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt {
+                        if prompt.searching {
+                            prompt.searching = false;
+                        } else if !prompt.filter.is_empty() {
+                            prompt.filter.clear();
+                            Self::clamp_kill_running_prompt(prompt);
+                        } else {
+                            closed = true;
+                        }
+                    }
+                    if closed {
+                        self.prompt = PromptState::None;
+                        self.set_info("Closed Kill Running. No agents or terminals were killed.");
+                    }
+                }
+                Some(Action::SearchToggle) if !is_searching => {
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt {
+                        prompt.filter.move_end();
+                        prompt.searching = true;
+                        prompt.focus = KillRunningFocus::List;
+                    }
+                }
+                Some(Action::MoveDown) => {
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt
+                        && matches!(prompt.focus, KillRunningFocus::List)
+                    {
+                        let count = Self::visible_kill_running_indices(prompt).len();
+                        if prompt.hovered_visible_index + 1 < count {
+                            prompt.hovered_visible_index += 1;
+                        }
+                    }
+                }
+                Some(Action::MoveUp) => {
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt
+                        && matches!(prompt.focus, KillRunningFocus::List)
+                        && prompt.hovered_visible_index > 0
+                    {
+                        prompt.hovered_visible_index -= 1;
+                    }
+                }
+                Some(Action::FocusNext) => {
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt {
+                        prompt.focus = match prompt.focus {
+                            KillRunningFocus::List => {
+                                KillRunningFocus::Footer(KillRunningFooterAction::Hovered)
+                            }
+                            KillRunningFocus::Footer(action) => action
+                                .next()
+                                .map(KillRunningFocus::Footer)
+                                .unwrap_or(KillRunningFocus::List),
+                        };
+                    }
+                }
+                Some(Action::FocusPrev) => {
+                    if let PromptState::KillRunning(prompt) = &mut self.prompt {
+                        prompt.focus = match prompt.focus {
+                            KillRunningFocus::List => {
+                                KillRunningFocus::Footer(KillRunningFooterAction::Visible)
+                            }
+                            KillRunningFocus::Footer(action) => action
+                                .previous()
+                                .map(KillRunningFocus::Footer)
+                                .unwrap_or(KillRunningFocus::List),
+                        };
+                    }
+                }
+                Some(Action::ToggleMarked) => {
+                    self.toggle_hovered_kill_running_selection();
+                }
+                Some(Action::Confirm) => {
+                    if is_searching {
+                        if let PromptState::KillRunning(prompt) = &mut self.prompt {
+                            prompt.searching = false;
+                        }
+                    } else {
+                        let focus = match &self.prompt {
+                            PromptState::KillRunning(prompt) => prompt.focus,
+                            _ => KillRunningFocus::List,
+                        };
+                        match focus {
+                            KillRunningFocus::List => self.toggle_hovered_kill_running_selection(),
+                            KillRunningFocus::Footer(action) => {
+                                self.execute_kill_running_footer_action(action)?;
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    if is_searching && let PromptState::KillRunning(prompt) = &mut self.prompt {
+                        if prompt.filter.handle_key(key) {
+                            prompt.hovered_visible_index = 0;
+                        }
+                        Self::clamp_kill_running_prompt(prompt);
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if matches!(self.prompt, PromptState::BrowseProjects { .. }) {
             // Check sub-mode states and do binding lookup before mutable borrow.
             let is_editing_path = matches!(
@@ -1298,6 +1424,27 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ConfirmKillRunning(confirm_prompt) = &mut self.prompt {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => {
+                    let previous = confirm_prompt.previous.clone();
+                    self.prompt = PromptState::KillRunning(previous);
+                    self.set_info(
+                        "Kill cancelled. Your running agents and companion terminals are unchanged.",
+                    );
+                }
+                Some(Action::ToggleSelection) => {
+                    confirm_prompt.confirm_selected = !confirm_prompt.confirm_selected;
+                }
+                Some(Action::Confirm) => {
+                    let confirm = confirm_prompt.confirm_selected;
+                    return Ok(self.resolve_confirm_kill_running(confirm));
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ConfirmDeleteAgent {
             confirm_selected, ..
         } = &mut self.prompt
@@ -1467,6 +1614,44 @@ impl App {
                 ..
             } => Self::overlay_row_at(list, offset, items, column, row)
                 .map(PromptMouseTarget::PickEditorItem),
+            OverlayMouseLayout::KillRunning {
+                input,
+                list,
+                items,
+                offset,
+                cancel_button,
+                hovered_button,
+                selected_button,
+                visible_button,
+            } => {
+                if input.is_some_and(|rect| contains_point(rect, column, row)) {
+                    Some(PromptMouseTarget::RuntimeKillInput)
+                } else if let Some(index) = Self::overlay_row_at(list, offset, items, column, row) {
+                    Some(PromptMouseTarget::RuntimeKillItem(index))
+                } else if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::RuntimeKillCancel)
+                } else if contains_point(hovered_button, column, row) {
+                    Some(PromptMouseTarget::RuntimeKillHovered)
+                } else if contains_point(selected_button, column, row) {
+                    Some(PromptMouseTarget::RuntimeKillSelected)
+                } else if contains_point(visible_button, column, row) {
+                    Some(PromptMouseTarget::RuntimeKillVisible)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmKillRunning {
+                cancel_button,
+                kill_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmKillCancel)
+                } else if contains_point(kill_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmKillConfirm)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::ConfirmDeleteAgent {
                 cancel_button,
                 delete_button,
@@ -1790,6 +1975,77 @@ impl App {
         }
     }
 
+    fn set_kill_running_hovered(&mut self, visible_index: usize) {
+        if let PromptState::KillRunning(prompt) = &mut self.prompt {
+            let count = Self::visible_kill_running_indices(prompt).len();
+            if count == 0 {
+                prompt.hovered_visible_index = 0;
+                return;
+            }
+            prompt.hovered_visible_index = visible_index.min(count.saturating_sub(1));
+            prompt.focus = KillRunningFocus::List;
+        }
+    }
+
+    fn set_kill_running_search_cursor_from_mouse(&mut self, column: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::KillRunning {
+                input: Some(input), ..
+            } => input,
+            _ => return,
+        };
+        if let PromptState::KillRunning(prompt) = &mut self.prompt {
+            prompt.filter.cursor =
+                cursor_from_single_line_position(&prompt.filter.text, input_area, 2, column);
+            prompt.searching = true;
+            prompt.focus = KillRunningFocus::List;
+        }
+    }
+
+    fn toggle_hovered_kill_running_selection(&mut self) {
+        let target_id = match &self.prompt {
+            PromptState::KillRunning(prompt) => {
+                let visible = Self::visible_kill_running_indices(prompt);
+                visible
+                    .get(prompt.hovered_visible_index)
+                    .and_then(|&index| prompt.runtimes.get(index))
+                    .map(|runtime| runtime.id.clone())
+            }
+            _ => None,
+        };
+
+        let Some(target_id) = target_id else {
+            self.set_error(
+                "No running agent or terminal is highlighted. Move to a visible row first.",
+            );
+            return;
+        };
+
+        if let PromptState::KillRunning(prompt) = &mut self.prompt
+            && !prompt.selected_ids.insert(target_id.clone())
+        {
+            prompt.selected_ids.remove(&target_id);
+        }
+    }
+
+    fn execute_kill_running_footer_action(
+        &mut self,
+        action: KillRunningFooterAction,
+    ) -> Result<()> {
+        match action {
+            KillRunningFooterAction::Cancel => {
+                self.prompt = PromptState::None;
+                self.set_info("Closed Kill Running. No agents or terminals were killed.");
+            }
+            _ => {
+                if let Some(action) = action.action() {
+                    self.open_confirm_kill_running_action(action)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn open_selected_browser_entry(&mut self) {
         let visible = self.visible_browser_entries();
         let mut browse_to: Option<PathBuf> = None;
@@ -1862,6 +2118,48 @@ impl App {
         if confirm && let Err(e) = self.do_delete_session(&session_id) {
             self.set_error(format!("{e:#}"));
         }
+        false
+    }
+
+    fn resolve_confirm_kill_running(&mut self, confirm: bool) -> bool {
+        let confirm_prompt = match &self.prompt {
+            PromptState::ConfirmKillRunning(confirm_prompt) => confirm_prompt.clone(),
+            _ => return false,
+        };
+        if !confirm {
+            self.prompt = PromptState::KillRunning(confirm_prompt.previous);
+            self.set_info(
+                "Kill cancelled. Your running agents and companion terminals are unchanged.",
+            );
+            return false;
+        }
+
+        self.prompt = PromptState::None;
+        let (agents, terminals) = self.kill_runtime_targets(&confirm_prompt.target_ids);
+        if agents + terminals == 0 {
+            self.set_error(
+                "None of the selected runtimes were still running. Reopen Kill Running to refresh the list and try again.",
+            );
+            return false;
+        }
+
+        let mut pieces = Vec::new();
+        if agents > 0 {
+            pieces.push(format!(
+                "{agents} agent{}",
+                if agents == 1 { "" } else { "s" }
+            ));
+        }
+        if terminals > 0 {
+            pieces.push(format!(
+                "{terminals} terminal{}",
+                if terminals == 1 { "" } else { "s" }
+            ));
+        }
+        self.set_info(format!(
+            "Killed {}. In-progress CLI work was stopped, but the worktree files are still available for review or relaunch.",
+            pieces.join(" and ")
+        ));
         false
     }
 
@@ -1945,6 +2243,47 @@ impl App {
                 if double_click {
                     self.open_selected_pick_editor();
                 }
+            }
+            PromptMouseTarget::RuntimeKillInput => {
+                self.set_kill_running_search_cursor_from_mouse(mouse.column);
+            }
+            PromptMouseTarget::RuntimeKillItem(index) => {
+                self.set_kill_running_hovered(index);
+                self.toggle_hovered_kill_running_selection();
+            }
+            PromptMouseTarget::RuntimeKillCancel => {
+                if let Err(e) =
+                    self.execute_kill_running_footer_action(KillRunningFooterAction::Cancel)
+                {
+                    self.set_error(format!("{e:#}"));
+                }
+            }
+            PromptMouseTarget::RuntimeKillHovered => {
+                if let Err(e) =
+                    self.execute_kill_running_footer_action(KillRunningFooterAction::Hovered)
+                {
+                    self.set_error(format!("{e:#}"));
+                }
+            }
+            PromptMouseTarget::RuntimeKillSelected => {
+                if let Err(e) =
+                    self.execute_kill_running_footer_action(KillRunningFooterAction::Selected)
+                {
+                    self.set_error(format!("{e:#}"));
+                }
+            }
+            PromptMouseTarget::RuntimeKillVisible => {
+                if let Err(e) =
+                    self.execute_kill_running_footer_action(KillRunningFooterAction::Visible)
+                {
+                    self.set_error(format!("{e:#}"));
+                }
+            }
+            PromptMouseTarget::ConfirmKillCancel => {
+                return self.resolve_confirm_kill_running(false);
+            }
+            PromptMouseTarget::ConfirmKillConfirm => {
+                return self.resolve_confirm_kill_running(true);
             }
             PromptMouseTarget::ConfirmDeleteCancel => {
                 return self.resolve_confirm_delete_agent(false);
@@ -2454,7 +2793,10 @@ mod tests {
 
     use crate::app::{
         App, CenterMode, FocusPane, FullscreenOverlay, InputTarget, LeftSection, MouseLayoutState,
-        OverlayMouseLayout, OverlayMouseLayoutState, PromptState, RightSection, TextInput,
+        App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
+        KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
+        KillableRuntime, KillableRuntimeKind, LeftSection, MouseLayoutState, OverlayMouseLayout,
+        OverlayMouseLayoutState, PromptState, RightSection, RuntimeTargetId, TextInput,
     };
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};
@@ -2663,6 +3005,19 @@ mod tests {
         };
     }
 
+    fn install_kill_running_overlay(app: &mut App, items: usize) {
+        app.overlay_layout.active = OverlayMouseLayout::KillRunning {
+            input: Some(Rect::new(12, 4, 70, 1)),
+            list: Rect::new(12, 6, 70, 8),
+            items,
+            offset: 0,
+            cancel_button: Rect::new(12, 16, 14, 3),
+            hovered_button: Rect::new(28, 16, 16, 3),
+            selected_button: Rect::new(46, 16, 17, 3),
+            visible_button: Rect::new(65, 16, 15, 3),
+        };
+    }
+
     fn install_confirm_delete_overlay(app: &mut App) {
         app.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
             cancel_button: Rect::new(34, 10, 16, 3),
@@ -2688,6 +3043,21 @@ mod tests {
         app.overlay_layout.active = OverlayMouseLayout::RenameSession {
             input: Rect::new(24, 10, 30, 1),
         };
+    }
+
+    fn sample_runtime(
+        id: RuntimeTargetId,
+        kind: KillableRuntimeKind,
+        label: &str,
+        context: &str,
+    ) -> KillableRuntime {
+        KillableRuntime {
+            id,
+            kind,
+            label: label.to_string(),
+            context: context.to_string(),
+            search_text: format!("{label} {context}"),
+        }
     }
 
     fn init_git_repo_with_modified_file(
@@ -2805,6 +3175,243 @@ mod tests {
         assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
         assert_eq!(app.input_target, InputTarget::None);
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+    }
+
+    #[test]
+    fn open_kill_running_requires_live_runtimes() {
+        let mut app = test_app(default_bindings());
+
+        app.open_kill_running().unwrap();
+
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(app.status.text().contains("No running agents"));
+    }
+
+    #[test]
+    fn open_kill_running_snapshots_agents_and_terminals() {
+        let mut app = test_app(default_bindings());
+        let worktree_path = app.sessions[0].worktree_path.clone();
+        let worktree = std::path::Path::new(&worktree_path);
+        let args = vec!["-c".to_string(), "sleep 5".to_string()];
+        app.providers.insert(
+            app.sessions[0].id.clone(),
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn agent"),
+        );
+        app.companion_terminals.insert(
+            "term-1".to_string(),
+            crate::app::CompanionTerminal {
+                session_id: app.sessions[0].id.clone(),
+                label: "shell".to_string(),
+                foreground_cmd: None,
+                client: PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000)
+                    .expect("spawn terminal"),
+            },
+        );
+
+        app.open_kill_running().unwrap();
+
+        match &app.prompt {
+            PromptState::KillRunning(prompt) => {
+                assert_eq!(prompt.runtimes.len(), 2);
+                assert!(
+                    prompt
+                        .runtimes
+                        .iter()
+                        .any(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
+                );
+                assert!(
+                    prompt
+                        .runtimes
+                        .iter()
+                        .any(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
+                );
+            }
+            other => panic!("expected kill-running prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kill_running_search_keeps_hidden_selection() {
+        let mut app = test_app(default_bindings());
+        let selected_id = RuntimeTargetId::Agent("session-1".to_string());
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: vec![
+                sample_runtime(
+                    selected_id.clone(),
+                    KillableRuntimeKind::Agent,
+                    "alpha-agent",
+                    "demo / codex / alpha-agent",
+                ),
+                sample_runtime(
+                    RuntimeTargetId::Terminal("term-1".to_string()),
+                    KillableRuntimeKind::Terminal,
+                    "beta-shell",
+                    "demo / alpha-agent",
+                ),
+            ],
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::iter::once(selected_id.clone()).collect(),
+            focus: KillRunningFocus::List,
+        });
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE))
+            .unwrap();
+        for ch in ['b', 'e', 't', 'a'] {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE))
+                .unwrap();
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        let PromptState::KillRunning(prompt) = &app.prompt else {
+            panic!("expected kill-running prompt");
+        };
+        let visible = App::visible_kill_running_indices(prompt);
+        assert_eq!(visible.len(), 1);
+        assert!(prompt.selected_ids.contains(&selected_id));
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .unwrap();
+        let PromptState::KillRunning(prompt) = &app.prompt else {
+            panic!("expected kill-running prompt");
+        };
+        assert!(prompt.selected_ids.contains(&selected_id));
+    }
+
+    #[test]
+    fn confirm_kill_cancel_restores_selection_modal_state() {
+        let mut app = test_app(default_bindings());
+        let selected_id = RuntimeTargetId::Agent("session-1".to_string());
+        let previous = KillRunningPrompt {
+            runtimes: vec![sample_runtime(
+                selected_id.clone(),
+                KillableRuntimeKind::Agent,
+                "agent-branch",
+                "demo / codex / agent-branch",
+            )],
+            filter: TextInput::with_text("agent".to_string()),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::iter::once(selected_id).collect(),
+            focus: KillRunningFocus::Footer(KillRunningFooterAction::Selected),
+        };
+        app.prompt = PromptState::ConfirmKillRunning(ConfirmKillRunningPrompt {
+            previous: previous.clone(),
+            action: KillRunningAction::Selected,
+            target_ids: vec![RuntimeTargetId::Agent("session-1".to_string())],
+            confirm_selected: false,
+        });
+
+        app.resolve_confirm_kill_running(false);
+
+        match &app.prompt {
+            PromptState::KillRunning(prompt) => {
+                assert_eq!(prompt.filter.text, previous.filter.text);
+                assert_eq!(prompt.selected_ids, previous.selected_ids);
+                assert_eq!(prompt.focus, previous.focus);
+            }
+            other => panic!("expected restored kill-running prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kill_visible_only_kills_filtered_rows() {
+        let mut app = test_app(default_bindings());
+        let worktree_path = app.sessions[0].worktree_path.clone();
+        let worktree = std::path::Path::new(&worktree_path);
+        std::fs::create_dir_all(app.paths.worktrees_root.join("other")).expect("other worktree");
+        let now = Utc::now();
+        app.sessions.push(AgentSession {
+            id: "session-2".to_string(),
+            project_id: app.projects[0].id.clone(),
+            project_path: Some(app.projects[0].path.clone()),
+            provider: ProviderKind::from_str("claude"),
+            source_branch: "main".to_string(),
+            branch_name: "beta-agent".to_string(),
+            worktree_path: app.paths.worktrees_root.join("other").display().to_string(),
+            title: None,
+            status: SessionStatus::Detached,
+            created_at: now,
+            updated_at: now,
+        });
+        let args = vec!["-c".to_string(), "sleep 5".to_string()];
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn first"),
+        );
+        app.providers.insert(
+            "session-2".to_string(),
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn second"),
+        );
+
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: app.running_runtime_snapshot(),
+            filter: TextInput::with_text("beta".to_string()),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::iter::once(RuntimeTargetId::Agent("session-1".to_string()))
+                .collect(),
+            focus: KillRunningFocus::Footer(KillRunningFooterAction::Visible),
+        });
+
+        app.open_confirm_kill_running_action(KillRunningAction::Visible)
+            .unwrap();
+        app.resolve_confirm_kill_running(true);
+
+        assert!(app.providers.contains_key("session-1"));
+        assert!(!app.providers.contains_key("session-2"));
+    }
+
+    #[test]
+    fn kill_selected_removes_running_targets_and_resets_terminal_surface() {
+        let mut app = test_app(default_bindings());
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let args = vec!["-c".to_string(), "sleep 5".to_string()];
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn agent"),
+        );
+        app.companion_terminals.insert(
+            "term-1".to_string(),
+            crate::app::CompanionTerminal {
+                session_id: app.sessions[0].id.clone(),
+                label: "shell".to_string(),
+                foreground_cmd: None,
+                client: PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000)
+                    .expect("spawn terminal"),
+            },
+        );
+        app.active_terminal_id = Some("term-1".to_string());
+        app.session_surface = SessionSurface::Terminal;
+        app.input_target = InputTarget::None;
+        app.fullscreen_overlay = FullscreenOverlay::Terminal;
+
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: app.running_runtime_snapshot(),
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: [
+                RuntimeTargetId::Agent("session-1".to_string()),
+                RuntimeTargetId::Terminal("term-1".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+            focus: KillRunningFocus::Footer(KillRunningFooterAction::Selected),
+        });
+
+        app.open_confirm_kill_running_action(KillRunningAction::Selected)
+            .unwrap();
+        app.resolve_confirm_kill_running(true);
+
+        assert!(app.providers.is_empty());
+        assert!(app.companion_terminals.is_empty());
+        assert_eq!(app.session_surface, SessionSurface::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        assert!(matches!(app.prompt, PromptState::None));
     }
 
     #[test]
@@ -3751,6 +4358,65 @@ mod tests {
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 20, 8));
         assert!(matches!(app.prompt, PromptState::None));
         assert!(app.status.text().contains("Opened agent"));
+    }
+
+    #[test]
+    fn mouse_click_kill_running_row_toggles_selection() {
+        let mut app = test_app(default_bindings());
+        let runtime_id = RuntimeTargetId::Agent("session-1".to_string());
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: vec![sample_runtime(
+                runtime_id.clone(),
+                KillableRuntimeKind::Agent,
+                "agent-branch",
+                "demo / codex / agent-branch",
+            )],
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::collections::HashSet::new(),
+            focus: KillRunningFocus::List,
+        });
+        install_kill_running_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 12, 6));
+
+        match &app.prompt {
+            PromptState::KillRunning(prompt) => {
+                assert!(prompt.selected_ids.contains(&runtime_id));
+            }
+            other => panic!("expected kill-running prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_kill_selected_button_opens_confirmation() {
+        let mut app = test_app(default_bindings());
+        let runtime_id = RuntimeTargetId::Agent("session-1".to_string());
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: vec![sample_runtime(
+                runtime_id.clone(),
+                KillableRuntimeKind::Agent,
+                "agent-branch",
+                "demo / codex / agent-branch",
+            )],
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::iter::once(runtime_id).collect(),
+            focus: KillRunningFocus::Footer(KillRunningFooterAction::Selected),
+        });
+        install_kill_running_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 47, 16));
+
+        match &app.prompt {
+            PromptState::ConfirmKillRunning(confirm_prompt) => {
+                assert_eq!(confirm_prompt.action, KillRunningAction::Selected);
+                assert_eq!(confirm_prompt.target_ids.len(), 1);
+            }
+            other => panic!("expected confirm kill prompt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3249,6 +3249,31 @@ mod tests {
     }
 
     #[test]
+    fn kill_running_terminal_label_deduplicates_term_prefix() {
+        let mut app = test_app(default_bindings());
+        let worktree_path = app.sessions[0].worktree_path.clone();
+        let worktree = std::path::Path::new(&worktree_path);
+        let args = vec!["-c".to_string(), "sleep 5".to_string()];
+        app.companion_terminals.insert(
+            "term-1".to_string(),
+            crate::app::CompanionTerminal {
+                session_id: app.sessions[0].id.clone(),
+                label: "shell".to_string(),
+                foreground_cmd: Some("TERM sleep".to_string()),
+                client: PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000)
+                    .expect("spawn terminal"),
+            },
+        );
+
+        let runtimes = app.running_runtime_snapshot();
+        let terminal = runtimes
+            .iter()
+            .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
+            .expect("terminal runtime");
+        assert_eq!(terminal.label, "TERM sleep");
+    }
+
+    #[test]
     fn kill_running_search_keeps_hidden_selection() {
         let mut app = test_app(default_bindings());
         let selected_id = RuntimeTargetId::Agent("session-1".to_string());

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1096,12 +1096,11 @@ impl App {
                     if let PromptState::KillRunning(prompt) = &mut self.prompt {
                         prompt.focus = match prompt.focus {
                             KillRunningFocus::List => {
-                                KillRunningFocus::Footer(KillRunningFooterAction::Hovered)
+                                Self::next_kill_running_footer_action(prompt, None, true)
                             }
-                            KillRunningFocus::Footer(action) => action
-                                .next()
-                                .map(KillRunningFocus::Footer)
-                                .unwrap_or(KillRunningFocus::List),
+                            KillRunningFocus::Footer(action) => {
+                                Self::next_kill_running_footer_action(prompt, Some(action), true)
+                            }
                         };
                     }
                 }
@@ -1109,12 +1108,11 @@ impl App {
                     if let PromptState::KillRunning(prompt) = &mut self.prompt {
                         prompt.focus = match prompt.focus {
                             KillRunningFocus::List => {
-                                KillRunningFocus::Footer(KillRunningFooterAction::Visible)
+                                Self::next_kill_running_footer_action(prompt, None, false)
                             }
-                            KillRunningFocus::Footer(action) => action
-                                .previous()
-                                .map(KillRunningFocus::Footer)
-                                .unwrap_or(KillRunningFocus::List),
+                            KillRunningFocus::Footer(action) => {
+                                Self::next_kill_running_footer_action(prompt, Some(action), false)
+                            }
                         };
                     }
                 }
@@ -2032,6 +2030,18 @@ impl App {
         &mut self,
         action: KillRunningFooterAction,
     ) -> Result<()> {
+        let enabled = match &self.prompt {
+            PromptState::KillRunning(prompt) => Self::kill_running_footer_enabled(prompt, action),
+            _ => true,
+        };
+        if !enabled {
+            if matches!(action, KillRunningFooterAction::Selected) {
+                self.set_info(
+                    "Select one or more runtimes before using Kill Selected. Press Space to mark the highlighted row.",
+                );
+            }
+            return Ok(());
+        }
         match action {
             KillRunningFooterAction::Cancel => {
                 self.prompt = PromptState::None;
@@ -2044,6 +2054,71 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn kill_running_footer_enabled(
+        prompt: &KillRunningPrompt,
+        action: KillRunningFooterAction,
+    ) -> bool {
+        match action {
+            KillRunningFooterAction::Cancel => true,
+            KillRunningFooterAction::Selected => !prompt.selected_ids.is_empty(),
+            KillRunningFooterAction::Hovered | KillRunningFooterAction::Visible => {
+                !Self::visible_kill_running_indices(prompt).is_empty()
+            }
+        }
+    }
+
+    fn next_kill_running_footer_action(
+        prompt: &KillRunningPrompt,
+        current: Option<KillRunningFooterAction>,
+        forward: bool,
+    ) -> KillRunningFocus {
+        const ACTIONS: [KillRunningFooterAction; 4] = [
+            KillRunningFooterAction::Cancel,
+            KillRunningFooterAction::Hovered,
+            KillRunningFooterAction::Selected,
+            KillRunningFooterAction::Visible,
+        ];
+
+        let enabled: Vec<KillRunningFooterAction> = ACTIONS
+            .into_iter()
+            .filter(|action| Self::kill_running_footer_enabled(prompt, *action))
+            .collect();
+
+        if enabled.is_empty() {
+            return KillRunningFocus::List;
+        }
+
+        match current {
+            None => {
+                if forward {
+                    KillRunningFocus::Footer(enabled[0])
+                } else {
+                    KillRunningFocus::Footer(*enabled.last().unwrap())
+                }
+            }
+            Some(current) => {
+                let Some(index) = enabled.iter().position(|action| *action == current) else {
+                    return if forward {
+                        KillRunningFocus::Footer(enabled[0])
+                    } else {
+                        KillRunningFocus::Footer(*enabled.last().unwrap())
+                    };
+                };
+                if forward {
+                    if index + 1 < enabled.len() {
+                        KillRunningFocus::Footer(enabled[index + 1])
+                    } else {
+                        KillRunningFocus::List
+                    }
+                } else if index > 0 {
+                    KillRunningFocus::Footer(enabled[index - 1])
+                } else {
+                    KillRunningFocus::List
+                }
+            }
+        }
     }
 
     fn open_selected_browser_entry(&mut self) {
@@ -3274,6 +3349,68 @@ mod tests {
             .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
             .expect("terminal runtime");
         assert_eq!(terminal.label, "sleep");
+    }
+
+    #[test]
+    fn kill_running_tab_focus_reaches_cancel_button() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: vec![sample_runtime(
+                RuntimeTargetId::Agent("session-1".to_string()),
+                KillableRuntimeKind::Agent,
+                "Codex",
+                "on agent \"agent-branch\" under project \"demo\"",
+            )],
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::collections::HashSet::new(),
+            focus: KillRunningFocus::List,
+        });
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::KillRunning(prompt) => {
+                assert_eq!(
+                    prompt.focus,
+                    KillRunningFocus::Footer(KillRunningFooterAction::Cancel)
+                )
+            }
+            other => panic!("expected kill-running prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kill_running_footer_skips_kill_selected_when_nothing_is_marked() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes: vec![sample_runtime(
+                RuntimeTargetId::Agent("session-1".to_string()),
+                KillableRuntimeKind::Agent,
+                "Codex",
+                "on agent \"agent-branch\" under project \"demo\"",
+            )],
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: std::collections::HashSet::new(),
+            focus: KillRunningFocus::Footer(KillRunningFooterAction::Hovered),
+        });
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::KillRunning(prompt) => {
+                assert_eq!(
+                    prompt.focus,
+                    KillRunningFocus::Footer(KillRunningFooterAction::Visible)
+                )
+            }
+            other => panic!("expected kill-running prompt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3230,8 +3230,11 @@ mod tests {
                     .iter()
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
                     .expect("agent runtime");
-                assert_eq!(agent.label, "Codex agent-branch");
-                assert_eq!(agent.context, "under project \"demo\"");
+                assert_eq!(agent.label, "Codex");
+                assert_eq!(
+                    agent.context,
+                    "on agent \"agent-branch\" under project \"demo\""
+                );
 
                 let terminal = prompt
                     .runtimes

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2804,7 +2804,6 @@ mod tests {
     use std::sync::{Arc, Mutex, mpsc};
 
     use crate::app::{
-        App, CenterMode, FocusPane, FullscreenOverlay, InputTarget, LeftSection, MouseLayoutState,
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
         KillableRuntime, KillableRuntimeKind, LeftSection, MouseLayoutState, OverlayMouseLayout,
@@ -3226,18 +3225,24 @@ mod tests {
         match &app.prompt {
             PromptState::KillRunning(prompt) => {
                 assert_eq!(prompt.runtimes.len(), 2);
-                assert!(
-                    prompt
-                        .runtimes
-                        .iter()
-                        .any(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
-                );
-                assert!(
-                    prompt
-                        .runtimes
-                        .iter()
-                        .any(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
-                );
+                let agent = prompt
+                    .runtimes
+                    .iter()
+                    .find(|runtime| matches!(runtime.id, RuntimeTargetId::Agent(_)))
+                    .expect("agent runtime");
+                assert_eq!(agent.label, "agent-branch");
+                assert!(agent.context.contains("project: demo"));
+                assert!(agent.context.contains("provider: codex"));
+                assert!(agent.context.contains("agent: agent-branch"));
+
+                let terminal = prompt
+                    .runtimes
+                    .iter()
+                    .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
+                    .expect("terminal runtime");
+                assert_eq!(terminal.label, "shell");
+                assert!(terminal.context.contains("project: demo"));
+                assert!(terminal.context.contains("agent: agent-branch"));
             }
             other => panic!("expected kill-running prompt, got {other:?}"),
         }
@@ -3437,8 +3442,7 @@ mod tests {
                     "agent-branch",
                     "demo / codex / agent-branch",
                 )],
-                filter: String::new(),
-                filter_cursor: 0,
+                filter: TextInput::new(),
                 searching: false,
                 hovered_visible_index: 0,
                 selected_ids: std::iter::once(RuntimeTargetId::Agent("session-1".to_string()))

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3238,7 +3238,7 @@ mod tests {
                     .iter()
                     .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
                     .expect("terminal runtime");
-                assert_eq!(terminal.label, "TERM python");
+                assert_eq!(terminal.label, "python");
                 assert_eq!(
                     terminal.context,
                     "on agent \"agent-branch\" under project \"demo\""
@@ -3270,7 +3270,7 @@ mod tests {
             .iter()
             .find(|runtime| matches!(runtime.id, RuntimeTargetId::Terminal(_)))
             .expect("terminal runtime");
-        assert_eq!(terminal.label, "TERM sleep");
+        assert_eq!(terminal.label, "sleep");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -191,6 +191,130 @@ pub(crate) enum CenterMode {
     },
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum KillableRuntimeKind {
+    Agent,
+    Terminal,
+}
+
+impl KillableRuntimeKind {
+    pub(crate) fn noun(self) -> &'static str {
+        match self {
+            Self::Agent => "agent",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    pub(crate) fn badge(self) -> &'static str {
+        match self {
+            Self::Agent => "Agent",
+            Self::Terminal => "Term",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum RuntimeTargetId {
+    Agent(String),
+    Terminal(String),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct KillableRuntime {
+    pub(crate) id: RuntimeTargetId,
+    pub(crate) kind: KillableRuntimeKind,
+    pub(crate) label: String,
+    pub(crate) context: String,
+    pub(crate) search_text: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KillRunningAction {
+    Hovered,
+    Selected,
+    Visible,
+}
+
+impl KillRunningAction {
+    pub(crate) fn button_label(self) -> &'static str {
+        match self {
+            Self::Hovered => "Kill Hovered",
+            Self::Selected => "Kill Selected",
+            Self::Visible => "Kill Visible",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KillRunningFooterAction {
+    Cancel,
+    Hovered,
+    Selected,
+    Visible,
+}
+
+impl KillRunningFooterAction {
+    pub(crate) fn button_label(self) -> &'static str {
+        match self {
+            Self::Cancel => "Cancel",
+            Self::Hovered => KillRunningAction::Hovered.button_label(),
+            Self::Selected => KillRunningAction::Selected.button_label(),
+            Self::Visible => KillRunningAction::Visible.button_label(),
+        }
+    }
+
+    pub(crate) fn next(self) -> Option<Self> {
+        match self {
+            Self::Cancel => Some(Self::Hovered),
+            Self::Hovered => Some(Self::Selected),
+            Self::Selected => Some(Self::Visible),
+            Self::Visible => None,
+        }
+    }
+
+    pub(crate) fn previous(self) -> Option<Self> {
+        match self {
+            Self::Cancel => None,
+            Self::Hovered => Some(Self::Cancel),
+            Self::Selected => Some(Self::Hovered),
+            Self::Visible => Some(Self::Selected),
+        }
+    }
+
+    pub(crate) fn action(self) -> Option<KillRunningAction> {
+        match self {
+            Self::Cancel => None,
+            Self::Hovered => Some(KillRunningAction::Hovered),
+            Self::Selected => Some(KillRunningAction::Selected),
+            Self::Visible => Some(KillRunningAction::Visible),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KillRunningFocus {
+    List,
+    Footer(KillRunningFooterAction),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct KillRunningPrompt {
+    pub(crate) runtimes: Vec<KillableRuntime>,
+    pub(crate) filter: TextInput,
+    pub(crate) searching: bool,
+    pub(crate) hovered_visible_index: usize,
+    pub(crate) selected_ids: HashSet<RuntimeTargetId>,
+    pub(crate) focus: KillRunningFocus,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ConfirmKillRunningPrompt {
+    pub(crate) previous: KillRunningPrompt,
+    pub(crate) action: KillRunningAction,
+    pub(crate) target_ids: Vec<RuntimeTargetId>,
+    pub(crate) confirm_selected: bool,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum PromptState {
     None,
@@ -211,6 +335,8 @@ pub(crate) enum PromptState {
         tab_completions: Vec<String>,
         tab_index: usize,
     },
+    KillRunning(KillRunningPrompt),
+    ConfirmKillRunning(ConfirmKillRunningPrompt),
     ConfirmDeleteAgent {
         session_id: String,
         branch_name: String,
@@ -322,6 +448,20 @@ pub(crate) enum OverlayMouseLayout {
         list: Rect,
         items: usize,
         offset: usize,
+    },
+    KillRunning {
+        input: Option<Rect>,
+        list: Rect,
+        items: usize,
+        offset: usize,
+        cancel_button: Rect,
+        hovered_button: Rect,
+        selected_button: Rect,
+        visible_button: Rect,
+    },
+    ConfirmKillRunning {
+        cancel_button: Rect,
+        kill_button: Rect,
     },
     ConfirmDeleteAgent {
         cancel_button: Rect,
@@ -660,6 +800,7 @@ impl App {
             "remove-project" => self.remove_selected_project(),
             "delete-agent" => self.confirm_delete_selected_session(),
             "rename-agent" => self.open_rename_session(),
+            "kill-running" => self.open_kill_running(),
             "reconnect-agent" => self.reconnect_selected_session(),
             "show-agent" => self.activate_center_agent(),
             "show-terminal" => self.show_companion_terminal(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -263,24 +263,6 @@ impl KillRunningFooterAction {
         }
     }
 
-    pub(crate) fn next(self) -> Option<Self> {
-        match self {
-            Self::Cancel => Some(Self::Hovered),
-            Self::Hovered => Some(Self::Selected),
-            Self::Selected => Some(Self::Visible),
-            Self::Visible => None,
-        }
-    }
-
-    pub(crate) fn previous(self) -> Option<Self> {
-        match self {
-            Self::Cancel => None,
-            Self::Hovered => Some(Self::Cancel),
-            Self::Selected => Some(Self::Hovered),
-            Self::Visible => Some(Self::Selected),
-        }
-    }
-
     pub(crate) fn action(self) -> Option<KillRunningAction> {
         match self {
             Self::Cancel => None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -785,6 +785,10 @@ impl App {
         self.status.busy(message);
     }
 
+    pub(crate) fn set_warning(&mut self, message: impl Into<String>) {
+        self.status.warning(message);
+    }
+
     pub(crate) fn set_error(&mut self, message: impl Into<String>) {
         self.status.error(message);
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -207,8 +207,8 @@ impl KillableRuntimeKind {
 
     pub(crate) fn badge(self) -> &'static str {
         match self {
-            Self::Agent => "Agent",
-            Self::Terminal => "Term",
+            Self::Agent => "AGENT",
+            Self::Terminal => "TERM",
         }
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2152,25 +2152,35 @@ impl App {
                         height: 3,
                     };
                     button_rects[index] = rect;
-                    let selected = matches!(prompt.focus, KillRunningFocus::Footer(current) if current == *action);
-                    let is_danger = !matches!(action, KillRunningFooterAction::Cancel);
+                    let enabled = Self::kill_running_footer_enabled(prompt, *action);
+                    let selected = enabled
+                        && matches!(prompt.focus, KillRunningFocus::Footer(current) if current == *action);
+                    let is_danger = enabled && !matches!(action, KillRunningFooterAction::Cancel);
                     let border = if selected {
                         if is_danger {
                             self.theme.button_danger_border
                         } else {
                             self.theme.button_confirm_border
                         }
+                    } else if !enabled {
+                        self.theme.border_normal
                     } else {
                         self.theme.border_normal
                     };
                     let fg = if selected {
                         self.theme.button_active_fg
+                    } else if !enabled {
+                        self.theme.hint_dim_desc_fg
                     } else {
                         self.theme.hint_desc_fg
                     };
                     Paragraph::new(Line::from(Span::styled(
                         action.button_label(),
-                        Style::default().fg(fg).add_modifier(Modifier::BOLD),
+                        if enabled {
+                            Style::default().fg(fg).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(fg)
+                        },
                     )))
                     .alignment(ratatui::layout::Alignment::Center)
                     .block(

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1905,6 +1905,390 @@ impl App {
                     offset: state.offset(),
                 };
             }
+            PromptState::KillRunning(prompt) => {
+                self.render_dim_overlay(frame);
+                let popup = centered_rect(78, 72, frame.area());
+                Clear.render(popup, frame.buffer_mut());
+
+                let visible_indices = Self::visible_kill_running_indices(prompt);
+                let items = if visible_indices.is_empty() {
+                    vec![ListItem::new("No matching running agents or terminals.")]
+                } else {
+                    let label_col = visible_indices
+                        .iter()
+                        .filter_map(|index| prompt.runtimes.get(*index))
+                        .map(|runtime| runtime.label.len())
+                        .max()
+                        .unwrap_or(0)
+                        .min(28);
+                    visible_indices
+                        .iter()
+                        .filter_map(|index| prompt.runtimes.get(*index))
+                        .map(|runtime| {
+                            let checked = if prompt.selected_ids.contains(&runtime.id) {
+                                "[x]"
+                            } else {
+                                "[ ]"
+                            };
+                            let label = if runtime.label.chars().count() > label_col {
+                                runtime.label.chars().take(label_col).collect::<String>()
+                            } else {
+                                runtime.label.clone()
+                            };
+                            let label_padded = format!("{label:label_col$}");
+                            ListItem::new(Line::from(vec![
+                                Span::styled(
+                                    format!("{checked} "),
+                                    Style::default().fg(self.theme.hint_key_fg),
+                                ),
+                                Span::styled(
+                                    format!("{:>5} ", runtime.kind.badge()),
+                                    Style::default()
+                                        .fg(self.theme.help_section_header_fg)
+                                        .add_modifier(Modifier::BOLD),
+                                ),
+                                Span::styled(
+                                    label_padded,
+                                    Style::default().add_modifier(Modifier::BOLD),
+                                ),
+                                Span::styled(
+                                    format!("  {}", runtime.context),
+                                    Style::default().fg(self.theme.hint_desc_fg),
+                                ),
+                            ]))
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let mut state = ListState::default().with_selected(Some(
+                    prompt
+                        .hovered_visible_index
+                        .min(visible_indices.len().saturating_sub(1)),
+                ));
+                let show_top_input = prompt.searching || !prompt.filter.is_empty();
+                let (top_area, body_area) = if show_top_input {
+                    let [input_area, rest] = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([Constraint::Length(3), Constraint::Min(6)])
+                        .areas(popup);
+                    (Some(input_area), rest)
+                } else {
+                    (None, popup)
+                };
+                let [list_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(6), Constraint::Length(3)])
+                    .areas(body_area);
+
+                let search_key = self.bindings.label_for(Action::SearchToggle);
+                let toggle_key = self.bindings.label_for(Action::ToggleMarked);
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let next_key = self.bindings.label_for(Action::FocusNext);
+                let prev_key = self.bindings.label_for(Action::FocusPrev);
+                let mut hint_spans = vec![Span::raw(" ")];
+                if prompt.searching {
+                    hint_spans.extend(self.theme.key_badge_default(&confirm_key));
+                    hint_spans.push(Span::styled(
+                        " done  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hint_spans.extend(self.theme.key_badge_default(&close_key));
+                    hint_spans.push(Span::styled(
+                        " clear",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                } else {
+                    hint_spans.extend(self.theme.key_badge_default(&toggle_key));
+                    hint_spans.push(Span::styled(
+                        " select  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hint_spans.extend(self.theme.key_badge_default(&search_key));
+                    hint_spans.push(Span::styled(
+                        " search  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hint_spans.extend(self.theme.key_badge_default(&next_key));
+                    hint_spans.push(Span::styled(
+                        "/",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hint_spans.extend(self.theme.key_badge_default(&prev_key));
+                    hint_spans.push(Span::styled(
+                        " actions  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hint_spans.extend(self.theme.key_badge_default(&confirm_key));
+                    hint_spans.push(Span::styled(
+                        " use",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                }
+
+                let title = if prompt.searching {
+                    "Kill Running (searching)"
+                } else {
+                    "Kill Running"
+                };
+                if let Some(input_area) = top_area {
+                    let input_block = self.themed_overlay_block(title);
+                    let input_inner = input_block.inner(input_area);
+                    Paragraph::new(render_single_line_cursor_input(
+                        "/ ",
+                        &prompt.filter.text,
+                        prompt.filter.cursor,
+                        self.theme.input_cursor_fg,
+                        self.theme.input_cursor_bg,
+                    ))
+                    .block(input_block)
+                    .render(input_area, frame.buffer_mut());
+                    let list_block = Block::default()
+                        .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                        .border_type(ratatui::widgets::BorderType::Rounded)
+                        .border_style(Style::default().fg(self.theme.overlay_border))
+                        .title_bottom(Line::from(hint_spans));
+                    let list_inner = list_block.inner(list_area);
+                    StatefulWidget::render(
+                        List::new(items)
+                            .block(list_block)
+                            .highlight_style(self.theme.selection_style()),
+                        list_area,
+                        frame.buffer_mut(),
+                        &mut state,
+                    );
+                    self.overlay_layout.active = OverlayMouseLayout::KillRunning {
+                        input: Some(input_inner),
+                        list: list_inner,
+                        items: visible_indices.len(),
+                        offset: state.offset(),
+                        cancel_button: Rect::default(),
+                        hovered_button: Rect::default(),
+                        selected_button: Rect::default(),
+                        visible_button: Rect::default(),
+                    };
+                } else {
+                    let list_block = self
+                        .themed_overlay_block(title)
+                        .title_bottom(Line::from(hint_spans));
+                    let list_inner = list_block.inner(list_area);
+                    StatefulWidget::render(
+                        List::new(items)
+                            .block(list_block)
+                            .highlight_style(self.theme.selection_style()),
+                        list_area,
+                        frame.buffer_mut(),
+                        &mut state,
+                    );
+                    self.overlay_layout.active = OverlayMouseLayout::KillRunning {
+                        input: None,
+                        list: list_inner,
+                        items: visible_indices.len(),
+                        offset: state.offset(),
+                        cancel_button: Rect::default(),
+                        hovered_button: Rect::default(),
+                        selected_button: Rect::default(),
+                        visible_button: Rect::default(),
+                    };
+                }
+
+                let buttons = [
+                    KillRunningFooterAction::Cancel,
+                    KillRunningFooterAction::Hovered,
+                    KillRunningFooterAction::Selected,
+                    KillRunningFooterAction::Visible,
+                ];
+                let gap = 2u16;
+                let button_widths = buttons.map(|action| action.button_label().len() as u16 + 6);
+                let total_width = button_widths.iter().sum::<u16>() + gap * 3;
+                let start_x = buttons_area.x + buttons_area.width.saturating_sub(total_width) / 2;
+                let mut cursor_x = start_x;
+                let mut button_rects = [Rect::default(); 4];
+                for (index, action) in buttons.iter().enumerate() {
+                    let rect = Rect {
+                        x: cursor_x,
+                        y: buttons_area.y,
+                        width: button_widths[index],
+                        height: 3,
+                    };
+                    button_rects[index] = rect;
+                    let selected = matches!(prompt.focus, KillRunningFocus::Footer(current) if current == *action);
+                    let is_danger = !matches!(action, KillRunningFooterAction::Cancel);
+                    let border = if selected {
+                        if is_danger {
+                            self.theme.button_danger_border
+                        } else {
+                            self.theme.button_confirm_border
+                        }
+                    } else {
+                        self.theme.border_normal
+                    };
+                    let fg = if selected {
+                        self.theme.button_active_fg
+                    } else {
+                        self.theme.hint_desc_fg
+                    };
+                    Paragraph::new(Line::from(Span::styled(
+                        action.button_label(),
+                        Style::default().fg(fg).add_modifier(Modifier::BOLD),
+                    )))
+                    .alignment(ratatui::layout::Alignment::Center)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_set(border::ROUNDED)
+                            .border_style(Style::default().fg(border)),
+                    )
+                    .render(rect, frame.buffer_mut());
+                    cursor_x += button_widths[index] + gap;
+                }
+                self.overlay_layout.active = OverlayMouseLayout::KillRunning {
+                    input: match self.overlay_layout.active {
+                        OverlayMouseLayout::KillRunning { input, .. } => input,
+                        _ => None,
+                    },
+                    list: match self.overlay_layout.active {
+                        OverlayMouseLayout::KillRunning { list, .. } => list,
+                        _ => Rect::default(),
+                    },
+                    items: visible_indices.len(),
+                    offset: state.offset(),
+                    cancel_button: button_rects[0],
+                    hovered_button: button_rects[1],
+                    selected_button: button_rects[2],
+                    visible_button: button_rects[3],
+                };
+            }
+            PromptState::ConfirmKillRunning(confirm_prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(56, 32, frame.area());
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Confirm Kill");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                let targets = confirm_prompt.target_ids.len();
+                let (agent_count, terminal_count) = confirm_prompt.target_ids.iter().fold(
+                    (0usize, 0usize),
+                    |(agents, terminals), target_id| match target_id {
+                        RuntimeTargetId::Agent(_) => (agents + 1, terminals),
+                        RuntimeTargetId::Terminal(_) => (agents, terminals + 1),
+                    },
+                );
+                let mut summary = Vec::new();
+                if agent_count > 0 {
+                    summary.push(format!(
+                        "{agent_count} agent{}",
+                        if agent_count == 1 { "" } else { "s" }
+                    ));
+                }
+                if terminal_count > 0 {
+                    summary.push(format!(
+                        "{terminal_count} terminal{}",
+                        if terminal_count == 1 { "" } else { "s" }
+                    ));
+                }
+                let lines = vec![
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::raw(format!(
+                            " {} will stop ",
+                            confirm_prompt.action.button_label()
+                        )),
+                        Span::styled(
+                            format!(
+                                "{targets} running process{}",
+                                if targets == 1 { "" } else { "es" }
+                            ),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw("."),
+                    ]),
+                    Line::from(format!(" Affected: {}", summary.join(" and "))),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " In-progress CLI work will be lost immediately.",
+                        Style::default().fg(self.theme.warning_fg),
+                    )),
+                    Line::from(Span::styled(
+                        " Worktree files remain on disk for review or relaunch.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )),
+                ];
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = 16u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let kill_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) = if !confirm_prompt.confirm_selected {
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+                let (kill_border, kill_fg) = if confirm_prompt.confirm_selected {
+                    (self.theme.button_danger_border, self.theme.button_active_fg)
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Kill",
+                    Style::default().fg(kill_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(kill_border)),
+                )
+                .render(kill_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmKillRunning {
+                    cancel_button: cancel_area,
+                    kill_button: kill_area,
+                };
+            }
             PromptState::ConfirmDeleteAgent {
                 branch_name,
                 confirm_selected,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1961,9 +1961,7 @@ impl App {
                                 Style::default()
                                     .fg(self.theme.hint_dim_desc_fg)
                                     .add_modifier(Modifier::DIM),
-                                Style::default()
-                                    .fg(self.theme.branch_fg)
-                                    .add_modifier(Modifier::BOLD),
+                                Style::default().fg(self.theme.runtime_context_value_fg),
                             ));
                             ListItem::new(Line::from(spans))
                         })

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1919,7 +1919,7 @@ impl App {
                     let label_col = visible_indices
                         .iter()
                         .filter_map(|index| prompt.runtimes.get(*index))
-                        .map(|runtime| runtime.label.len())
+                        .map(|runtime| runtime.label.chars().count())
                         .max()
                         .unwrap_or(0)
                         .min(28);
@@ -1938,16 +1938,18 @@ impl App {
                                 runtime.label.clone()
                             };
                             let label_padded = format!("{label:label_col$}");
+                            let kind_color = match runtime.kind {
+                                KillableRuntimeKind::Agent => self.theme.session_active,
+                                KillableRuntimeKind::Terminal => self.theme.session_detached,
+                            };
                             ListItem::new(Line::from(vec![
                                 Span::styled(
                                     format!("{checked} "),
                                     Style::default().fg(self.theme.hint_key_fg),
                                 ),
                                 Span::styled(
-                                    format!("{:>5} ", runtime.kind.badge()),
-                                    Style::default()
-                                        .fg(self.theme.help_section_header_fg)
-                                        .add_modifier(Modifier::BOLD),
+                                    format!("{:>6} ", runtime.kind.badge()),
+                                    Style::default().fg(kind_color).add_modifier(Modifier::BOLD),
                                 ),
                                 Span::styled(
                                     label_padded,
@@ -1955,7 +1957,9 @@ impl App {
                                 ),
                                 Span::styled(
                                     format!("  {}", runtime.context),
-                                    Style::default().fg(self.theme.hint_desc_fg),
+                                    Style::default()
+                                        .fg(self.theme.hint_dim_desc_fg)
+                                        .add_modifier(Modifier::DIM),
                                 ),
                             ]))
                         })

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2102,6 +2102,7 @@ impl App {
                 }
 
                 let legend = Line::from(vec![
+                    Span::raw("  "),
                     Span::styled("Legend: ", Style::default().fg(self.theme.hint_desc_fg)),
                     Span::styled(
                         "AGENT",
@@ -2123,6 +2124,7 @@ impl App {
                         " = companion terminal  |  dim text = source context",
                         Style::default().fg(self.theme.hint_dim_desc_fg),
                     ),
+                    Span::raw("  "),
                 ]);
                 Paragraph::new(legend)
                     .wrap(Wrap { trim: false })

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1218,11 +1218,13 @@ impl App {
         let msg_color = match tone {
             StatusTone::Info => self.theme.status_info_fg,
             StatusTone::Busy => self.theme.status_busy_fg,
+            StatusTone::Warning => self.theme.warning_fg,
             StatusTone::Error => self.theme.status_error_fg,
         };
         let status_bg = match tone {
             StatusTone::Info => self.theme.status_info_bg,
             StatusTone::Busy => self.theme.status_busy_bg,
+            StatusTone::Warning => self.theme.status_info_bg,
             StatusTone::Error => self.theme.status_error_bg,
         };
         let prefix = format!(" {dot} ");

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1942,7 +1942,7 @@ impl App {
                                 KillableRuntimeKind::Agent => self.theme.session_active,
                                 KillableRuntimeKind::Terminal => self.theme.session_detached,
                             };
-                            ListItem::new(Line::from(vec![
+                            let mut spans = vec![
                                 Span::styled(
                                     format!("{checked} "),
                                     Style::default().fg(self.theme.hint_key_fg),
@@ -1955,13 +1955,17 @@ impl App {
                                     label_padded,
                                     Style::default().add_modifier(Modifier::BOLD),
                                 ),
-                                Span::styled(
-                                    format!("  {}", runtime.context),
-                                    Style::default()
-                                        .fg(self.theme.hint_dim_desc_fg)
-                                        .add_modifier(Modifier::DIM),
-                                ),
-                            ]))
+                            ];
+                            spans.extend(runtime_context_spans(
+                                &format!("  {}", runtime.context),
+                                Style::default()
+                                    .fg(self.theme.hint_dim_desc_fg)
+                                    .add_modifier(Modifier::DIM),
+                                Style::default()
+                                    .fg(self.theme.branch_fg)
+                                    .add_modifier(Modifier::BOLD),
+                            ));
+                            ListItem::new(Line::from(spans))
                         })
                         .collect::<Vec<_>>()
                 };
@@ -2971,6 +2975,41 @@ fn render_single_line_cursor_input(
     }
 }
 
+fn runtime_context_spans(
+    context: &str,
+    prose_style: Style,
+    quoted_style: Style,
+) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    let mut buf = String::new();
+    let mut in_quotes = false;
+
+    for ch in context.chars() {
+        if ch == '"' {
+            if in_quotes {
+                buf.push(ch);
+                spans.push(Span::styled(std::mem::take(&mut buf), quoted_style));
+                in_quotes = false;
+            } else {
+                if !buf.is_empty() {
+                    spans.push(Span::styled(std::mem::take(&mut buf), prose_style));
+                }
+                buf.push(ch);
+                in_quotes = true;
+            }
+        } else {
+            buf.push(ch);
+        }
+    }
+
+    if !buf.is_empty() {
+        let style = if in_quotes { quoted_style } else { prose_style };
+        spans.push(Span::styled(buf, style));
+    }
+
+    spans
+}
+
 fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {
     if scrolled == 0 {
         return None;
@@ -3127,6 +3166,28 @@ mod tests {
             companion_terminal_row_badge(CompanionTerminalStatus::NotLaunched, &theme).is_empty()
         );
         assert!(!companion_terminal_row_badge(CompanionTerminalStatus::Running, &theme).is_empty());
+    }
+
+    #[test]
+    fn runtime_context_spans_highlight_quoted_values() {
+        let prose = Style::default().fg(Color::DarkGray);
+        let quoted = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+        let spans = runtime_context_spans(
+            "on agent \"foxy-basilisk\" under project \"http-server\"",
+            prose,
+            quoted,
+        );
+
+        assert_eq!(spans.len(), 4);
+        assert_eq!(spans[0].content.as_ref(), "on agent ");
+        assert_eq!(spans[1].content.as_ref(), "\"foxy-basilisk\"");
+        assert_eq!(spans[2].content.as_ref(), " under project ");
+        assert_eq!(spans[3].content.as_ref(), "\"http-server\"");
+        assert_eq!(spans[0].style, prose);
+        assert_eq!(spans[1].style, quoted);
+        assert_eq!(spans[3].style, quoted);
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1980,9 +1980,13 @@ impl App {
                 } else {
                     (None, popup)
                 };
-                let [list_area, buttons_area] = Layout::default()
+                let [list_area, legend_area, buttons_area] = Layout::default()
                     .direction(Direction::Vertical)
-                    .constraints([Constraint::Min(6), Constraint::Length(3)])
+                    .constraints([
+                        Constraint::Min(6),
+                        Constraint::Length(2),
+                        Constraint::Length(3),
+                    ])
                     .areas(body_area);
 
                 let search_key = self.bindings.label_for(Action::SearchToggle);
@@ -2096,6 +2100,33 @@ impl App {
                         visible_button: Rect::default(),
                     };
                 }
+
+                let legend = Line::from(vec![
+                    Span::styled("Legend: ", Style::default().fg(self.theme.hint_desc_fg)),
+                    Span::styled(
+                        "AGENT",
+                        Style::default()
+                            .fg(self.theme.session_active)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        " = running agent CLI  |  ",
+                        Style::default().fg(self.theme.hint_dim_desc_fg),
+                    ),
+                    Span::styled(
+                        "TERM",
+                        Style::default()
+                            .fg(self.theme.session_detached)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        " = companion terminal  |  dim text = source context",
+                        Style::default().fg(self.theme.hint_dim_desc_fg),
+                    ),
+                ]);
+                Paragraph::new(legend)
+                    .wrap(Wrap { trim: false })
+                    .render(legend_area, frame.buffer_mut());
 
                 let buttons = [
                     KillRunningFooterAction::Cancel,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -693,8 +693,8 @@ impl App {
             let project_name = self.project_name_for_session(session);
             let agent_name = self.session_label(session);
             let provider_name = session.provider.as_str();
-            let label = format!("{} {agent_name}", Self::title_case_word(provider_name));
-            let context = format!("under project \"{project_name}\"");
+            let label = Self::title_case_word(provider_name);
+            let context = format!("on agent \"{agent_name}\" under project \"{project_name}\"");
             let search_text = format!(
                 "{} {} {} {} {}",
                 label,
@@ -727,6 +727,14 @@ impl App {
             let foreground = terminal
                 .foreground_cmd
                 .clone()
+                .map(|cmd| {
+                    let trimmed = cmd.trim();
+                    trimmed
+                        .strip_prefix("TERM ")
+                        .or_else(|| trimmed.strip_prefix("term "))
+                        .unwrap_or(trimmed)
+                        .to_string()
+                })
                 .filter(|cmd| !cmd.trim().is_empty())
                 .unwrap_or_else(|| "shell".to_string());
             let label = foreground;

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -727,6 +727,14 @@ impl App {
             let foreground = terminal
                 .foreground_cmd
                 .clone()
+                .map(|cmd| {
+                    let trimmed = cmd.trim();
+                    trimmed
+                        .strip_prefix("TERM ")
+                        .or_else(|| trimmed.strip_prefix("term "))
+                        .unwrap_or(trimmed)
+                        .to_string()
+                })
                 .filter(|cmd| !cmd.trim().is_empty())
                 .unwrap_or_else(|| "shell".to_string());
             let label = format!("TERM {foreground}");

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -693,7 +693,7 @@ impl App {
             let project_name = self.project_name_for_session(session);
             let label = self.session_label(session);
             let context = format!(
-                "project: {project_name}; provider: {}; agent: {label}",
+                "project: {project_name} | provider: {} | agent: {label}",
                 session.provider.as_str()
             );
             let search_text = format!(
@@ -724,7 +724,7 @@ impl App {
                     )
                 })
                 .unwrap_or_else(|| ("unknown".to_string(), terminal.session_id.clone()));
-            let context = format!("project: {project_name}; agent: {session_label}");
+            let context = format!("project: {project_name} | agent: {session_label}");
             let search_text = format!(
                 "{} {} {}",
                 terminal.label,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -737,7 +737,7 @@ impl App {
                 })
                 .filter(|cmd| !cmd.trim().is_empty())
                 .unwrap_or_else(|| "shell".to_string());
-            let label = format!("TERM {foreground}");
+            let label = foreground;
             let context = format!("on agent \"{session_label}\" under project \"{project_name}\"");
             let search_text = format!(
                 "{} {} {} {}",

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -694,7 +694,7 @@ impl App {
             let agent_name = self.session_label(session);
             let provider_name = session.provider.as_str();
             let label = format!("{} {agent_name}", Self::title_case_word(provider_name));
-            let context = format!("under project {project_name}");
+            let context = format!("under project \"{project_name}\"");
             let search_text = format!(
                 "{} {} {} {} {}",
                 label,
@@ -730,7 +730,7 @@ impl App {
                 .filter(|cmd| !cmd.trim().is_empty())
                 .unwrap_or_else(|| "shell".to_string());
             let label = format!("TERM {foreground}");
-            let context = format!("on agent {session_label} under project {project_name}");
+            let context = format!("on agent \"{session_label}\" under project \"{project_name}\"");
             let search_text = format!(
                 "{} {} {} {}",
                 label,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -727,14 +727,6 @@ impl App {
             let foreground = terminal
                 .foreground_cmd
                 .clone()
-                .map(|cmd| {
-                    let trimmed = cmd.trim();
-                    trimmed
-                        .strip_prefix("TERM ")
-                        .or_else(|| trimmed.strip_prefix("term "))
-                        .unwrap_or(trimmed)
-                        .to_string()
-                })
                 .filter(|cmd| !cmd.trim().is_empty())
                 .unwrap_or_else(|| "shell".to_string());
             let label = foreground;

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -693,10 +693,8 @@ impl App {
             let project_name = self.project_name_for_session(session);
             let label = self.session_label(session);
             let context = format!(
-                "{} / {} / {}",
-                project_name,
-                session.provider.as_str(),
-                session.branch_name
+                "project: {project_name}; provider: {}; agent: {label}",
+                session.provider.as_str()
             );
             let search_text = format!(
                 "{} {} {} {}",
@@ -726,7 +724,7 @@ impl App {
                     )
                 })
                 .unwrap_or_else(|| ("unknown".to_string(), terminal.session_id.clone()));
-            let context = format!("{project_name} / {session_label}");
+            let context = format!("project: {project_name}; agent: {session_label}");
             let search_text = format!(
                 "{} {} {}",
                 terminal.label,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -656,6 +656,240 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn open_kill_running(&mut self) -> Result<()> {
+        let runtimes = self.running_runtime_snapshot();
+        if runtimes.is_empty() {
+            self.set_error(
+                "No running agents or companion terminals are available to kill. Start one first, then reopen the command palette.",
+            );
+            return Ok(());
+        }
+
+        self.prompt = PromptState::KillRunning(KillRunningPrompt {
+            runtimes,
+            filter: TextInput::new(),
+            searching: false,
+            hovered_visible_index: 0,
+            selected_ids: HashSet::new(),
+            focus: KillRunningFocus::List,
+        });
+        let select = self.bindings.label_for(Action::ToggleMarked);
+        let search = self.bindings.label_for(Action::SearchToggle);
+        let next = self.bindings.label_for(Action::FocusNext);
+        let prev = self.bindings.label_for(Action::FocusPrev);
+        self.set_info(format!(
+            "Kill Running opened. Press {select} to toggle runtimes, {search} to search, and {next}/{prev} to move between the list and actions.",
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn running_runtime_snapshot(&self) -> Vec<KillableRuntime> {
+        let mut runtimes = Vec::new();
+
+        for session in &self.sessions {
+            if !self.providers.contains_key(&session.id) {
+                continue;
+            }
+            let project_name = self.project_name_for_session(session);
+            let label = self.session_label(session);
+            let context = format!(
+                "{} / {} / {}",
+                project_name,
+                session.provider.as_str(),
+                session.branch_name
+            );
+            let search_text = format!(
+                "{} {} {} {}",
+                label,
+                context,
+                session.provider.as_str(),
+                KillableRuntimeKind::Agent.noun()
+            );
+            runtimes.push(KillableRuntime {
+                id: RuntimeTargetId::Agent(session.id.clone()),
+                kind: KillableRuntimeKind::Agent,
+                label,
+                context,
+                search_text,
+            });
+        }
+
+        for (terminal_id, terminal) in self.terminal_items() {
+            let (project_name, session_label) = self
+                .sessions
+                .iter()
+                .find(|session| session.id == terminal.session_id)
+                .map(|session| {
+                    (
+                        self.project_name_for_session(session),
+                        self.session_label(session),
+                    )
+                })
+                .unwrap_or_else(|| ("unknown".to_string(), terminal.session_id.clone()));
+            let context = format!("{project_name} / {session_label}");
+            let search_text = format!(
+                "{} {} {}",
+                terminal.label,
+                context,
+                KillableRuntimeKind::Terminal.noun()
+            );
+            runtimes.push(KillableRuntime {
+                id: RuntimeTargetId::Terminal(terminal_id.clone()),
+                kind: KillableRuntimeKind::Terminal,
+                label: terminal.label.clone(),
+                context,
+                search_text,
+            });
+        }
+
+        runtimes.sort_by(|a, b| {
+            (
+                a.context.to_lowercase(),
+                a.kind.noun(),
+                a.label.to_lowercase(),
+            )
+                .cmp(&(
+                    b.context.to_lowercase(),
+                    b.kind.noun(),
+                    b.label.to_lowercase(),
+                ))
+        });
+        runtimes
+    }
+
+    pub(crate) fn visible_kill_running_indices(prompt: &KillRunningPrompt) -> Vec<usize> {
+        if prompt.filter.is_empty() {
+            return (0..prompt.runtimes.len()).collect();
+        }
+        let needle = prompt.filter.text.to_lowercase();
+        prompt
+            .runtimes
+            .iter()
+            .enumerate()
+            .filter(|(_, runtime)| runtime.search_text.to_lowercase().contains(&needle))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    pub(crate) fn clamp_kill_running_prompt(prompt: &mut KillRunningPrompt) {
+        let visible_len = Self::visible_kill_running_indices(prompt).len();
+        if visible_len == 0 {
+            prompt.hovered_visible_index = 0;
+        } else if prompt.hovered_visible_index >= visible_len {
+            prompt.hovered_visible_index = visible_len.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn open_confirm_kill_running_action(
+        &mut self,
+        action: KillRunningAction,
+    ) -> Result<()> {
+        let PromptState::KillRunning(prompt) = &self.prompt else {
+            return Ok(());
+        };
+        let prompt = prompt.clone();
+        let visible_indices = Self::visible_kill_running_indices(&prompt);
+        let target_ids = match action {
+            KillRunningAction::Hovered => visible_indices
+                .get(prompt.hovered_visible_index)
+                .map(|&index| vec![prompt.runtimes[index].id.clone()])
+                .unwrap_or_default(),
+            KillRunningAction::Selected => prompt
+                .runtimes
+                .iter()
+                .filter(|runtime| prompt.selected_ids.contains(&runtime.id))
+                .map(|runtime| runtime.id.clone())
+                .collect(),
+            KillRunningAction::Visible => visible_indices
+                .iter()
+                .map(|&index| prompt.runtimes[index].id.clone())
+                .collect(),
+        };
+
+        if target_ids.is_empty() {
+            let message = match action {
+                KillRunningAction::Hovered => {
+                    "No running agent or terminal is highlighted. Move to a visible row first."
+                }
+                KillRunningAction::Selected => {
+                    "No running agents or terminals are selected. Press Space to select one or more runtimes first."
+                }
+                KillRunningAction::Visible => {
+                    "No running agents or terminals are visible for the current filter. Clear or change the search first."
+                }
+            };
+            self.set_error(message);
+            return Ok(());
+        }
+
+        self.prompt = PromptState::ConfirmKillRunning(ConfirmKillRunningPrompt {
+            previous: prompt,
+            action,
+            target_ids,
+            confirm_selected: false,
+        });
+        self.set_info(format!(
+            "{} is ready. Review the warning and press Enter to confirm, or Esc to keep your running sessions alive.",
+            action.button_label()
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn kill_runtime_targets(
+        &mut self,
+        target_ids: &[RuntimeTargetId],
+    ) -> (usize, usize) {
+        let selected_session_id = self.selected_session().map(|session| session.id.clone());
+        let active_terminal_id = self.active_terminal_id.clone();
+        let mut killed_agents = 0;
+        let mut killed_terminals = 0;
+        let mut selected_agent_killed = false;
+        let mut active_terminal_killed = false;
+
+        for target_id in target_ids {
+            match target_id {
+                RuntimeTargetId::Agent(session_id) => {
+                    if self.providers.remove(session_id).is_some() {
+                        self.mark_session_status(session_id, SessionStatus::Detached);
+                        killed_agents += 1;
+                        if selected_session_id.as_deref() == Some(session_id.as_str()) {
+                            selected_agent_killed = true;
+                        }
+                    }
+                }
+                RuntimeTargetId::Terminal(terminal_id) => {
+                    if self.companion_terminals.remove(terminal_id).is_some() {
+                        killed_terminals += 1;
+                        if active_terminal_id.as_deref() == Some(terminal_id.as_str()) {
+                            active_terminal_killed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if active_terminal_killed {
+            self.active_terminal_id = None;
+            if self.session_surface == SessionSurface::Terminal {
+                self.input_target = InputTarget::None;
+                self.fullscreen_overlay = FullscreenOverlay::None;
+                self.session_surface = SessionSurface::Agent;
+            }
+        }
+
+        if selected_agent_killed && self.session_surface == SessionSurface::Agent {
+            self.input_target = InputTarget::None;
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.focus = FocusPane::Left;
+        }
+
+        self.clamp_terminal_cursor();
+        self.has_active_processes
+            .store(self.running_process_count() > 0, Ordering::Relaxed);
+
+        (killed_agents, killed_terminals)
+    }
+
     fn session_label(&self, session: &AgentSession) -> String {
         session
             .title

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -691,16 +691,16 @@ impl App {
                 continue;
             }
             let project_name = self.project_name_for_session(session);
-            let label = self.session_label(session);
-            let context = format!(
-                "project: {project_name} | provider: {} | agent: {label}",
-                session.provider.as_str()
-            );
+            let agent_name = self.session_label(session);
+            let provider_name = session.provider.as_str();
+            let label = format!("{} {agent_name}", Self::title_case_word(provider_name));
+            let context = format!("under project {project_name}");
             let search_text = format!(
-                "{} {} {} {}",
+                "{} {} {} {} {}",
                 label,
                 context,
-                session.provider.as_str(),
+                provider_name,
+                agent_name,
                 KillableRuntimeKind::Agent.noun()
             );
             runtimes.push(KillableRuntime {
@@ -724,17 +724,24 @@ impl App {
                     )
                 })
                 .unwrap_or_else(|| ("unknown".to_string(), terminal.session_id.clone()));
-            let context = format!("project: {project_name} | agent: {session_label}");
+            let foreground = terminal
+                .foreground_cmd
+                .clone()
+                .filter(|cmd| !cmd.trim().is_empty())
+                .unwrap_or_else(|| "shell".to_string());
+            let label = format!("TERM {foreground}");
+            let context = format!("on agent {session_label} under project {project_name}");
             let search_text = format!(
-                "{} {} {}",
-                terminal.label,
+                "{} {} {} {}",
+                label,
                 context,
+                terminal.label,
                 KillableRuntimeKind::Terminal.noun()
             );
             runtimes.push(KillableRuntime {
                 id: RuntimeTargetId::Terminal(terminal_id.clone()),
                 kind: KillableRuntimeKind::Terminal,
-                label: terminal.label.clone(),
+                label,
                 context,
                 search_text,
             });
@@ -767,6 +774,14 @@ impl App {
             .filter(|(_, runtime)| runtime.search_text.to_lowercase().contains(&needle))
             .map(|(index, _)| index)
             .collect()
+    }
+
+    fn title_case_word(word: &str) -> String {
+        let mut chars = word.chars();
+        match chars.next() {
+            Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+            None => String::new(),
+        }
     }
 
     pub(crate) fn clamp_kill_running_prompt(prompt: &mut KillRunningPrompt) {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -62,7 +62,9 @@ pub enum Action {
     AddCurrentDir,
     Confirm,
     ToggleSelection,
+    ToggleMarked,
     // Palette-only (no direct keybinding)
+    KillRunning,
     RenameSession,
     DeleteProject,
     RemoveProject,
@@ -82,6 +84,7 @@ pub enum BindingScope {
     Resize,
     Palette,
     Browser,
+    RuntimeKill,
     Dialog,
     CommitInput,
     Help,
@@ -99,6 +102,7 @@ impl BindingScope {
             Self::Resize => "Resize mode",
             Self::Palette => "Command palette",
             Self::Browser => "Project browser",
+            Self::RuntimeKill => "Kill running modal",
             Self::Dialog => "Dialog",
             Self::CommitInput => "Commit input",
             Self::Help => "Help overlay",
@@ -193,6 +197,8 @@ impl Action {
             Action::AddCurrentDir => "add_current_dir",
             Action::Confirm => "confirm",
             Action::ToggleSelection => "toggle_selection",
+            Action::ToggleMarked => "toggle_marked",
+            Action::KillRunning => "kill_running",
             Action::RenameSession => "rename_session",
             Action::DeleteProject => "delete_project",
             Action::RemoveProject => "remove_project",
@@ -261,6 +267,10 @@ impl Action {
             Action::AddCurrentDir => "Add the current directory as a project.",
             Action::Confirm => "Confirm the selected action in a dialog.",
             Action::ToggleSelection => "Toggle between options in a confirmation dialog.",
+            Action::ToggleMarked => "Toggle the hovered runtime in the kill-running modal.",
+            Action::KillRunning => {
+                "Open the kill-running modal for agents and companion terminals."
+            }
             Action::RenameSession => "Rename the selected agent session.",
             Action::DeleteProject => "Remove the selected project and its sessions.",
             Action::RemoveProject => "Remove project from app (keeps files on disk).",
@@ -321,8 +331,10 @@ impl Action {
             | Action::OpenEntry
             | Action::AddCurrentDir
             | Action::Confirm
-            | Action::ToggleSelection => Some("Overlays"),
-            Action::RenameSession
+            | Action::ToggleSelection
+            | Action::ToggleMarked => Some("Overlays"),
+            Action::KillRunning
+            | Action::RenameSession
             | Action::DeleteProject
             | Action::RemoveProject
             | Action::SortAgentsByUpdated
@@ -372,6 +384,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             BindingScope::Files,
             BindingScope::Palette,
             BindingScope::Browser,
+            BindingScope::RuntimeKill,
             BindingScope::Help,
         ],
         help: Some(HelpEntry {
@@ -393,6 +406,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             BindingScope::Files,
             BindingScope::Palette,
             BindingScope::Browser,
+            BindingScope::RuntimeKill,
             BindingScope::Help,
         ],
         help: None, // covered by MoveDown's combined label
@@ -819,7 +833,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::FocusNext,
         default_keys: &[key!(tab)],
-        scopes: &[BindingScope::Global],
+        scopes: &[BindingScope::Global, BindingScope::RuntimeKill],
         help: Some(HelpEntry {
             section: "Global",
             description: "Focus next pane",
@@ -830,7 +844,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::FocusPrev,
         default_keys: &[key!(shift - tab)],
-        scopes: &[BindingScope::Global],
+        scopes: &[BindingScope::Global, BindingScope::RuntimeKill],
         help: Some(HelpEntry {
             section: "Global",
             description: "Focus previous pane",
@@ -922,6 +936,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             BindingScope::Global,
             BindingScope::Palette,
             BindingScope::Browser,
+            BindingScope::RuntimeKill,
             BindingScope::Dialog,
         ],
         help: Some(HelpEntry {
@@ -961,7 +976,11 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             KeyCode::Char('/'),
             KeyModifiers::NONE,
         )],
-        scopes: &[BindingScope::Palette, BindingScope::Browser],
+        scopes: &[
+            BindingScope::Palette,
+            BindingScope::Browser,
+            BindingScope::RuntimeKill,
+        ],
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Toggle search mode",
@@ -1005,7 +1024,11 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::Confirm,
         default_keys: &[key!(enter)],
-        scopes: &[BindingScope::Dialog, BindingScope::Palette],
+        scopes: &[
+            BindingScope::Dialog,
+            BindingScope::Palette,
+            BindingScope::RuntimeKill,
+        ],
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Confirm the selected action",
@@ -1024,7 +1047,29 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[],
         palette: None,
     },
+    BindingDef {
+        action: Action::ToggleMarked,
+        default_keys: &[key!(space)],
+        scopes: &[BindingScope::RuntimeKill],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Toggle the hovered runtime selection",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
     // ── Palette-only (no direct keybinding) ────────────────────────
+    BindingDef {
+        action: Action::KillRunning,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "kill-running",
+            description: "Open a modal to kill running agents and companion terminals",
+        }),
+    },
     BindingDef {
         action: Action::RenameSession,
         default_keys: &[key!(e)],
@@ -1730,6 +1775,17 @@ mod tests {
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
         assert!(names.contains(&"fork-agent"));
+    }
+
+    #[test]
+    fn filtered_palette_includes_kill_running_command() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("kill");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"kill-running"));
     }
 
     #[test]

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 pub enum StatusTone {
     Info,
     Busy,
+    Warning,
     Error,
 }
 
@@ -34,6 +35,12 @@ impl StatusLine {
         self.since = Instant::now();
     }
 
+    pub fn warning(&mut self, message: impl Into<String>) {
+        self.message = message.into();
+        self.tone = StatusTone::Warning;
+        self.since = Instant::now();
+    }
+
     pub fn error(&mut self, message: impl Into<String>) {
         self.message = message.into();
         self.tone = StatusTone::Error;
@@ -43,6 +50,7 @@ impl StatusLine {
     pub fn text(&self) -> String {
         match self.tone {
             StatusTone::Busy => format!("{} {}", self.spinner_frame(), self.message),
+            StatusTone::Warning => format!("[warning] {}", self.message),
             StatusTone::Error => format!("[error] {}", self.message),
             StatusTone::Info => self.message.clone(),
         }
@@ -56,5 +64,18 @@ impl StatusLine {
         const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
         let index = ((self.since.elapsed().as_millis() / 100) as usize) % FRAMES.len();
         FRAMES[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StatusLine, StatusTone};
+
+    #[test]
+    fn warning_tone_formats_with_warning_prefix() {
+        let mut status = StatusLine::new("ready");
+        status.warning("something changed");
+        assert_eq!(status.tone(), StatusTone::Warning);
+        assert_eq!(status.text(), "[warning] something changed");
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -60,6 +60,7 @@ pub struct Theme {
     pub diff_binary_fg: Color,
     pub diff_stat_add_fg: Color,
     pub diff_stat_remove_fg: Color,
+    pub runtime_context_value_fg: Color,
 }
 
 impl Theme {
@@ -121,6 +122,7 @@ impl Theme {
             diff_binary_fg: Color::Yellow,
             diff_stat_add_fg: Color::Green,
             diff_stat_remove_fg: Color::Red,
+            runtime_context_value_fg: Color::Rgb(125, 150, 160),
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -161,6 +161,9 @@ impl Theme {
             crate::statusline::StatusTone::Busy => Style::default()
                 .fg(self.status_busy_fg)
                 .bg(self.status_busy_bg),
+            crate::statusline::StatusTone::Warning => {
+                Style::default().fg(self.warning_fg).bg(self.status_info_bg)
+            }
             crate::statusline::StatusTone::Error => Style::default()
                 .fg(self.status_error_fg)
                 .bg(self.status_error_bg),
@@ -171,6 +174,7 @@ impl Theme {
         match tone {
             crate::statusline::StatusTone::Info => ("●", self.session_active),
             crate::statusline::StatusTone::Busy => ("●", self.session_detached),
+            crate::statusline::StatusTone::Warning => ("●", self.warning_fg),
             crate::statusline::StatusTone::Error => ("●", self.status_error_fg),
         }
     }


### PR DESCRIPTION
This adds a dedicated `kill-running` workflow to `dux` so stuck agents and companion terminals can be stopped from the command palette without touching worktrees or session metadata. The picker is built as a modal instead of a direct hotkey to keep the destructive path explicit and consistent with the rest of the app.

Inside the modal you can **search**, select entries with `Space`, keep selections while filtering, and choose between `Kill Hovered`, `Kill Selected`, or `Kill Visible`. Each path opens a second confirmation step that calls out exactly how many runtimes will be stopped before anything is killed.

This also adds a real warning status tone for the bottom status line so stale kill targets are treated as idempotent warnings rather than errors. Verification included `cargo fmt`, `cargo test`, and `cargo run -- --help`.

<img width="1232" height="701" alt="image" src="https://github.com/user-attachments/assets/6a134146-ac74-44c7-95a7-80d270fe5eb1" />
