### PR TITLE
Allow Ctrl+G to toggle interactive mode in both directions

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -335,7 +335,9 @@ impl App {
                         self.reload_changed_files();
                     }
                 }
-                Action::FocusAgent => self.activate_selected_left_item()?,
+                Action::FocusAgent | Action::ExitInteractive => {
+                    self.activate_selected_left_item()?
+                }
                 Action::OpenProjectBrowser => {
                     self.open_project_browser()?;
                 }
@@ -400,7 +402,7 @@ impl App {
                         }
                     }
                 }
-                Action::FocusAgent => {
+                Action::FocusAgent | Action::ExitInteractive => {
                     // Open terminal overlay for the selected terminal item.
                     self.open_terminal_from_terminal_list()?;
                 }
@@ -864,10 +866,18 @@ impl App {
         for action in actions {
             match action {
                 SeqAction::Intercept(Action::ExitInteractive, _, _) => {
+                    let return_to_terminal_list =
+                        matches!(self.input_target, InputTarget::Terminal)
+                            && self.terminal_return_to_list;
                     self.input_target = InputTarget::None;
                     self.fullscreen_overlay = FullscreenOverlay::None;
                     self.session_surface = SessionSurface::Agent;
                     self.raw_input_buf.clear();
+                    if return_to_terminal_list {
+                        self.left_section = LeftSection::Terminals;
+                        self.clamp_terminal_cursor();
+                        self.focus = FocusPane::Left;
+                    }
                     self.set_info("Exited interactive mode.");
                     return Ok(false);
                 }
@@ -2984,6 +2994,7 @@ mod tests {
             providers: std::collections::HashMap::new(),
             companion_terminals: std::collections::HashMap::new(),
             active_terminal_id: None,
+            terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
@@ -4882,14 +4893,23 @@ mod tests {
         assert_eq!(matched, Some((Action::ExitInteractive, false)));
 
         // Apply the same state change that poll_and_forward_raw_input does.
+        let return_to_list =
+            matches!(app.input_target, InputTarget::Terminal) && app.terminal_return_to_list;
         app.input_target = InputTarget::None;
         app.fullscreen_overlay = FullscreenOverlay::None;
         app.session_surface = SessionSurface::Agent;
         app.raw_input_buf.clear();
+        if return_to_list {
+            app.left_section = LeftSection::Terminals;
+            app.focus = FocusPane::Left;
+        }
 
+        // Launched via `t` → returns to terminals list on the left pane.
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
         assert_eq!(app.session_surface, SessionSurface::Agent);
         assert_eq!(app.input_target, InputTarget::None);
+        assert_eq!(app.left_section, LeftSection::Terminals);
+        assert_eq!(app.focus, FocusPane::Left);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4893,6 +4893,32 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_g_enters_interactive_mode_from_center_pane() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Center;
+        app.center_mode = CenterMode::Agent;
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn(
+                "sh",
+                &["-c".to_string(), "printf ready; sleep 0.2".to_string()],
+                std::path::Path::new("."),
+                10,
+                10,
+                100,
+            )
+            .expect("spawn pty"),
+        );
+
+        // Ctrl+G from non-interactive center pane should enter interactive mode.
+        app.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL))
+            .unwrap();
+
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
+    }
+
+    #[test]
     fn close_top_overlay_closes_terminal_overlay() {
         let mut app = test_app(default_bindings());
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -418,6 +418,7 @@ impl App {
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Center) {
             match action {
                 Action::FocusAgent if !in_diff => self.activate_center_agent()?,
+                Action::ExitInteractive if !in_diff => self.activate_center_agent()?,
                 Action::ShowTerminal if !in_diff => self.show_companion_terminal()?,
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
@@ -4372,7 +4373,9 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
             .unwrap();
         match &app.prompt {
-            PromptState::Command { input, selected, .. } => {
+            PromptState::Command {
+                input, selected, ..
+            } => {
                 assert_eq!(input.text, "j");
                 assert_eq!(*selected, 0, "selection should stay at 0, not move down");
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -88,6 +88,7 @@ pub struct App {
     pub(crate) providers: HashMap<String, PtyClient>,
     pub(crate) companion_terminals: HashMap<String, CompanionTerminal>,
     pub(crate) active_terminal_id: Option<String>,
+    pub(crate) terminal_return_to_list: bool,
     pub(crate) terminal_counter: usize,
     pub(crate) create_agent_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
@@ -626,6 +627,7 @@ impl App {
             providers: HashMap::new(),
             companion_terminals: HashMap::new(),
             active_terminal_id: None,
+            terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
@@ -729,9 +731,15 @@ impl App {
 
     pub(crate) fn close_top_overlay(&mut self) -> bool {
         if matches!(self.fullscreen_overlay, FullscreenOverlay::Terminal) {
+            let return_to_list = self.terminal_return_to_list;
             self.fullscreen_overlay = FullscreenOverlay::None;
             self.session_surface = SessionSurface::Agent;
             self.input_target = InputTarget::None;
+            if return_to_list {
+                self.left_section = LeftSection::Terminals;
+                self.clamp_terminal_cursor();
+                self.focus = FocusPane::Left;
+            }
             let key = self.bindings.label_for(Action::ToggleFullscreen);
             self.set_info(format!(
                 "Closed fullscreen terminal. Press {key} to reopen."

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -256,6 +256,7 @@ impl App {
             },
         );
         self.active_terminal_id = Some(terminal_id);
+        self.terminal_return_to_list = true;
         self.show_companion_terminal_surface();
         self.input_target = InputTarget::Terminal;
         self.set_info(format!(
@@ -287,6 +288,7 @@ impl App {
         self.reload_changed_files();
 
         self.active_terminal_id = Some(terminal_id);
+        self.terminal_return_to_list = false;
         self.show_companion_terminal_surface();
         self.input_target = InputTarget::Terminal;
         self.set_info(format!("Opened terminal \"{label}\"."));

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -623,7 +623,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::ExitInteractive,
         default_keys: &[key!(ctrl - g)],
-        scopes: &[BindingScope::Interactive],
+        scopes: &[BindingScope::Interactive, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Agent pane",
             description: "Exit interactive mode",

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -623,7 +623,11 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::ExitInteractive,
         default_keys: &[key!(ctrl - g)],
-        scopes: &[BindingScope::Interactive, BindingScope::Center],
+        scopes: &[
+            BindingScope::Interactive,
+            BindingScope::Center,
+            BindingScope::Left,
+        ],
         help: Some(HelpEntry {
             section: "Agent pane",
             description: "Exit interactive mode",


### PR DESCRIPTION
Currently, `Ctrl+G` only exits interactive mode while `Enter` is the only way to enter it. This change makes `Ctrl+G` work as a full toggle: pressing it from the non-interactive center pane enters interactive mode, and pressing it again exits. The `Enter` key continues to work as before, so existing muscle memory is preserved.

The implementation adds the `ExitInteractive` action to the `BindingScope::Center` scope and handles it in `handle_center_key` by calling the existing `activate_center_agent()` method — which already contains all the necessary guards (active PTY check, diff-mode exclusion, session existence). This means the toggle reuses the same code path as `Enter` with no new actions or keybinding definitions needed.

The toggle is intentionally not promoted in footer hints or the help overlay, keeping it as a power-user shortcut for those who prefer a single key to flip in and out of interactive mode.