### PR TITLE
Handle interrupted terminal input without crashing

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -799,15 +799,18 @@ impl App {
             tv_nsec: 100_000_000, // 100ms
         };
         let stdin_borrow = stdin_handle.as_fd();
-        let mut pollfd = [PollFd::new(&stdin_borrow, PollFlags::IN)];
-        let ready = poll(&mut pollfd, Some(&timeout))?;
+        let ready = crate::io_retry::retry_on_interrupt_errno(|| {
+            let mut pollfd = [PollFd::new(&stdin_borrow, PollFlags::IN)];
+            poll(&mut pollfd, Some(&timeout))
+        })?;
         if ready == 0 {
             return Ok(false);
         }
 
         // Read available bytes from the same handle used for polling.
         let mut buf = [0u8; 4096];
-        let n = stdin_handle.lock().read(&mut buf)?;
+        let mut stdin_lock = stdin_handle.lock();
+        let n = crate::io_retry::retry_on_interrupt(|| stdin_lock.read(&mut buf))?;
         if n == 0 {
             return Ok(false);
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -664,10 +664,18 @@ impl App {
                 // Check SIGWINCH — needed when bypassing crossterm's event
                 // reader (which would otherwise deliver Resize events).
                 if self.sigwinch_flag.swap(false, Ordering::Relaxed) {
-                    terminal.autoresize()?;
+                    if let Err(err) =
+                        crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
+                    {
+                        self.report_runtime_error("terminal resize failed", &err);
+                    }
                 }
 
-                terminal.draw(|frame| self.render(frame))?;
+                if let Err(err) = terminal.draw(|frame| self.render(frame)) {
+                    self.report_runtime_error("terminal draw failed", &err);
+                    thread::sleep(Duration::from_millis(100));
+                    continue;
+                }
 
                 if matches!(
                     self.input_target,
@@ -677,15 +685,58 @@ impl App {
                     // crossterm's event reader is not called — all bytes
                     // (keyboard, mouse, paste) go to the child process
                     // except intercepted bindings.
-                    if self.poll_and_forward_raw_input()? {
+                    let should_exit = match self.poll_and_forward_raw_input() {
+                        Ok(should_exit) => should_exit,
+                        Err(err) => {
+                            self.report_runtime_error(
+                                "interactive input failed; staying in the current session",
+                                err.as_ref(),
+                            );
+                            false
+                        }
+                    };
+                    if should_exit {
                         break;
                     }
                 } else {
                     // Normal UI mode: use crossterm's structured event reader.
-                    if event::poll(Duration::from_millis(100))? {
-                        match event::read()? {
+                    let ready =
+                        match crate::io_retry::retry_on_interrupt(|| {
+                            event::poll(Duration::from_millis(100))
+                        }) {
+                            Ok(ready) => ready,
+                            Err(err) => {
+                                self.report_runtime_error(
+                                    "event polling failed; input handling was skipped",
+                                    &err,
+                                );
+                                false
+                            }
+                        };
+                    if ready {
+                        let event = match crate::io_retry::retry_on_interrupt(event::read) {
+                            Ok(event) => event,
+                            Err(err) => {
+                                self.report_runtime_error(
+                                    "event read failed; input handling was skipped",
+                                    &err,
+                                );
+                                continue;
+                            }
+                        };
+                        match event {
                             Event::Key(key) => {
-                                if self.handle_key(key)? {
+                                let should_exit = match self.handle_key(key) {
+                                    Ok(should_exit) => should_exit,
+                                    Err(err) => {
+                                        self.report_runtime_error(
+                                            "key handling failed",
+                                            err.as_ref(),
+                                        );
+                                        false
+                                    }
+                                };
+                                if should_exit {
                                     break;
                                 }
                             }
@@ -772,6 +823,11 @@ impl App {
 
     pub(crate) fn set_error(&mut self, message: impl Into<String>) {
         self.status.error(message);
+    }
+
+    fn report_runtime_error(&mut self, context: &str, err: &dyn std::error::Error) {
+        logger::error(&format!("{context}: {err}"));
+        self.set_error(format!("{context}: {err}"));
     }
 
     pub(crate) fn execute_command(&mut self, command: String) -> Result<()> {

--- a/src/io_retry.rs
+++ b/src/io_retry.rs
@@ -1,0 +1,69 @@
+use std::io::{self, ErrorKind};
+
+pub(crate) fn retry_on_interrupt<T, F>(mut op: F) -> io::Result<T>
+where
+    F: FnMut() -> io::Result<T>,
+{
+    loop {
+        match op() {
+            Err(err) if err.kind() == ErrorKind::Interrupted => continue,
+            result => return result,
+        }
+    }
+}
+
+pub(crate) fn retry_on_interrupt_errno<T, F>(mut op: F) -> rustix::io::Result<T>
+where
+    F: FnMut() -> rustix::io::Result<T>,
+{
+    loop {
+        match op() {
+            Err(rustix::io::Errno::INTR) => continue,
+            result => return result,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn retries_std_io_interrupts_until_success() {
+        let calls = Cell::new(0);
+
+        let result = retry_on_interrupt(|| {
+            let call = calls.get();
+            calls.set(call + 1);
+            if call == 0 {
+                Err(io::Error::new(ErrorKind::Interrupted, "signal"))
+            } else {
+                Ok(7)
+            }
+        })
+        .expect("retry should succeed");
+
+        assert_eq!(result, 7);
+        assert_eq!(calls.get(), 2);
+    }
+
+    #[test]
+    fn retries_rustix_interrupts_until_success() {
+        let calls = Cell::new(0);
+
+        let result = retry_on_interrupt_errno(|| {
+            let call = calls.get();
+            calls.set(call + 1);
+            if call == 0 {
+                Err(rustix::io::Errno::INTR)
+            } else {
+                Ok(5usize)
+            }
+        })
+        .expect("retry should succeed");
+
+        assert_eq!(result, 5);
+        assert_eq!(calls.get(), 2);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod diff;
 mod editor;
 mod git;
+mod io_retry;
 mod keybindings;
 mod logger;
 mod model;

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -133,7 +133,7 @@ impl PtyClient {
     ) {
         let mut buf = [0u8; 4096];
         loop {
-            match reader.read(&mut buf) {
+            match crate::io_retry::retry_on_interrupt(|| reader.read(&mut buf)) {
                 Ok(0) => {
                     exited.store(true, Ordering::Release);
                     break;


### PR DESCRIPTION
This change keeps Dux alive when signal-interrupted syscalls happen in agent or terminal sessions. It retries  in the blocking input paths and avoids unwinding the whole app for recoverable runtime loop failures.

- add shared retry helpers for interrupted std I/O and rustix calls
- harden interactive stdin polling, PTY reads, and normal crossterm event polling
- surface recoverable runtime issues in the status line instead of crashing the TUI


running 302 tests
test app::input::tests::ctrl_f_does_not_resolve_scroll_in_center_scope ... ok
test app::input::tests::ctrl_b_does_not_resolve_scroll_in_center_scope ... ok
test app::input::tests::kill_selected_warns_when_targets_are_already_gone ... ok
test app::input::tests::command_palette_jk_keys_insert_text_instead_of_navigating ... ok
test app::input::tests::confirm_kill_cancel_restores_selection_modal_state ... ok
test app::input::tests::kill_running_search_keeps_hidden_selection ... ok
test app::input::tests::kill_running_tab_focus_reaches_cancel_button ... ok
test app::input::tests::mouse_click_browser_search_input_moves_cursor_and_edits_filter ... ok
test app::input::tests::fork_action_requires_selected_session ... ok
test app::input::tests::kill_running_footer_skips_kill_selected_when_nothing_is_marked ... ok
test app::input::tests::fork_selected_session_sets_busy_state_and_keeps_fresh_create_flow ... ok
test app::input::tests::mouse_click_browser_path_input_moves_cursor_and_edits_path ... ok
test app::input::tests::cycle_provider_only_updates_new_and_stopped_agents ... ok
test app::input::tests::mouse_click_command_palette_input_moves_cursor_and_keyboard_inserts_there ... ok
test app::input::tests::mouse_click_commit_text_second_click_enters_edit_mode_and_moves_cursor ... ok
test app::input::tests::mouse_click_commit_text_first_click_only_focuses_commit_input ... ok
test app::input::tests::mouse_click_delete_dialog_cancel_button_closes_prompt ... ok
test app::input::tests::mouse_click_empty_left_list_focuses_left_pane ... ok
test app::input::tests::mouse_click_kill_selected_button_opens_confirmation ... ok
test app::input::tests::mouse_click_kill_running_row_toggles_selection ... ok
test app::input::tests::mouse_click_command_palette_row_selects_then_double_click_executes ... ok
test app::input::tests::mouse_click_left_row_focuses_and_selects_it ... ok
test app::input::tests::mouse_click_left_pane_chrome_focuses_left_pane ... ok
test app::input::tests::mouse_click_pick_editor_row_selects_then_double_click_opens_editor ... ok
test app::input::tests::mouse_click_project_browser_row_selects_then_double_click_opens_entry ... ok
test app::input::tests::mouse_click_right_row_focuses_and_selects_unstaged_file ... ok
test app::input::tests::mouse_click_right_pane_chrome_focuses_files_pane ... ok
test app::input::tests::mouse_click_while_prompt_open_does_not_change_underlying_focus ... ok
test app::input::tests::mouse_click_rename_input_moves_cursor ... ok
test app::input::tests::mouse_commit_divider_not_detected_without_staged_files ... ok
test app::input::tests::mouse_click_quit_dialog_buttons_cancel_or_exit ... ok
test app::input::tests::mouse_double_click_project_row_toggles_collapse_like_space ... ok
test app::input::tests::mouse_double_click_left_pane_empty_space_does_not_activate_selected_row ... ok
test app::input::tests::mouse_drag_commit_divider_downward_shrinks_commit_section ... ok
test app::input::tests::mouse_drag_left_divider_updates_widths ... ok
test app::input::tests::mouse_drag_commit_divider_updates_height ... ok
test app::input::tests::mouse_drag_staged_divider_updates_height ... ok
test app::input::tests::mouse_journey_can_switch_files_sections_by_clicking_rows ... ok
test app::input::tests::mouse_drag_staged_divider_upward_grows_staged_section ... ok
test app::input::tests::mouse_journey_commit_chrome_then_text_enters_editing ... ok
test app::input::tests::mouse_journey_can_switch_focus_across_all_panes ... ok
test app::input::tests::mouse_journey_divider_drag_persists_widths_on_release ... ok
test app::input::tests::mouse_wheel_center_diff_scrolls_lines ... ok
test app::input::tests::mouse_staged_divider_not_detected_without_staged_files ... ok
test app::input::tests::mouse_wheel_commit_text_scrolls_commit_viewport ... ok
test app::input::tests::open_kill_running_requires_live_runtimes ... ok
test app::input::tests::mouse_wheel_left_pane_advances_selection_under_cursor ... ok
test app::input::tests::open_rename_session_clears_interactive_target ... ok
test app::input::tests::rename_session_prompt_accepts_text_before_agent_input ... ok
test app::input::tests::scroll_line_down_resolves_arrow_down_in_center_scope ... ok
test app::input::tests::scroll_line_down_resolves_arrow_down_in_interactive_scope ... ok
test app::input::tests::scroll_line_down_resolves_space_in_center_scope ... ok
test app::input::tests::scroll_line_down_resolves_space_in_interactive_scope ... ok
test app::input::tests::scroll_line_up_resolves_arrow_up_in_center_scope ... ok
test app::input::tests::scroll_line_up_resolves_arrow_up_in_interactive_scope ... ok
test app::input::tests::scroll_page_down_resolves_in_interactive_scope ... ok
test app::input::tests::scroll_page_up_resolves_in_interactive_scope ... ok
test app::input::tests::rename_session_uses_custom_dialog_confirm_binding ... ok
test app::input::tests::rename_session_text_ignores_printable_close_overlay_binding ... ok
test app::input::tests::slash_search_selects_first_match_and_n_advances ... ok
test app::render::tests::centered_rect_exact_centers_requested_size ... ok
test app::render::tests::centered_rect_exact_clamps_to_available_area ... ok
test app::render::tests::companion_terminal_status_meta_covers_v1_states ... ok
test app::render::tests::consistency_exact_width ... ok
test app::render::tests::consistency_long_commit_message ... ok
test app::render::tests::consistency_mixed_wrap_and_newlines ... ok
test app::input::tests::mouse_click_discard_dialog_button_discards_changes ... ok
test app::render::tests::consistency_short_text ... ok
test app::render::tests::consistency_width_one ... ok
test app::render::tests::consistency_with_newlines ... ok
test app::render::tests::cursor_after_newline ... ok
test app::render::tests::consistency_wrapping_text ... ok
test app::render::tests::cursor_after_wrap ... ok
test app::render::tests::cursor_at_end ... ok
test app::render::tests::cursor_at_start ... ok
test app::render::tests::cursor_at_wrap_boundary ... ok
test app::render::tests::cursor_mid_line ... ok
test app::render::tests::cursor_correct_after_deletion_near_wrap ... ok
test app::render::tests::row_badge_hidden_until_terminal_is_launched ... ok
test app::render::tests::runtime_context_spans_highlight_quoted_values ... ok
test app::render::tests::scrollback_indicator_handles_singular_total ... ok
test app::render::tests::scrollback_indicator_hides_at_live_bottom ... ok
test app::render::tests::scrollback_indicator_uses_fractional_label ... ok
test app::render::tests::wrap_empty_string ... ok
test app::render::tests::wrap_exact_width ... ok
test app::render::tests::wrap_longer_than_width ... ok
test app::render::tests::wrap_multiple_lines ... ok
test app::render::tests::rendered_cursor_matches_buffer_content ... ok
test app::render::tests::wrap_newline_resets_column ... ok
test app::render::tests::wrap_shorter_than_width ... ok
test app::render::tests::wrap_preserves_existing_newlines ... ok
test app::render::tests::wrap_width_one ... ok
test app::render::tests::wrap_width_zero_returns_unchanged ... ok
test app::render::tests::wrapped_position_handles_newline_rows ... ok
test app::render::tests::wrapped_position_maps_back_to_cursor_index ... ok
test app::text_input::tests::backspace_word_at_start_is_noop ... ok
test app::text_input::tests::backspace_word_deletes_word ... ok
test app::text_input::tests::delete_word_at_end_is_noop ... ok
test app::text_input::tests::delete_word_deletes_forward ... ok
test app::text_input::tests::handle_key_alt_delete ... ok
test app::text_input::tests::handle_key_alt_backspace ... ok
test app::text_input::tests::handle_key_alt_left_right ... ok
test app::text_input::tests::handle_key_backspace ... ok
test app::text_input::tests::handle_key_ctrl_char_not_inserted ... ok
test app::text_input::tests::handle_key_ctrl_left_right ... ok
test app::text_input::tests::handle_key_ctrl_delete ... ok
test app::text_input::tests::handle_key_ctrl_w ... ok
test app::text_input::tests::handle_key_plain_char ... ok
test app::text_input::tests::handle_key_home_end ... ok
test app::text_input::tests::handle_key_returns_false_for_enter ... ok
test app::text_input::tests::handle_key_returns_false_for_esc ... ok
test app::text_input::tests::handle_key_returns_false_for_tab ... ok
test app::text_input::tests::insert_and_navigate ... ok
test app::text_input::tests::move_left_word_and_right_word ... ok
test app::text_input::tests::prev_word_boundary_simple ... ok
test app::text_input::tests::next_word_boundary_simple ... ok
test app::text_input::tests::word_boundary_empty ... ok
test app::text_input::tests::word_boundary_multiple_spaces ... ok
test app::text_input::tests::word_boundary_punctuation ... ok
test app::text_input::tests::word_boundary_underscore ... ok
test app::text_input::tests::word_boundary_unicode ... ok
test config::tests::built_in_providers_ship_resume_args ... ok
test config::tests::commit_prompt_resolution_uses_system_default ... ok
test config::tests::commit_prompt_resolution_uses_project_override ... ok
test config::tests::config_root_falls_back_to_dot_config_when_xdg_missing ... ok
test config::tests::config_root_ignores_relative_xdg_config_home ... ok
test config::tests::config_root_uses_xdg_config_home_when_absolute ... ok
test config::tests::default_claude_oneshot_uses_bare_and_no_tools ... ok
test config::tests::config_comment_uses_dynamic_keybinding_label ... ok
test config::tests::default_config_is_commented_and_complete ... ok
test config::tests::default_config_keys_valid_after_round_trip ... ok
test config::tests::default_config_round_trips_agent_scrollback_lines ... ok
test app::input::tests::enter_opens_selected_file_diff_from_files_pane ... ok
test config::tests::default_config_round_trips_commit_pane_height ... ok
test config::tests::default_config_round_trips_default_editor ... ok
test config::tests::default_config_round_trips_staged_pane_height ... ok
test config::tests::default_config_round_trips_terminal_command ... ok
test config::tests::ensure_defaults_preserves_explicit_resume_disable ... ok
test config::tests::ensure_defaults_backfills_missing_resume_args_for_builtins ... ok
test config::tests::legacy_provider_config_without_resume_args_still_parses ... ok
test config::tests::old_config_missing_staged_pane_height_defaults_to_50 ... ok
test config::tests::provider_command_config_selects_resume_args_only_when_available ... ok
test config::tests::provider_configs_without_resume_args_still_parse ... ok
test config::tests::multiline_string_with_triple_quotes_roundtrips ... ok
test config::tests::default_config_round_trips_through_toml ... ok
test config::tests::resolve_root_errors_on_empty_dux_home ... ok
test config::tests::resolve_root_errors_on_relative_dux_home ... ok
test config::tests::resolve_root_falls_through_when_dux_home_unset ... ok
test config::tests::resolve_root_uses_dux_home_when_absolute ... ok
test config::tests::validate_keys_accepts_valid_config ... ok
test config::tests::validate_keys_detects_conflict ... ok
test config::tests::render_config_escapes_special_chars ... ok
test config::tests::validate_keys_normalizes_bare_uppercase ... ok
test config::tests::validate_keys_rejects_bad_key ... ok
test config::tests::validate_keys_rejects_unknown_action ... ok
test editor::tests::configured_matching_accepts_command_aliases ... ok
test editor::tests::detect_editors_prefers_popular_order ... ok
test editor::tests::preferred_editor_falls_back_to_first_detected ... ok
test editor::tests::preferred_editor_uses_configured_alias_when_available ... ok
test config::tests::render_config_escapes_newlines_and_control_chars ... ok
test app::input::tests::close_top_overlay_closes_terminal_overlay ... ok
test app::input::tests::exit_interactive_from_terminal_overlay_resets_state ... ok
test app::input::tests::header_running_terminal_count ... ok
test git::tests::docker_name_uses_dash ... ok
test git::tests::ellipsizes_in_the_middle ... ok
test app::input::tests::launch_companion_terminal_sets_runtime_state_and_overlay ... ok
test git::tests::is_under_checks_real_paths ... ok
test git::tests::is_under_rejects_nonexistent_candidate ... ok
test git::tests::parse_numstat_handles_binary_records ... ok
test git::tests::parse_numstat_handles_regular_path_with_spaces ... ok
test git::tests::parse_numstat_handles_rename_records ... ok
test git::tests::parse_status_porcelain_z_handles_untracked_and_spaces ... ok
test git::tests::parse_status_porcelain_z_skips_empty_records ... ok
test git::tests::parse_status_porcelain_z_uses_destination_path_for_renames ... ok
test app::input::tests::kill_running_terminal_label_deduplicates_term_prefix ... ok
test app::input::tests::left_section_navigation_crosses_to_terminals ... ok
test diff::tests::binary_files_render_summary_instead_of_text_diff ... ok
test app::input::tests::mouse_double_click_unstaged_file_row_opens_diff ... ok
test app::input::tests::mouse_double_click_center_agent_pane_opens_fullscreen ... ok
test app::input::tests::mouse_double_click_unstaged_file_opens_diff_from_center_focus ... ok
test app::input::tests::mouse_double_click_session_row_activates_like_enter ... ok
test io_retry::tests::retries_rustix_interrupts_until_success ... ok
test io_retry::tests::retries_std_io_interrupts_until_success ... ok
test keybindings::tests::bytes_arrow_keys ... ok
test keybindings::tests::bytes_ctrl_letter ... ok
test keybindings::tests::bytes_enter_backspace ... ok
test keybindings::tests::bytes_page_up_down ... ok
test keybindings::tests::bytes_plain_char ... ok
test keybindings::tests::combined_label_for_move ... ok
test keybindings::tests::detect_conflicts_default_config_clean ... ok
test keybindings::tests::detect_conflicts_different_scopes_no_conflict ... ok
test keybindings::tests::detect_conflicts_plain_vs_modifier_no_conflict ... ok
test keybindings::tests::detect_conflicts_same_key_same_scope ... ok
test keybindings::tests::every_action_has_config_name ... ok
test keybindings::tests::every_keyed_binding_has_help_entry ... ok
test keybindings::tests::files_scope_resolves_n_to_search_next ... ok
test keybindings::tests::files_scope_resolves_slash_to_search_toggle ... ok
test keybindings::tests::filtered_palette_filters_by_name ... ok
test keybindings::tests::filtered_palette_includes_companion_terminal_commands ... ok
test keybindings::tests::filtered_palette_includes_fork_agent_command ... ok
test keybindings::tests::filtered_palette_includes_kill_running_command ... ok
test keybindings::tests::filtered_palette_returns_all_when_empty ... ok
test keybindings::tests::format_key_display_uses_title_case_modifiers ... ok
test keybindings::tests::format_key_for_config_is_all_lowercase ... ok
test keybindings::tests::help_scope_rejects_unrelated_actions ... ok
test keybindings::tests::help_scope_resolves_scroll_keys ... ok
test keybindings::tests::help_sections_produces_valid_sections ... ok
test keybindings::tests::hints_for_returns_dynamic_labels ... ok
test keybindings::tests::interactive_byte_patterns_matches_defaults ... ok
test keybindings::tests::interactive_byte_patterns_no_match ... ok
test keybindings::tests::interactive_byte_patterns_scroll_line_is_conditional ... ok
test keybindings::tests::label_for_returns_display_label ... ok
test keybindings::tests::labels_for_joins_multiple_keys ... ok
test keybindings::tests::left_scope_resolves_f_to_fork_agent ... ok
test keybindings::tests::left_scope_resolves_t_to_show_terminal ... ok
test keybindings::tests::lookup_ctrl_combo_matches ... ok
test keybindings::tests::lookup_declaration_order_wins ... ok
test keybindings::tests::lookup_finds_action_in_correct_scope ... ok
test keybindings::tests::lookup_plain_key_ignores_shift_variant ... ok
test git::tests::changed_files_expands_untracked_directories_into_files ... ok
test keybindings::tests::lookup_plain_key_rejects_ctrl_modifier ... ok
test keybindings::tests::lookup_shift_key_ignores_plain ... ok
test keybindings::tests::lookup_shift_p_and_plain_p_coexist ... ok
test keybindings::tests::new_actions_are_in_binding_defs ... ok
test keybindings::tests::lookup_shift_tab_matches_backtab ... ok
test keybindings::tests::normalize_key_string_bare_uppercase ... ok
test keybindings::tests::normalize_key_string_lowercase_unchanged ... ok
test keybindings::tests::normalize_key_string_modifier_combo_unchanged ... ok
test keybindings::tests::normalize_key_string_special_keys_unchanged ... ok
test keybindings::tests::normalize_key_string_shift_letter_unchanged ... ok
test keybindings::tests::normalized_uppercase_matches_shift ... ok
test provider::tests::claude_style_stdout_build_command ... ok
test provider::tests::claude_style_run_oneshot ... ok
test provider::tests::codex_style_run_oneshot_via_tempfile ... ok
test provider::tests::codex_style_tempfile_build_command ... ok
test provider::tests::run_oneshot_reports_failure ... ok
test provider::tests::custom_provider_with_extra_args ... ok
test pty::tests::apply_terminal_env_sets_expected_term_override ... ok
test pty::tests::falls_back_to_xterm_256color_for_missing_or_low_capability_terms ... ok
test pty::tests::osc_color_queries_produce_terminal_replies ... ok
test pty::tests::preserves_rich_parent_term_values ... ok
test pty::tests::scrollback_offset_accessor_matches_grid_state ... ok
test git::tests::changed_files_marks_untracked_binary_files ... ok
test pty::tests::scrollback_reaches_beyond_visible_rows ... ok
test pty::tests::snapshot_preserves_ansi_background_colors ... ok
test raw_input::tests::alt_key ... ok
test raw_input::tests::bare_esc_at_end ... ok
test raw_input::tests::csi_cursor_up ... ok
test raw_input::tests::csi_modified_key ... ok
test raw_input::tests::csi_page_up ... ok
test pty::tests::scrolling_while_output_arrives_keeps_valid_offset ... ok
test raw_input::tests::del_byte ... ok
test raw_input::tests::empty_buffer ... ok
test raw_input::tests::incomplete_csi ... ok
test raw_input::tests::incomplete_ss3 ... ok
test raw_input::tests::incomplete_utf8 ... ok
test raw_input::tests::mixed_with_trailing_incomplete ... ok
test raw_input::tests::mixed_buffer ... ok
test raw_input::tests::non_mouse_csi_not_detected ... ok
test raw_input::tests::sgr_mouse_left_drag ... ok
test raw_input::tests::sgr_mouse_left_press ... ok
test raw_input::tests::sgr_mouse_left_release ... ok
test raw_input::tests::multiple_csi_sequences ... ok
test provider::tests::tempfile_cleaned_up_after_read ... ok
test raw_input::tests::sgr_mouse_right_press ... ok
test raw_input::tests::sgr_mouse_scroll_down ... ok
test raw_input::tests::sgr_mouse_scroll_up ... ok
test raw_input::tests::sgr_mouse_motion_no_button ... ok
test raw_input::tests::sgr_mouse_split_and_parse ... ok
test raw_input::tests::single_control_char ... ok
test raw_input::tests::single_printable_ascii ... ok
test raw_input::tests::space_byte ... ok
test raw_input::tests::ss3_f1 ... ok
test raw_input::tests::utf8_four_byte ... ok
test raw_input::tests::utf8_three_byte ... ok
test raw_input::tests::utf8_two_byte ... ok
removed /tmp/.tmpNrW1kf/dux/worktrees
removed /tmp/.tmpNrW1kf/dux
reset complete
test reset::tests::delete_agent_data_removes_worktrees_without_database ... ok
test reset::tests::reset_rejects_removed_keep_config_flag ... ok
test reset::tests::reset_rejects_unknown_flags ... ok
test git::tests::rename_branch_fails_when_old_name_wrong ... ok
test statusline::tests::warning_tone_formats_with_warning_prefix ... ok
removed /tmp/.tmpN7aGvA/dux
reset complete
test reset::tests::reset_succeeds_when_paths_are_already_missing ... ok
test storage::tests::load_sessions_ordered_by_updated_at_desc ... ok
test storage::tests::upsert_without_changing_updated_at_preserves_order ... ok
removed /tmp/.tmpqJXKJY/dux/logs/custom.log
removed /tmp/.tmpqJXKJY/dux/config.toml
reset complete
removed 1 session worktree(s)
removed /tmp/.tmpOYCE2Q/dux/worktrees
removed /tmp/.tmpOYCE2Q/dux/sessions.sqlite3
removed /tmp/.tmpOYCE2Q/dux/logs/custom.log
removed /tmp/.tmpOYCE2Q/dux/config.toml
removed /tmp/.tmpOYCE2Q/dux
reset complete
test reset::tests::delete_agent_data_flag_wipes_database_and_worktrees ... ok
test git::tests::staged_diff_text_empty_when_nothing_staged ... ok
test git::tests::rename_branch_fails_on_invalid_name ... ok
test git::tests::rename_branch_succeeds ... ok
test reset::tests::default_reset_removes_config_and_logs_but_keeps_agent_data ... ok
test git::tests::staged_diff_text_returns_diff_for_staged_changes ... ok
test git::tests::rename_branch_noop_same_name ... ok
test git::tests::mirror_worktree_contents_copies_visible_tree_and_preserves_git_admin_state ... ok
test git::tests::changed_files_uses_destination_path_for_staged_rename ... ok
test app::input::tests::session_switch_closes_terminal_overlay_but_keeps_pty ... ok
test git::tests::rename_branch_fails_on_conflict ... ok
test git::tests::create_worktree_from_start_point_uses_explicit_head_commit ... ok
test app::input::tests::terminal_items_returns_running_terminals ... ok
test app::input::tests::kill_visible_only_kills_filtered_rows ... ok
test app::input::tests::kill_selected_removes_running_targets_and_resets_terminal_surface ... ok
test app::input::tests::open_kill_running_snapshots_agents_and_terminals ... ok
test app::input::tests::multiple_terminals_per_session ... ok
test app::input::tests::quit_prompt_counts_running_companion_terminals_and_agents ... ok

test result: ok. 302 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s


running 4 tests
test pty_resize ... ok
test pty_spawn_and_detect_exit ... ok
test pty_read_output_into_alacritty_terminal ... ok
test pty_write_input ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s passes, covering both the new retry helpers and the existing app and PTY test suites.