### PR TITLE
Add collapsible and removable git pane with ] key and command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This means:
 - Center pane for live agent terminal output or file diffs
 - Right pane for changed files and diffs
 - Resizable panes with keyboard shortcuts and mouse drag
-- Collapsible project sidebar
+- Collapsible project sidebar and git pane
 - Command palette with fuzzy search
 - Config written to `~/.config/dux/config.toml` (Linux) or `~/.dux/config.toml` (macOS)
 - Session metadata stored alongside the config directory

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -225,6 +225,9 @@ impl App {
                         }
                     } else {
                         self.focus = self.focus.next();
+                        if self.focus == FocusPane::Files && self.right_hidden {
+                            self.focus = self.focus.next();
+                        }
                         if self.focus == FocusPane::Files {
                             self.right_section = RightSection::first();
                             self.clamp_files_cursor();
@@ -244,6 +247,9 @@ impl App {
                         && self.left_section == LeftSection::Projects
                     {
                         self.focus = self.focus.previous();
+                        if self.focus == FocusPane::Files && self.right_hidden {
+                            self.focus = self.focus.previous();
+                        }
                         if self.focus == FocusPane::Files {
                             self.right_section = RightSection::last(has_staged);
                             self.clamp_files_cursor();
@@ -260,6 +266,9 @@ impl App {
                         }
                     } else {
                         self.focus = self.focus.previous();
+                        if self.focus == FocusPane::Files && self.right_hidden {
+                            self.focus = self.focus.previous();
+                        }
                         if self.focus == FocusPane::Files {
                             self.right_section = RightSection::last(has_staged);
                             self.clamp_files_cursor();
@@ -277,6 +286,18 @@ impl App {
                 }
                 Action::ToggleSidebar => {
                     self.left_collapsed = !self.left_collapsed;
+                }
+                Action::ToggleGitPane => {
+                    self.right_collapsed = !self.right_collapsed;
+                    if self.right_collapsed && self.focus == FocusPane::Files {
+                        self.focus = FocusPane::Center;
+                    }
+                }
+                Action::RemoveGitPane => {
+                    self.right_hidden = !self.right_hidden;
+                    if self.right_hidden && self.focus == FocusPane::Files {
+                        self.focus = FocusPane::Center;
+                    }
                 }
                 Action::ToggleResizeMode => {
                     self.resize_mode = !self.resize_mode;
@@ -1754,7 +1775,7 @@ impl App {
             return Some(ResizeDragState::LeftDivider);
         }
 
-        if column == center_right || column == right_left {
+        if !self.right_hidden && (column == center_right || column == right_left) {
             return Some(ResizeDragState::RightDivider);
         }
 
@@ -2969,6 +2990,8 @@ mod tests {
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             left_collapsed: false,
+            right_collapsed: false,
+            right_hidden: false,
             resize_mode: false,
             help_scroll: None,
             last_help_height: 0,
@@ -4372,7 +4395,9 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
             .unwrap();
         match &app.prompt {
-            PromptState::Command { input, selected, .. } => {
+            PromptState::Command {
+                input, selected, ..
+            } => {
                 assert_eq!(input.text, "j");
                 assert_eq!(*selected, 0, "selection should stay at 0, not move down");
             }
@@ -5068,5 +5093,80 @@ mod tests {
 
         assert_eq!(app.focus, FocusPane::Left);
         assert!(matches!(app.prompt, PromptState::Command { .. }));
+    }
+
+    #[test]
+    fn toggle_git_pane_collapses_right() {
+        let mut app = test_app(default_bindings());
+        assert!(!app.right_collapsed);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE))
+            .unwrap();
+        assert!(app.right_collapsed);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE))
+            .unwrap();
+        assert!(!app.right_collapsed);
+    }
+
+    #[test]
+    fn collapse_git_pane_moves_focus_from_files() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Files;
+
+        app.handle_key(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(app.right_collapsed);
+        assert_eq!(app.focus, FocusPane::Center);
+    }
+
+    #[test]
+    fn remove_git_pane_hides_right() {
+        let mut app = test_app(default_bindings());
+        assert!(!app.right_hidden);
+
+        app.execute_command("remove-git-pane".to_string()).unwrap();
+        assert!(app.right_hidden);
+
+        app.execute_command("remove-git-pane".to_string()).unwrap();
+        assert!(!app.right_hidden);
+    }
+
+    #[test]
+    fn remove_git_pane_moves_focus_from_files() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Files;
+
+        app.execute_command("remove-git-pane".to_string()).unwrap();
+
+        assert!(app.right_hidden);
+        assert_eq!(app.focus, FocusPane::Center);
+    }
+
+    #[test]
+    fn focus_skips_removed_git_pane_forward() {
+        let mut app = test_app(default_bindings());
+        app.right_hidden = true;
+        app.focus = FocusPane::Center;
+
+        // Tab from Center should skip Files and go to Left
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
+    fn focus_skips_removed_git_pane_backward() {
+        let mut app = test_app(default_bindings());
+        app.right_hidden = true;
+        app.focus = FocusPane::Left;
+
+        // Shift-Tab from Left should skip Files and go to Center
+        app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT))
+            .unwrap();
+
+        assert_eq!(app.focus, FocusPane::Center);
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -5126,10 +5126,10 @@ mod tests {
         let mut app = test_app(default_bindings());
         assert!(!app.right_hidden);
 
-        app.execute_command("remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
         assert!(app.right_hidden);
 
-        app.execute_command("remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
         assert!(!app.right_hidden);
     }
 
@@ -5138,7 +5138,7 @@ mod tests {
         let mut app = test_app(default_bindings());
         app.focus = FocusPane::Files;
 
-        app.execute_command("remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
 
         assert!(app.right_hidden);
         assert_eq!(app.focus, FocusPane::Center);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -812,7 +812,7 @@ impl App {
                 }
                 Ok(())
             }
-            "remove-git-pane" => {
+            "toggle-remove-git-pane" => {
                 self.right_hidden = !self.right_hidden;
                 if self.right_hidden && self.focus == FocusPane::Files {
                     self.focus = FocusPane::Center;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,6 +74,8 @@ pub struct App {
     pub(crate) focus: FocusPane,
     pub(crate) center_mode: CenterMode,
     pub(crate) left_collapsed: bool,
+    pub(crate) right_collapsed: bool,
+    pub(crate) right_hidden: bool,
     pub(crate) resize_mode: bool,
     pub(crate) help_scroll: Option<u16>,
     pub(crate) last_help_height: u16,
@@ -610,6 +612,8 @@ impl App {
             commit_scroll: 0,
             commit_generating: false,
             left_collapsed: false,
+            right_collapsed: false,
+            right_hidden: false,
             focus: FocusPane::Left,
             center_mode: CenterMode::Agent,
             resize_mode: false,
@@ -799,6 +803,20 @@ impl App {
             }
             "toggle-sidebar" => {
                 self.left_collapsed = !self.left_collapsed;
+                Ok(())
+            }
+            "toggle-git-pane" => {
+                self.right_collapsed = !self.right_collapsed;
+                if self.right_collapsed && self.focus == FocusPane::Files {
+                    self.focus = FocusPane::Center;
+                }
+                Ok(())
+            }
+            "remove-git-pane" => {
+                self.right_hidden = !self.right_hidden;
+                if self.right_hidden && self.focus == FocusPane::Files {
+                    self.focus = FocusPane::Center;
+                }
                 Ok(())
             }
             "help" => {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -34,25 +34,34 @@ impl App {
             ])
             .areas(frame.area());
         self.render_header(frame, header);
+        let right_constraint = if self.right_hidden {
+            Constraint::Length(0)
+        } else if self.right_collapsed {
+            Constraint::Length(4)
+        } else {
+            Constraint::Percentage(self.right_width_pct)
+        };
+
         let [left, center, right] = if self.left_collapsed {
             Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Length(4),
-                    Constraint::Min(20),
-                    Constraint::Percentage(self.right_width_pct),
-                ])
+                .constraints([Constraint::Length(4), Constraint::Min(20), right_constraint])
                 .areas(body)
         } else {
+            let right_pct = if self.right_hidden || self.right_collapsed {
+                0
+            } else {
+                self.right_width_pct
+            };
             let center_pct = 100u16
-                .saturating_sub(self.left_width_pct + self.right_width_pct)
+                .saturating_sub(self.left_width_pct + right_pct)
                 .max(20);
             Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([
                     Constraint::Percentage(self.left_width_pct),
                     Constraint::Percentage(center_pct),
-                    Constraint::Percentage(self.right_width_pct),
+                    right_constraint,
                 ])
                 .areas(body)
         };
@@ -840,6 +849,39 @@ impl App {
     }
 
     fn render_files(&mut self, frame: &mut Frame, area: Rect) {
+        if self.right_hidden {
+            return;
+        }
+
+        if self.right_collapsed {
+            let focused = self.focus == FocusPane::Files;
+            let all_files: Vec<(&str, Color)> = self
+                .unstaged_files
+                .iter()
+                .chain(self.staged_files.iter())
+                .map(|f| (f.status.as_str(), self.theme.file_status_fg))
+                .collect();
+            let items: Vec<ListItem> = all_files
+                .iter()
+                .map(|(s, color)| {
+                    ListItem::new(Line::from(Span::styled(
+                        format!("{s:>2}"),
+                        Style::default().fg(*color),
+                    )))
+                })
+                .collect();
+            let mut state = ListState::default().with_selected(Some(self.files_index));
+            StatefulWidget::render(
+                List::new(items)
+                    .block(self.themed_block("", focused))
+                    .highlight_style(self.theme.selection_style()),
+                area,
+                frame.buffer_mut(),
+                &mut state,
+            );
+            return;
+        }
+
         let has_staged = !self.staged_files.is_empty();
         let focused = self.focus == FocusPane::Files;
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1167,7 +1167,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         help: None,
         hint_contexts: &[],
         palette: Some(PaletteEntry {
-            name: "remove-git-pane",
+            name: "toggle-remove-git-pane",
             description: "Remove or restore the git pane entirely",
         }),
     },

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -49,6 +49,7 @@ pub enum Action {
     OpenPalette,
     ToggleResizeMode,
     ToggleSidebar,
+    ToggleGitPane,
     ToggleHelp,
     Quit,
     CloseOverlay,
@@ -71,6 +72,7 @@ pub enum Action {
     SortAgentsByUpdated,
     SortAgentsByCreated,
     SortAgentsByName,
+    RemoveGitPane,
 }
 
 /// Where a binding's key combo is matched.
@@ -186,6 +188,7 @@ impl Action {
             Action::OpenPalette => "open_palette",
             Action::ToggleResizeMode => "toggle_resize_mode",
             Action::ToggleSidebar => "toggle_sidebar",
+            Action::ToggleGitPane => "toggle_git_pane",
             Action::ToggleHelp => "toggle_help",
             Action::Quit => "quit",
             Action::CloseOverlay => "close_overlay",
@@ -205,6 +208,7 @@ impl Action {
             Action::SortAgentsByUpdated => "sort_agents_by_updated",
             Action::SortAgentsByCreated => "sort_agents_by_created",
             Action::SortAgentsByName => "sort_agents_by_name",
+            Action::RemoveGitPane => "remove_git_pane",
         }
     }
 
@@ -256,6 +260,7 @@ impl Action {
             Action::OpenPalette => "Open the command palette.",
             Action::ToggleResizeMode => "Enter resize mode to resize side panes.",
             Action::ToggleSidebar => "Toggle the projects sidebar.",
+            Action::ToggleGitPane => "Toggle the git pane.",
             Action::ToggleHelp => "Toggle the help overlay.",
             Action::Quit => "Quit the application.",
             Action::CloseOverlay => "Close the current overlay or dialog.",
@@ -277,6 +282,7 @@ impl Action {
             Action::SortAgentsByUpdated => "Sort agents by most recently updated.",
             Action::SortAgentsByCreated => "Sort agents by creation date (newest first).",
             Action::SortAgentsByName => "Sort agents alphabetically by name.",
+            Action::RemoveGitPane => "Remove or restore the git pane.",
         }
     }
 
@@ -322,6 +328,7 @@ impl Action {
             | Action::OpenPalette
             | Action::ToggleResizeMode
             | Action::ToggleSidebar
+            | Action::ToggleGitPane
             | Action::ToggleHelp
             | Action::Quit
             | Action::CloseOverlay => Some("Global"),
@@ -339,7 +346,8 @@ impl Action {
             | Action::RemoveProject
             | Action::SortAgentsByUpdated
             | Action::SortAgentsByCreated
-            | Action::SortAgentsByName => None,
+            | Action::SortAgentsByName
+            | Action::RemoveGitPane => None,
         }
     }
 }
@@ -897,6 +905,23 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
     },
     BindingDef {
+        action: Action::ToggleGitPane,
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char(']'),
+            KeyModifiers::NONE,
+        )],
+        scopes: &[BindingScope::Global],
+        help: Some(HelpEntry {
+            section: "Global",
+            description: "Toggle git pane",
+        }),
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "toggle-git-pane",
+            description: "Collapse or expand the git pane",
+        }),
+    },
+    BindingDef {
         action: Action::ToggleHelp,
         default_keys: &[KeyCombination::one_key(
             KeyCode::Char('?'),
@@ -1133,6 +1158,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "sort-agents-by-name",
             description: "Sort agents alphabetically by name",
+        }),
+    },
+    BindingDef {
+        action: Action::RemoveGitPane,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "remove-git-pane",
+            description: "Remove or restore the git pane entirely",
         }),
     },
 ];


### PR DESCRIPTION
The right (git) pane can now be collapsed to a thin 4-character strip by pressing `]`, mirroring the existing `[` key that collapses the left sidebar. When collapsed, the strip displays file status indicators (`M`, `A`, `D`, etc.) so you can still see at a glance what has changed. Pressing `]` again restores the pane to its full width.

A separate **remove-git-pane** command is available exclusively through the command palette (`Ctrl-P`). This completely removes the git pane from the layout, giving the center agent pane the full remaining width. Running the command again restores it. Both `toggle-git-pane` and `remove-git-pane` appear as searchable entries in the command palette alongside the existing `toggle-sidebar`.

Focus navigation adapts automatically: when the git pane is removed, `Tab`/`Shift-Tab` cycling skips the files pane entirely, and if focus was on the files pane at the time of collapse or removal it moves to the center pane. Mouse drag on the right divider is also disabled while the pane is removed.