### PR TITLE
Fix command palette j/k keys being swallowed as navigation

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -55,8 +55,6 @@ fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
         && row < rect.y + rect.height
 }
 
-use super::text_input::clamp_cursor;
-
 fn cursor_from_single_line_position(
     text: &str,
     text_area: Rect,
@@ -198,7 +196,6 @@ impl App {
                     self.prompt = PromptState::Command {
                         input: TextInput::new(),
                         selected: 0,
-                        searching: false,
                     };
                     self.set_info("Command palette opened.");
                 }
@@ -949,17 +946,11 @@ impl App {
 
     fn handle_prompt_key(&mut self, key: KeyEvent) -> Result<bool> {
         if matches!(self.prompt, PromptState::Command { .. }) {
-            // Determine search state and do binding lookup before taking a mutable borrow.
-            let is_searching = matches!(
-                self.prompt,
-                PromptState::Command {
-                    searching: true,
-                    ..
-                }
-            );
+            // Plain character keys always go to TextInput so j/k etc. can be
+            // typed without conflicting with navigation bindings.
             let is_plain_char = matches!(key.code, KeyCode::Char(_))
                 && !key.modifiers.contains(KeyModifiers::CONTROL);
-            let action = if is_searching && is_plain_char {
+            let action = if is_plain_char {
                 None
             } else {
                 self.bindings.lookup(&key, BindingScope::Palette)
@@ -967,22 +958,7 @@ impl App {
 
             match action {
                 Some(Action::CloseOverlay) => {
-                    if is_searching {
-                        if let PromptState::Command { searching, .. } = &mut self.prompt {
-                            *searching = false;
-                        }
-                    } else {
-                        self.prompt = PromptState::None;
-                    }
-                }
-                Some(Action::SearchToggle) if !is_searching => {
-                    if let PromptState::Command {
-                        input, searching, ..
-                    } = &mut self.prompt
-                    {
-                        input.cursor = clamp_cursor(&input.text, input.text.len());
-                        *searching = true;
-                    }
+                    self.prompt = PromptState::None;
                 }
                 Some(Action::MoveDown) => {
                     if let PromptState::Command {
@@ -1003,13 +979,7 @@ impl App {
                     }
                 }
                 Some(Action::Confirm) => {
-                    if is_searching {
-                        if let PromptState::Command { searching, .. } = &mut self.prompt {
-                            *searching = false;
-                        }
-                    } else {
-                        self.execute_selected_command_palette();
-                    }
+                    self.execute_selected_command_palette();
                 }
                 _ => {
                     // Text input fallback: Tab (autocomplete), then delegate to TextInput.
@@ -1892,7 +1862,7 @@ impl App {
             _ => return,
         };
         if let PromptState::Command { input, .. } = &mut self.prompt {
-            let prefix_width = 2; // "> " or "/ "
+            let prefix_width = 2; // "> "
             input.cursor =
                 cursor_from_single_line_position(&input.text, input_area, prefix_width, column);
         }
@@ -4391,12 +4361,41 @@ mod tests {
     }
 
     #[test]
+    fn command_palette_jk_keys_insert_text_instead_of_navigating() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::Command {
+            input: TextInput::new(),
+            selected: 0,
+        };
+
+        // Press 'j' — should insert into text, not move selection down.
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::Command { input, selected, .. } => {
+                assert_eq!(input.text, "j");
+                assert_eq!(*selected, 0, "selection should stay at 0, not move down");
+            }
+            other => panic!("expected command prompt, got {other:?}"),
+        }
+
+        // Press 'k' — should also insert, not move selection up.
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::Command { input, .. } => {
+                assert_eq!(input.text, "jk");
+            }
+            other => panic!("expected command prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn mouse_click_command_palette_row_selects_then_double_click_executes() {
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::Command {
             input: TextInput::with_text("help".to_string()),
             selected: 0,
-            searching: false,
         };
         install_command_overlay(&mut app, 1);
 
@@ -4417,7 +4416,6 @@ mod tests {
         app.prompt = PromptState::Command {
             input: TextInput::with_text("help".to_string()),
             selected: 0,
-            searching: false,
         };
         install_command_overlay(&mut app, 1);
 
@@ -5063,7 +5061,6 @@ mod tests {
         app.prompt = PromptState::Command {
             input: TextInput::with_text("help".to_string()),
             selected: 0,
-            searching: false,
         };
         install_command_overlay(&mut app, 1);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -303,7 +303,6 @@ pub(crate) enum PromptState {
     Command {
         input: TextInput,
         selected: usize,
-        searching: bool,
     },
     BrowseProjects {
         current_dir: PathBuf,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1450,11 +1450,7 @@ impl App {
 
     fn render_prompt(&mut self, frame: &mut Frame) {
         match &self.prompt {
-            PromptState::Command {
-                input,
-                selected,
-                searching,
-            } => {
+            PromptState::Command { input, selected } => {
                 self.render_dim_overlay(frame);
                 let popup = centered_rect(72, 40, frame.area());
                 Clear.render(popup, frame.buffer_mut());
@@ -1501,50 +1497,27 @@ impl App {
                     .direction(Direction::Vertical)
                     .constraints([Constraint::Length(3), Constraint::Min(3)])
                     .areas(popup);
-                let title = if *searching {
-                    "Command Palette (searching)"
-                } else {
-                    "Command Palette"
-                };
+                let title = "Command Palette";
                 let confirm_key = self.bindings.label_for(Action::Confirm);
                 let close_key = self.bindings.label_for(Action::CloseOverlay);
-                let search_key = self.bindings.label_for(Action::SearchToggle);
                 let mut bottom_spans = vec![Span::raw(" ")];
-                if *searching {
-                    bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
-                    bottom_spans.push(Span::styled(
-                        " done  ",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                    bottom_spans.extend(self.theme.key_badge_default(&close_key));
-                    bottom_spans.push(Span::styled(
-                        " clear",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                } else {
-                    bottom_spans.extend(self.theme.key_badge_default(&search_key));
-                    bottom_spans.push(Span::styled(
-                        " search  ",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                    bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
-                    bottom_spans.push(Span::styled(
-                        " run  ",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                    // Tab autocomplete is text-input behavior, not a rebindable action.
-                    bottom_spans.extend(self.theme.key_badge_default("Tab"));
-                    bottom_spans.push(Span::styled(
-                        " complete  ",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                    bottom_spans.extend(self.theme.key_badge_default(&close_key));
-                    bottom_spans.push(Span::styled(
-                        " cancel",
-                        Style::default().fg(self.theme.hint_desc_fg),
-                    ));
-                }
-                let prompt_prefix = if *searching { "/ " } else { "> " };
+                bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
+                bottom_spans.push(Span::styled(
+                    " run  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                // Tab autocomplete is text-input behavior, not a rebindable action.
+                bottom_spans.extend(self.theme.key_badge_default("Tab"));
+                bottom_spans.push(Span::styled(
+                    " complete  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                let prompt_prefix = "> ";
                 let input_block = self
                     .themed_overlay_block(title)
                     .title_bottom(Line::from(bottom_spans));

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -976,11 +976,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             KeyCode::Char('/'),
             KeyModifiers::NONE,
         )],
-        scopes: &[
-            BindingScope::Palette,
-            BindingScope::Browser,
-            BindingScope::RuntimeKill,
-        ],
+        scopes: &[BindingScope::Browser, BindingScope::RuntimeKill],
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Toggle search mode",


### PR DESCRIPTION
The command palette (`Ctrl+P`) had a dual-mode design: a **browse mode** where `j`/`k` navigated the list, and a **search mode** (toggled with `/`) where they were treated as text input. Since the text input field was always visible and accepted most keystrokes on open, users would naturally start typing to filter commands — only to find that `j` and `k` were silently consumed as navigation instead of being inserted. This made the palette feel broken for any command containing those letters.

This change removes the dual-mode concept entirely. Plain character keys now **always** go to the text input, while `Up`/`Down` arrow keys handle list navigation. The `searching` state, the `/` toggle, and all the conditional rendering it drove (title suffix, hint bar variants, prompt prefix) have been removed. The existing `filtered_palette()` ranking — which already prioritizes command name matches over description matches — is now always active as the user types.

Files changed: `src/app/mod.rs` (removed `searching` field from `PromptState::Command`), `src/app/input.rs` (simplified key dispatch, removed `SearchToggle` handling and unused `clamp_cursor` import), `src/app/render.rs` (unified hint bar and removed search-mode conditionals), `src/keybindings.rs` (removed `Palette` scope from `SearchToggle`). All 284 tests pass, clippy is clean.