### PR TITLE
Fix Linux worktree path copying

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2854,6 +2854,7 @@ mod tests {
         KillableRuntime, KillableRuntimeKind, LeftSection, MouseLayoutState, OverlayMouseLayout,
         OverlayMouseLayoutState, PromptState, RightSection, RuntimeTargetId, TextInput,
     };
+    use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
@@ -2978,6 +2979,7 @@ mod tests {
             prompt: PromptState::None,
             input_target: InputTarget::None,
             session_surface: crate::model::SessionSurface::Agent,
+            clipboard: Clipboard::new(),
             worker_tx,
             worker_rx,
             providers: std::collections::HashMap::new(),
@@ -3099,6 +3101,14 @@ mod tests {
         app.overlay_layout.active = OverlayMouseLayout::RenameSession {
             input: Rect::new(24, 10, 30, 1),
         };
+    }
+
+    fn clipboard_ok(_: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn clipboard_fail(_: &str) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("linux clipboard unavailable"))
     }
 
     fn sample_runtime(
@@ -3620,6 +3630,59 @@ mod tests {
                 .text()
                 .contains("Select an agent session first to fork.")
         );
+    }
+
+    #[test]
+    fn copy_path_copies_selected_session_worktree() {
+        let mut app = test_app(default_bindings());
+        let worktree_path = app.sessions[0].worktree_path.clone();
+        app.clipboard = Clipboard::from_fn(clipboard_ok);
+
+        app.copy_selected_path().unwrap();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+        assert!(app.status.text().contains(&worktree_path));
+    }
+
+    #[test]
+    fn copy_path_copies_selected_project_path() {
+        let mut app = test_app(default_bindings());
+        let project_path = app.projects[0].path.clone();
+        app.selected_left = 0;
+        app.clipboard = Clipboard::from_fn(clipboard_ok);
+
+        app.copy_selected_path().unwrap();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+        assert!(app.status.text().contains(&project_path));
+    }
+
+    #[test]
+    fn copy_path_requires_project_or_session_selection() {
+        let mut app = test_app(default_bindings());
+        app.left_items_cache.clear();
+        app.selected_left = 0;
+
+        app.copy_selected_path().unwrap();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(
+            app.status
+                .text()
+                .contains("No project or agent selected. Select one from the sidebar first.")
+        );
+    }
+
+    #[test]
+    fn copy_path_failure_sets_error_status() {
+        let mut app = test_app(default_bindings());
+        app.clipboard = Clipboard::from_fn(clipboard_fail);
+
+        app.copy_selected_path().unwrap();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(app.status.text().contains("Copy path failed"));
+        assert!(app.status.text().contains("linux clipboard unavailable"));
     }
 
     #[test]
@@ -4372,7 +4435,9 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
             .unwrap();
         match &app.prompt {
-            PromptState::Command { input, selected, .. } => {
+            PromptState::Command {
+                input, selected, ..
+            } => {
                 assert_eq!(input.text, "j");
                 assert_eq!(*selected, 0, "selection should stay at 0, not move down");
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,7 @@ use ratatui::widgets::{
 };
 use uuid::Uuid;
 
+use crate::clipboard::Clipboard;
 use crate::config::{
     Config, DuxPaths, ProjectConfig, ProviderCommandConfig, check_provider_available,
     ensure_config, save_config, validate_keys,
@@ -83,6 +84,7 @@ pub struct App {
     pub(crate) prompt: PromptState,
     pub(crate) input_target: InputTarget,
     pub(crate) session_surface: SessionSurface,
+    pub(crate) clipboard: Clipboard,
     pub(crate) worker_tx: Sender<WorkerEvent>,
     pub(crate) worker_rx: Receiver<WorkerEvent>,
     pub(crate) providers: HashMap<String, PtyClient>,
@@ -621,6 +623,7 @@ impl App {
             prompt: PromptState::None,
             input_target: InputTarget::None,
             session_surface: SessionSurface::Agent,
+            clipboard: Clipboard::new(),
             worker_tx,
             worker_rx,
             providers: HashMap::new(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2135,8 +2135,6 @@ impl App {
                         } else {
                             self.theme.button_confirm_border
                         }
-                    } else if !enabled {
-                        self.theme.border_normal
                     } else {
                         self.theme.border_normal
                     };

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -566,12 +566,10 @@ impl App {
         };
         match path {
             Some(p) => {
-                let mut clipboard = arboard::Clipboard::new()
-                    .map_err(|e| anyhow::anyhow!("Failed to access clipboard: {e}"))?;
-                clipboard
-                    .set_text(&p)
-                    .map_err(|e| anyhow::anyhow!("Failed to copy to clipboard: {e}"))?;
-                self.set_info(format!("Copied path to clipboard: \"{p}\""));
+                match self.clipboard.copy_text(&p) {
+                    Ok(()) => self.set_info(format!("Copied path to clipboard: \"{p}\"")),
+                    Err(err) => self.set_error(format!("Copy path failed: {err}")),
+                }
                 Ok(())
             }
             None => {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,339 @@
+use std::collections::HashSet;
+use std::env;
+use std::ffi::OsStr;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow};
+
+pub(crate) struct Clipboard {
+    copy_text_fn: fn(&str) -> Result<()>,
+}
+
+impl Clipboard {
+    pub(crate) fn new() -> Self {
+        Self {
+            copy_text_fn: copy_text_impl,
+        }
+    }
+
+    pub(crate) fn copy_text(&self, text: &str) -> Result<()> {
+        (self.copy_text_fn)(text)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_fn(copy_text_fn: fn(&str) -> Result<()>) -> Self {
+        Self { copy_text_fn }
+    }
+}
+
+fn copy_text_impl(text: &str) -> Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        copy_text_linux(text)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        copy_text_arboard(text)
+    }
+}
+
+fn copy_text_arboard(text: &str) -> Result<()> {
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|e| anyhow!("Failed to access clipboard: {e}"))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| anyhow!("Failed to copy to clipboard: {e}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LinuxClipboardBackend {
+    WlCopy,
+    Xclip,
+    Xsel,
+    Arboard,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxClipboardBackend {
+    fn label(self) -> &'static str {
+        match self {
+            Self::WlCopy => "wl-copy",
+            Self::Xclip => "xclip",
+            Self::Xsel => "xsel",
+            Self::Arboard => "arboard",
+        }
+    }
+
+    fn command_spec(self) -> Option<LinuxClipboardCommand> {
+        match self {
+            Self::WlCopy => Some(LinuxClipboardCommand {
+                program: "wl-copy",
+                args: &[],
+            }),
+            Self::Xclip => Some(LinuxClipboardCommand {
+                program: "xclip",
+                args: &["-selection", "clipboard"],
+            }),
+            Self::Xsel => Some(LinuxClipboardCommand {
+                program: "xsel",
+                args: &["--clipboard", "--input"],
+            }),
+            Self::Arboard => None,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LinuxClipboardCommand {
+    program: &'static str,
+    args: &'static [&'static str],
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default)]
+struct LinuxClipboardEnvironment {
+    wayland_display: bool,
+    x11_display: bool,
+    executables: HashSet<String>,
+}
+
+#[cfg(target_os = "linux")]
+impl LinuxClipboardEnvironment {
+    fn current() -> Self {
+        let executables = env::var_os("PATH")
+            .map(|path| executable_names_on_path(&path))
+            .unwrap_or_default();
+        Self {
+            wayland_display: has_env_var("WAYLAND_DISPLAY"),
+            x11_display: has_env_var("DISPLAY"),
+            executables,
+        }
+    }
+
+    fn has_command(&self, command: &str) -> bool {
+        self.executables.contains(command)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn has_env_var(key: &str) -> bool {
+    env::var_os(key)
+        .map(|value| !value.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn executable_names_on_path(path: &OsStr) -> HashSet<String> {
+    let mut names = HashSet::new();
+
+    for dir in env::split_paths(path) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                names.insert(normalize_executable_name(name));
+            }
+        }
+    }
+
+    names
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_executable_name(value: &str) -> String {
+    Path::new(value)
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or(value)
+        .to_ascii_lowercase()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_backends(env: &LinuxClipboardEnvironment) -> Vec<LinuxClipboardBackend> {
+    let mut backends = Vec::new();
+
+    if env.wayland_display && env.has_command("wl-copy") {
+        backends.push(LinuxClipboardBackend::WlCopy);
+    }
+    if env.x11_display && env.has_command("xclip") {
+        backends.push(LinuxClipboardBackend::Xclip);
+    }
+    if env.x11_display && env.has_command("xsel") {
+        backends.push(LinuxClipboardBackend::Xsel);
+    }
+
+    backends.push(LinuxClipboardBackend::Arboard);
+    backends
+}
+
+#[cfg(target_os = "linux")]
+fn copy_text_linux(text: &str) -> Result<()> {
+    let env = LinuxClipboardEnvironment::current();
+    let mut errors = Vec::new();
+
+    for backend in linux_backends(&env) {
+        let result = match backend.command_spec() {
+            Some(command) => run_linux_clipboard_command(command, text),
+            None => copy_text_arboard(text),
+        };
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(err) => errors.push(format!("{}: {err}", backend.label())),
+        }
+    }
+
+    Err(anyhow!(format_linux_clipboard_error(&env, &errors)))
+}
+
+#[cfg(target_os = "linux")]
+fn run_linux_clipboard_command(command: LinuxClipboardCommand, text: &str) -> Result<()> {
+    let mut child = Command::new(command.program)
+        .args(command.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("Failed to launch {}", command.program))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text.as_bytes())
+            .with_context(|| format!("Failed to write to {}", command.program))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("Failed to wait for {}", command.program))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let detail = if stderr.is_empty() {
+        format!("exited with status {}", output.status)
+    } else {
+        stderr
+    };
+    Err(anyhow!("{detail}"))
+}
+
+#[cfg(target_os = "linux")]
+fn format_linux_clipboard_error(env: &LinuxClipboardEnvironment, errors: &[String]) -> String {
+    let mut message = String::from("Failed to copy path to the Linux clipboard.");
+
+    if !errors.is_empty() {
+        message.push_str(" Tried ");
+        message.push_str(&errors.join("; "));
+        message.push('.');
+    }
+
+    if env.wayland_display {
+        message.push_str(
+            " Install `wl-clipboard` or ensure `wl-copy` can access the active Wayland session.",
+        );
+    } else if env.x11_display {
+        message.push_str(" Install `xclip` or `xsel`, or ensure the X11 clipboard is reachable.");
+    } else {
+        message.push_str(
+            " No `WAYLAND_DISPLAY` or `DISPLAY` session was detected. Install `wl-clipboard` for Wayland or `xclip`/`xsel` for X11.",
+        );
+    }
+
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    fn env_with(
+        wayland_display: bool,
+        x11_display: bool,
+        executables: &[&str],
+    ) -> LinuxClipboardEnvironment {
+        LinuxClipboardEnvironment {
+            wayland_display,
+            x11_display,
+            executables: executables
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect::<HashSet<_>>(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_prefers_wayland_before_x11_helpers() {
+        let env = env_with(true, true, &["wl-copy", "xclip", "xsel"]);
+
+        assert_eq!(
+            linux_backends(&env),
+            vec![
+                LinuxClipboardBackend::WlCopy,
+                LinuxClipboardBackend::Xclip,
+                LinuxClipboardBackend::Xsel,
+                LinuxClipboardBackend::Arboard,
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_uses_x11_helpers_when_wayland_is_unavailable() {
+        let env = env_with(false, true, &["xclip", "xsel"]);
+
+        assert_eq!(
+            linux_backends(&env),
+            vec![
+                LinuxClipboardBackend::Xclip,
+                LinuxClipboardBackend::Xsel,
+                LinuxClipboardBackend::Arboard,
+            ]
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_falls_back_to_arboard_when_no_helpers_are_available() {
+        let env = env_with(false, false, &[]);
+
+        assert_eq!(linux_backends(&env), vec![LinuxClipboardBackend::Arboard]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_backend_command_specs_match_expected_args() {
+        assert_eq!(
+            LinuxClipboardBackend::WlCopy.command_spec(),
+            Some(LinuxClipboardCommand {
+                program: "wl-copy",
+                args: &[],
+            })
+        );
+        assert_eq!(
+            LinuxClipboardBackend::Xclip.command_spec(),
+            Some(LinuxClipboardCommand {
+                program: "xclip",
+                args: &["-selection", "clipboard"],
+            })
+        );
+        assert_eq!(
+            LinuxClipboardBackend::Xsel.command_spec(),
+            Some(LinuxClipboardCommand {
+                program: "xsel",
+                args: &["--clipboard", "--input"],
+            })
+        );
+        assert_eq!(LinuxClipboardBackend::Arboard.command_spec(), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod clipboard;
 mod config;
 mod diff;
 mod editor;


### PR DESCRIPTION
This routes the worktree path copy action through a dedicated clipboard module so Linux can prefer wl-copy, xclip, or xsel before falling back to arboard.

It keeps the existing UI action intact while improving failure handling with clearer status messages when no usable Linux clipboard backend is available.

Verification covered cargo fmt, cargo clippy -- -D warnings, and cargo test -- --nocapture, plus focused regression tests for session copy, project copy, and copy failures.