### PR TITLE
Add configurable text macros for interactive mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -368,6 +368,7 @@ impl App {
                 Action::ShowTerminal => self.show_companion_terminal()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
                 Action::RenameSession => self.open_rename_session()?,
+                Action::EditMacros => self.open_edit_macros(),
                 Action::CycleProvider => self.cycle_selected_project_provider()?,
                 Action::CopyPath => self.copy_selected_path()?,
                 Action::OpenWorktreeInEditor => self.open_selected_worktree_in_default_editor()?,
@@ -860,6 +861,7 @@ impl App {
         // mouse event to handle in the UI, or raw bytes to forward.
         enum SeqAction {
             Intercept(Action, bool, Vec<u8>),
+            Macro(char),
             Mouse(MouseEvent, Vec<u8>),
             Forward(Vec<u8>),
         }
@@ -872,6 +874,10 @@ impl App {
                 // so terminal mouse events arrive as CSI `<…M` / `<…m`.
                 if let Some(mouse_ev) = crate::raw_input::parse_sgr_mouse(seq) {
                     return SeqAction::Mouse(mouse_ev, seq.to_vec());
+                }
+                // Text macros take priority over regular interactive bindings.
+                if let Some(letter) = self.macro_patterns.match_sequence(seq) {
+                    return SeqAction::Macro(letter);
                 }
                 if let Some((action, conditional)) = self.interactive_patterns.match_sequence(seq) {
                     SeqAction::Intercept(action, conditional, seq.to_vec())
@@ -965,6 +971,23 @@ impl App {
                         if let Some(provider) = self.selected_terminal_surface_client() {
                             let _ = provider.write_bytes(&raw);
                         }
+                    }
+                }
+                SeqAction::Macro(letter) => {
+                    let key = letter.to_string();
+                    if let Some(entry) = self.config.macros.entries.get(&key) {
+                        if let Some(provider) = self.selected_terminal_surface_client() {
+                            let text = entry.text();
+                            let mut payload = Vec::with_capacity(text.len() + 12);
+                            // Bracketed paste: text arrives atomically, newlines
+                            // are not interpreted as Enter.
+                            payload.extend_from_slice(b"\x1b[200~");
+                            payload.extend_from_slice(text.as_bytes());
+                            payload.extend_from_slice(b"\x1b[201~");
+                            let _ = provider.write_bytes(&payload);
+                        }
+                        let label = entry.display_name(&key);
+                        self.set_info(format!("Pasted macro \"{label}\""));
                     }
                 }
                 SeqAction::Intercept(_, _, raw) | SeqAction::Forward(raw) => {
@@ -1500,6 +1523,11 @@ impl App {
             return Ok(false);
         }
 
+        if matches!(self.prompt, PromptState::EditMacros { .. }) {
+            self.handle_edit_macros_key(key)?;
+            return Ok(false);
+        }
+
         if let PromptState::RenameSession {
             session_id, input, ..
         } = &mut self.prompt
@@ -1529,6 +1557,193 @@ impl App {
             return Ok(false);
         }
 
+        Ok(false)
+    }
+
+    fn handle_edit_macros_key(&mut self, key: KeyEvent) -> Result<bool> {
+        use crate::config::MacroEntry;
+
+        let PromptState::EditMacros {
+            entries,
+            selected,
+            editing,
+        } = &mut self.prompt
+        else {
+            return Ok(false);
+        };
+
+        if let Some(edit_state) = editing {
+            match edit_state.stage {
+                MacroEditStage::PickLetter => {
+                    if key.code == KeyCode::Esc {
+                        *editing = None;
+                        return Ok(false);
+                    }
+                    if key.code == KeyCode::Enter && !edit_state.letter_input.is_empty() {
+                        let ch = edit_state.letter_input.text.chars().next().unwrap();
+                        if !ch.is_ascii_lowercase() {
+                            return Ok(false);
+                        }
+                        if entries.iter().any(|(l, _)| *l == ch) {
+                            self.set_warning(format!(
+                                "Letter \"{ch}\" is already in use. Choose another."
+                            ));
+                            return Ok(false);
+                        }
+                        edit_state.letter = Some(ch);
+                        edit_state.stage = MacroEditStage::EditName;
+                        return Ok(false);
+                    }
+                    // Only accept a single lowercase letter
+                    if let KeyCode::Char(c) = key.code
+                        && c.is_ascii_lowercase()
+                        && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        edit_state.letter_input.set_text(c.to_string());
+                        return Ok(false);
+                    }
+                    edit_state.letter_input.handle_key(key);
+                }
+                MacroEditStage::EditName => {
+                    if key.code == KeyCode::Esc {
+                        *editing = None;
+                        return Ok(false);
+                    }
+                    if key.code == KeyCode::Enter {
+                        edit_state.stage = MacroEditStage::EditText;
+                        return Ok(false);
+                    }
+                    edit_state.name_input.handle_key(key);
+                }
+                MacroEditStage::EditText => {
+                    if key.code == KeyCode::Esc {
+                        // Save the macro
+                        let letter = edit_state.letter.unwrap();
+                        let name = edit_state.name_input.text.clone();
+                        let text = edit_state.text_input.text.clone();
+
+                        if text.is_empty() {
+                            // Empty text — don't save
+                            *editing = None;
+                            return Ok(false);
+                        }
+
+                        let entry = if name.is_empty() {
+                            MacroEntry::Plain(text)
+                        } else {
+                            MacroEntry::Named { name, text }
+                        };
+                        let label = entry.display_name(&letter.to_string());
+
+                        // Update config
+                        self.config
+                            .macros
+                            .entries
+                            .insert(letter.to_string(), entry.clone());
+
+                        // Update the entries snapshot in PromptState
+                        let PromptState::EditMacros {
+                            entries, editing, ..
+                        } = &mut self.prompt
+                        else {
+                            return Ok(false);
+                        };
+                        *editing = None;
+
+                        // Update entries list
+                        if let Some(existing) = entries.iter_mut().find(|(l, _)| *l == letter) {
+                            existing.1 = entry;
+                        } else {
+                            entries.push((letter, entry));
+                            entries.sort_by_key(|(ch, _)| *ch);
+                        }
+
+                        // Persist and rebuild
+                        let _ = crate::config::save_config(
+                            &self.paths.config_path,
+                            &self.config,
+                            &self.bindings,
+                        );
+                        self.rebuild_macro_patterns();
+                        self.set_info(format!("Macro \"{label}\" saved."));
+                        return Ok(false);
+                    }
+                    // In multiline mode, TextInput handles Enter/Up/Down
+                    edit_state.text_input.handle_key(key);
+                }
+            }
+            return Ok(false);
+        }
+
+        // List view — no active editing
+        match key.code {
+            KeyCode::Esc => {
+                self.prompt = PromptState::None;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !entries.is_empty() && *selected + 1 < entries.len() {
+                    *selected += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if *selected > 0 {
+                    *selected -= 1;
+                }
+            }
+            KeyCode::Enter => {
+                // Edit selected macro
+                if let Some((letter, entry)) = entries.get(*selected) {
+                    let letter = *letter;
+                    let name = entry.name().map(|s| s.to_string()).unwrap_or_default();
+                    let text = entry.text().to_string();
+                    *editing = Some(MacroEditState {
+                        letter: Some(letter),
+                        letter_input: TextInput::with_text(letter.to_string()),
+                        name_input: TextInput::with_text(name),
+                        text_input: TextInput::with_text(text).with_multiline(8),
+                        stage: MacroEditStage::EditName,
+                    });
+                }
+            }
+            KeyCode::Char('n') => {
+                // New macro
+                *editing = Some(MacroEditState {
+                    letter: None,
+                    letter_input: TextInput::new(),
+                    name_input: TextInput::new(),
+                    text_input: TextInput::new().with_multiline(8),
+                    stage: MacroEditStage::PickLetter,
+                });
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                // Delete selected macro
+                if let Some((letter, entry)) = entries.get(*selected) {
+                    let label = entry.display_name(&letter.to_string());
+                    let letter_str = letter.to_string();
+                    self.config.macros.entries.remove(&letter_str);
+
+                    let PromptState::EditMacros {
+                        entries, selected, ..
+                    } = &mut self.prompt
+                    else {
+                        return Ok(false);
+                    };
+                    entries.retain(|(l, _)| l.to_string() != letter_str);
+                    if *selected > 0 && *selected >= entries.len() {
+                        *selected = entries.len().saturating_sub(1);
+                    }
+
+                    let _ = crate::config::save_config(
+                        &self.paths.config_path,
+                        &self.config,
+                        &self.bindings,
+                    );
+                    self.rebuild_macro_patterns();
+                    self.set_info(format!("Macro \"{label}\" deleted."));
+                }
+            }
+            _ => {}
+        }
         Ok(false)
     }
 
@@ -3039,6 +3254,9 @@ mod tests {
             mouse_drag: None,
             last_mouse_click: None,
             interactive_patterns: crate::keybindings::InteractiveBytePatterns {
+                bindings: Vec::new(),
+            },
+            macro_patterns: crate::keybindings::MacroBytePatterns {
                 bindings: Vec::new(),
             },
             raw_input_buf: Vec::new(),
@@ -5177,10 +5395,7 @@ mod tests {
         let sid = app.sessions[0].id.clone();
         app.prompt = PromptState::RenameSession {
             session_id: sid,
-            input: TextInput {
-                text: "rename me".to_string(),
-                cursor: 0,
-            },
+            input: TextInput::with_text("rename me".to_string()),
         };
         install_rename_overlay(&mut app);
 
@@ -5239,10 +5454,12 @@ mod tests {
         let mut app = test_app(default_bindings());
         assert!(!app.right_hidden);
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
         assert!(app.right_hidden);
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
         assert!(!app.right_hidden);
     }
 
@@ -5251,7 +5468,8 @@ mod tests {
         let mut app = test_app(default_bindings());
         app.focus = FocusPane::Files;
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
 
         assert!(app.right_hidden);
         assert_eq!(app.focus, FocusPane::Center);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -109,6 +109,7 @@ pub struct App {
     pub(crate) mouse_drag: Option<ResizeDragState>,
     pub(crate) last_mouse_click: Option<RecentMouseClick>,
     pub(crate) interactive_patterns: InteractiveBytePatterns,
+    pub(crate) macro_patterns: crate::keybindings::MacroBytePatterns,
     pub(crate) raw_input_buf: Vec<u8>,
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
 }
@@ -348,6 +349,27 @@ pub(crate) enum PromptState {
         editors: Vec<DetectedEditor>,
         selected: usize,
     },
+    EditMacros {
+        entries: Vec<(char, crate::config::MacroEntry)>,
+        selected: usize,
+        editing: Option<MacroEditState>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MacroEditState {
+    pub(crate) letter: Option<char>,
+    pub(crate) letter_input: TextInput,
+    pub(crate) name_input: TextInput,
+    pub(crate) text_input: TextInput,
+    pub(crate) stage: MacroEditStage,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MacroEditStage {
+    PickLetter,
+    EditName,
+    EditText,
 }
 
 #[derive(Clone, Debug)]
@@ -573,6 +595,7 @@ impl App {
         }
         let bindings = RuntimeBindings::from_keys_config(&config.keys);
         let interactive_patterns = bindings.interactive_byte_patterns();
+        let macro_patterns = crate::keybindings::MacroBytePatterns::build(&config.macros);
 
         // Register SIGWINCH handler so we can detect terminal resizes even when
         // bypassing crossterm's event reader during interactive mode.
@@ -651,6 +674,7 @@ impl App {
             mouse_drag: None,
             last_mouse_click: None,
             interactive_patterns,
+            macro_patterns,
             raw_input_buf: Vec::new(),
             sigwinch_flag,
         };
@@ -673,8 +697,7 @@ impl App {
                 // Check SIGWINCH — needed when bypassing crossterm's event
                 // reader (which would otherwise deliver Resize events).
                 if self.sigwinch_flag.swap(false, Ordering::Relaxed) {
-                    if let Err(err) =
-                        crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
+                    if let Err(err) = crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
                     {
                         self.report_runtime_error("terminal resize failed", &err);
                     }
@@ -709,19 +732,18 @@ impl App {
                     }
                 } else {
                     // Normal UI mode: use crossterm's structured event reader.
-                    let ready =
-                        match crate::io_retry::retry_on_interrupt(|| {
-                            event::poll(Duration::from_millis(100))
-                        }) {
-                            Ok(ready) => ready,
-                            Err(err) => {
-                                self.report_runtime_error(
-                                    "event polling failed; input handling was skipped",
-                                    &err,
-                                );
-                                false
-                            }
-                        };
+                    let ready = match crate::io_retry::retry_on_interrupt(|| {
+                        event::poll(Duration::from_millis(100))
+                    }) {
+                        Ok(ready) => ready,
+                        Err(err) => {
+                            self.report_runtime_error(
+                                "event polling failed; input handling was skipped",
+                                &err,
+                            );
+                            false
+                        }
+                    };
                     if ready {
                         let event = match crate::io_retry::retry_on_interrupt(event::read) {
                             Ok(event) => event,
@@ -902,12 +924,44 @@ impl App {
                 self.sort_sessions_by_name();
                 Ok(())
             }
+            "edit-macros" => {
+                self.open_edit_macros();
+                Ok(())
+            }
             "" => Ok(()),
             other => {
                 self.set_error(format!("Unknown command: \"{other}\""));
                 Ok(())
             }
         }
+    }
+
+    pub(crate) fn rebuild_macro_patterns(&mut self) {
+        self.macro_patterns = crate::keybindings::MacroBytePatterns::build(&self.config.macros);
+    }
+
+    pub(crate) fn open_edit_macros(&mut self) {
+        let mut entries: Vec<(char, crate::config::MacroEntry)> = self
+            .config
+            .macros
+            .entries
+            .iter()
+            .filter_map(|(k, v)| {
+                if k.len() == 1 {
+                    let ch = k.chars().next().unwrap();
+                    if ch.is_ascii_lowercase() {
+                        return Some((ch, v.clone()));
+                    }
+                }
+                None
+            })
+            .collect();
+        entries.sort_by_key(|(ch, _)| *ch);
+        self.prompt = PromptState::EditMacros {
+            entries,
+            selected: 0,
+            editing: None,
+        };
     }
 
     pub(crate) fn left_items(&self) -> &[LeftItem] {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2751,8 +2751,309 @@ impl App {
                 self.overlay_layout.active =
                     OverlayMouseLayout::RenameSession { input: input_inner };
             }
+            PromptState::EditMacros { .. } => {
+                // Full rendering implemented in Task #5.
+                self.render_edit_macros(frame);
+            }
             PromptState::None => {}
         }
+    }
+
+    fn render_edit_macros(&mut self, frame: &mut Frame) {
+        use super::MacroEditStage;
+
+        let PromptState::EditMacros {
+            entries,
+            selected,
+            editing,
+        } = &self.prompt
+        else {
+            return;
+        };
+
+        self.render_dim_overlay(frame);
+
+        let popup = centered_rect_exact(64, 20, frame.area());
+        Clear.render(popup, frame.buffer_mut());
+
+        if let Some(edit_state) = editing {
+            // ── Edit view ──
+            let title = match edit_state.letter {
+                Some(ch) => format!("Edit Macro [{ch}]"),
+                None => "New Macro".to_string(),
+            };
+            let outer = self.themed_overlay_block(&title);
+            let inner = outer.inner(popup);
+            outer.render(popup, frame.buffer_mut());
+
+            match edit_state.stage {
+                MacroEditStage::PickLetter => {
+                    let [label_area, input_area, _, hint_area] = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([
+                            Constraint::Length(1),
+                            Constraint::Length(3),
+                            Constraint::Min(1),
+                            Constraint::Length(1),
+                        ])
+                        .areas(inner);
+
+                    Paragraph::new(Line::from(Span::styled(
+                        " Letter (a-z):",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )))
+                    .render(label_area, frame.buffer_mut());
+
+                    self.render_single_line_input(&edit_state.letter_input, input_area, frame);
+
+                    let hints = self.edit_macro_hints(&[("Enter", "next"), ("Esc", "cancel")]);
+                    Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                }
+                MacroEditStage::EditName => {
+                    let [label_area, input_area, _, hint_area] = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([
+                            Constraint::Length(1),
+                            Constraint::Length(3),
+                            Constraint::Min(1),
+                            Constraint::Length(1),
+                        ])
+                        .areas(inner);
+
+                    Paragraph::new(Line::from(Span::styled(
+                        " Name (optional, shown in status bar):",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )))
+                    .render(label_area, frame.buffer_mut());
+
+                    self.render_single_line_input(&edit_state.name_input, input_area, frame);
+
+                    let hints = self.edit_macro_hints(&[("Enter", "next"), ("Esc", "cancel")]);
+                    Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                }
+                MacroEditStage::EditText => {
+                    let [label_area, text_area, hint_area] = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([
+                            Constraint::Length(1),
+                            Constraint::Min(3),
+                            Constraint::Length(1),
+                        ])
+                        .areas(inner);
+
+                    Paragraph::new(Line::from(Span::styled(
+                        " Text (pasted to agent via bracketed paste):",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )))
+                    .render(label_area, frame.buffer_mut());
+
+                    self.render_multiline_input(&edit_state.text_input, text_area, frame);
+
+                    let hints =
+                        self.edit_macro_hints(&[("Enter", "newline"), ("Esc", "save & close")]);
+                    Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                }
+            }
+        } else {
+            // ── List view ──
+            let outer = self.themed_overlay_block("Text Macros");
+            let inner = outer.inner(popup);
+            outer.render(popup, frame.buffer_mut());
+
+            if entries.is_empty() {
+                let [msg_area, _, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(2),
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                    ])
+                    .areas(inner);
+
+                Paragraph::new(vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " No macros defined. Press n to create one.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )),
+                ])
+                .render(msg_area, frame.buffer_mut());
+
+                let hints = self.edit_macro_hints(&[("n", "new"), ("Esc", "close")]);
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+            } else {
+                let [list_area, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(1), Constraint::Length(1)])
+                    .areas(inner);
+
+                let items: Vec<ListItem> = entries
+                    .iter()
+                    .map(|(letter, entry)| {
+                        let prefix = format!(" [{letter}] ");
+                        let mut spans = vec![Span::styled(
+                            prefix,
+                            Style::default()
+                                .fg(self.theme.overlay_border)
+                                .add_modifier(ratatui::style::Modifier::BOLD),
+                        )];
+                        if let Some(name) = entry.name() {
+                            spans.push(Span::styled(
+                                format!("{name}: "),
+                                Style::default().fg(self.theme.input_label_fg),
+                            ));
+                        }
+                        let text_preview = entry.text().replace('\n', "↵");
+                        let max_len =
+                            list_area.width as usize - 8 - entry.name().map_or(0, |n| n.len() + 2);
+                        let truncated = if text_preview.len() > max_len {
+                            format!("{}…", &text_preview[..max_len.saturating_sub(1)])
+                        } else {
+                            text_preview
+                        };
+                        spans.push(Span::styled(
+                            truncated,
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ));
+                        ListItem::new(Line::from(spans))
+                    })
+                    .collect();
+
+                let list = List::new(items)
+                    .highlight_style(self.theme.selection_style())
+                    .highlight_symbol("▸ ");
+                let mut state = ratatui::widgets::ListState::default();
+                state.select(Some(*selected));
+                ratatui::prelude::StatefulWidget::render(
+                    list,
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+
+                let hints = self.edit_macro_hints(&[
+                    ("Enter", "edit"),
+                    ("n", "new"),
+                    ("d", "delete"),
+                    ("Esc", "close"),
+                ]);
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+            }
+        }
+    }
+
+    /// Render a single-line TextInput with cursor in a bordered box.
+    fn render_single_line_input(&self, input: &TextInput, area: Rect, frame: &mut Frame) {
+        let display = if input.cursor < input.text.len() {
+            let (before, after) = input.text.split_at(input.cursor);
+            let mut chars = after.chars();
+            let cursor_char = chars.next().unwrap_or(' ');
+            let rest: String = chars.collect();
+            Line::from(vec![
+                Span::raw(format!(" {before}")),
+                Span::styled(
+                    cursor_char.to_string(),
+                    Style::default()
+                        .fg(self.theme.input_cursor_fg)
+                        .bg(self.theme.input_cursor_bg),
+                ),
+                Span::raw(rest),
+            ])
+        } else {
+            Line::from(vec![
+                Span::raw(format!(" {}", &input.text)),
+                Span::styled(
+                    " ",
+                    Style::default()
+                        .fg(self.theme.input_cursor_fg)
+                        .bg(self.theme.input_cursor_bg),
+                ),
+            ])
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(border::ROUNDED)
+            .border_style(Style::default().fg(self.theme.overlay_border));
+        Paragraph::new(display)
+            .block(block)
+            .render(area, frame.buffer_mut());
+    }
+
+    /// Render a multiline TextInput with cursor in a bordered box.
+    fn render_multiline_input(&self, input: &TextInput, area: Rect, frame: &mut Frame) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(border::ROUNDED)
+            .border_style(Style::default().fg(self.theme.overlay_border));
+        let inner = block.inner(area);
+        block.render(area, frame.buffer_mut());
+
+        let visible = input.visible_lines();
+        let (cursor_row, cursor_col) = input.cursor_display_position();
+
+        for (i, line_text) in visible.iter().enumerate() {
+            if i >= inner.height as usize {
+                break;
+            }
+            let y = inner.y + i as u16;
+            let line_area = Rect::new(inner.x, y, inner.width, 1);
+
+            if i == cursor_row {
+                // Render line with cursor highlight
+                let col_byte = char_col_to_byte(line_text, cursor_col);
+                if col_byte < line_text.len() {
+                    let before = &line_text[..col_byte];
+                    let mut chars = line_text[col_byte..].chars();
+                    let cursor_char = chars.next().unwrap_or(' ');
+                    let rest: String = chars.collect();
+                    let line = Line::from(vec![
+                        Span::raw(format!(" {before}")),
+                        Span::styled(
+                            cursor_char.to_string(),
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                        Span::raw(rest),
+                    ]);
+                    Paragraph::new(line).render(line_area, frame.buffer_mut());
+                } else {
+                    let line = Line::from(vec![
+                        Span::raw(format!(" {line_text}")),
+                        Span::styled(
+                            " ",
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                    ]);
+                    Paragraph::new(line).render(line_area, frame.buffer_mut());
+                }
+            } else {
+                let line = Line::from(Span::raw(format!(" {line_text}")));
+                Paragraph::new(line).render(line_area, frame.buffer_mut());
+            }
+        }
+    }
+
+    /// Build hint spans from alternating key/description pairs.
+    /// Each pair is (key_label, description). Spans are fully owned.
+    fn edit_macro_hints(&self, pairs: &[(&str, &str)]) -> Vec<Span<'static>> {
+        let mut spans = vec![Span::raw(" ")];
+        for (key, desc) in pairs {
+            // key_badge ties lifetime to &str, so we convert to owned spans.
+            let badge = self.theme.key_badge_default(key);
+            spans.extend(
+                badge
+                    .into_iter()
+                    .map(|s| Span::styled(s.content.to_string(), s.style)),
+            );
+            spans.push(Span::styled(
+                format!(" {desc}  "),
+                Style::default().fg(self.theme.hint_desc_fg),
+            ));
+        }
+        spans
     }
 
     fn render_overlay(&mut self, frame: &mut Frame) {
@@ -2964,6 +3265,14 @@ pub(crate) fn centered_rect_exact(width: u16, height: u16, area: Rect) -> Rect {
     let x = area.x + area.width.saturating_sub(width) / 2;
     let y = area.y + area.height.saturating_sub(height) / 2;
     Rect::new(x, y, width, height)
+}
+
+/// Convert a character column index to a byte offset in a string.
+fn char_col_to_byte(text: &str, col: usize) -> usize {
+    text.char_indices()
+        .nth(col)
+        .map(|(i, _)| i)
+        .unwrap_or(text.len())
 }
 
 fn render_single_line_cursor_input(

--- a/src/app/text_input.rs
+++ b/src/app/text_input.rs
@@ -1,14 +1,27 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// Reusable single-field text input with cursor tracking.
+/// Reusable text input with cursor tracking and optional multiline support.
 ///
 /// Handles character-level and word-level editing, cursor movement, and
 /// common key dispatch. All cursor positions are byte indices into the
 /// underlying UTF-8 string.
+///
+/// By default operates in single-line mode. Call [`TextInput::with_multiline`]
+/// to enable multiline editing where Enter inserts newlines and Up/Down
+/// navigate between lines.
 #[derive(Clone, Debug)]
 pub struct TextInput {
     pub text: String,
     pub cursor: usize,
+    multiline: Option<MultilineState>,
+}
+
+#[derive(Clone, Debug)]
+struct MultilineState {
+    /// Maximum number of lines visible at once for rendering.
+    visible_lines: usize,
+    /// Index of the first visible line (0-based scroll position).
+    scroll_offset: usize,
 }
 
 impl Default for TextInput {
@@ -22,12 +35,30 @@ impl TextInput {
         Self {
             text: String::new(),
             cursor: 0,
+            multiline: None,
         }
     }
 
     pub fn with_text(text: String) -> Self {
         let cursor = text.len();
-        Self { text, cursor }
+        Self {
+            text,
+            cursor,
+            multiline: None,
+        }
+    }
+
+    /// Enable multiline editing with a visible line limit for rendering.
+    pub fn with_multiline(mut self, visible_lines: usize) -> Self {
+        self.multiline = Some(MultilineState {
+            visible_lines,
+            scroll_offset: 0,
+        });
+        self
+    }
+
+    pub fn is_multiline(&self) -> bool {
+        self.multiline.is_some()
     }
 
     // ── Character-level operations ──────────────────────────────────
@@ -118,6 +149,131 @@ impl TextInput {
         self.text.is_empty()
     }
 
+    // ── Multiline operations ───────────────────────────────────────
+
+    /// Move cursor to the same column on the previous line.
+    /// If the previous line is shorter, the cursor lands at its end.
+    /// No-op when already on the first line or in single-line mode.
+    pub fn move_up(&mut self) {
+        if self.multiline.is_none() {
+            return;
+        }
+        let (line, col) = self.cursor_line_col();
+        if line == 0 {
+            return;
+        }
+        self.cursor = byte_offset_at(&self.text, line - 1, col);
+        self.ensure_cursor_visible();
+    }
+
+    /// Move cursor to the same column on the next line.
+    /// If the next line is shorter, the cursor lands at its end.
+    /// No-op when already on the last line or in single-line mode.
+    pub fn move_down(&mut self) {
+        if self.multiline.is_none() {
+            return;
+        }
+        let (line, col) = self.cursor_line_col();
+        let total = self.total_lines();
+        if line + 1 >= total {
+            return;
+        }
+        self.cursor = byte_offset_at(&self.text, line + 1, col);
+        self.ensure_cursor_visible();
+    }
+
+    /// Move cursor to the start of the current line (multiline) or
+    /// to the start of the entire text (single-line).
+    pub fn move_line_home(&mut self) {
+        if self.multiline.is_none() {
+            self.cursor = 0;
+            return;
+        }
+        let idx = clamp_cursor(&self.text, self.cursor);
+        self.cursor = self.text[..idx].rfind('\n').map(|p| p + 1).unwrap_or(0);
+    }
+
+    /// Move cursor to the end of the current line (multiline) or
+    /// to the end of the entire text (single-line).
+    pub fn move_line_end(&mut self) {
+        if self.multiline.is_none() {
+            self.cursor = self.text.len();
+            return;
+        }
+        let idx = clamp_cursor(&self.text, self.cursor);
+        self.cursor = self.text[idx..]
+            .find('\n')
+            .map(|p| idx + p)
+            .unwrap_or(self.text.len());
+    }
+
+    /// Total number of lines in the text (count of `\n` + 1).
+    pub fn total_lines(&self) -> usize {
+        self.text.chars().filter(|&c| c == '\n').count() + 1
+    }
+
+    /// Current scroll offset (first visible line index). Returns 0 in single-line mode.
+    pub fn scroll_offset(&self) -> usize {
+        self.multiline
+            .as_ref()
+            .map(|m| m.scroll_offset)
+            .unwrap_or(0)
+    }
+
+    /// Maximum number of visible lines, if multiline is enabled.
+    pub fn visible_line_count(&self) -> Option<usize> {
+        self.multiline.as_ref().map(|m| m.visible_lines)
+    }
+
+    /// Returns the lines currently visible for rendering (accounting for scroll offset).
+    pub fn visible_lines(&self) -> Vec<&str> {
+        let lines: Vec<&str> = self.text.split('\n').collect();
+        match &self.multiline {
+            Some(m) => {
+                let start = m.scroll_offset.min(lines.len());
+                let end = (start + m.visible_lines).min(lines.len());
+                lines[start..end].to_vec()
+            }
+            None => lines,
+        }
+    }
+
+    /// Returns `(row, col)` of the cursor relative to the scroll offset, for rendering.
+    /// In single-line mode, returns `(0, cursor_position)`.
+    pub fn cursor_display_position(&self) -> (usize, usize) {
+        let (line, col) = self.cursor_line_col();
+        let offset = self.scroll_offset();
+        (line.saturating_sub(offset), col)
+    }
+
+    /// Compute the (line, column) of the cursor in character units.
+    fn cursor_line_col(&self) -> (usize, usize) {
+        let idx = clamp_cursor(&self.text, self.cursor);
+        let before = &self.text[..idx];
+        let line = before.chars().filter(|&c| c == '\n').count();
+        let line_start = before.rfind('\n').map(|p| p + 1).unwrap_or(0);
+        let col = before[line_start..].chars().count();
+        (line, col)
+    }
+
+    /// Adjust scroll offset so the cursor line is within the visible window.
+    fn ensure_cursor_visible(&mut self) {
+        let Some(m) = &mut self.multiline else {
+            return;
+        };
+        let (cursor_line, _) = {
+            let idx = clamp_cursor(&self.text, self.cursor);
+            let before = &self.text[..idx];
+            let line = before.chars().filter(|&c| c == '\n').count();
+            (line, 0)
+        };
+        if cursor_line < m.scroll_offset {
+            m.scroll_offset = cursor_line;
+        } else if cursor_line >= m.scroll_offset + m.visible_lines {
+            m.scroll_offset = cursor_line + 1 - m.visible_lines;
+        }
+    }
+
     // ── Key dispatch ────────────────────────────────────────────────
 
     /// Handle common text-editing keys. Returns `true` if the key was consumed.
@@ -127,14 +283,35 @@ impl TextInput {
     /// - `Backspace` → delete char backward; `Alt+Backspace` / `Ctrl+W` → delete word backward
     /// - `Delete` → delete char forward; `Alt+Delete` / `Ctrl+Delete` → delete word forward
     /// - `Left` / `Right` → move char; `Alt+Left/Right` / `Ctrl+Left/Right` → move word
-    /// - `Home` / `End` → jump to start/end
+    /// - `Home` / `End` → jump to start/end of line (multiline) or text (single-line)
     ///
-    /// Everything else (Enter, Esc, Tab, …) returns `false` for the caller to handle.
+    /// In multiline mode, additionally:
+    /// - `Enter` → insert newline
+    /// - `Up` / `Down` → move between lines
+    ///
+    /// Everything else (Esc, Tab, and Enter/Up/Down in single-line mode)
+    /// returns `false` for the caller to handle.
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         let has_alt = key.modifiers.contains(KeyModifiers::ALT);
         let has_ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let is_multiline = self.multiline.is_some();
 
         match key.code {
+            // Multiline-only: Enter inserts newline
+            KeyCode::Enter if is_multiline => {
+                self.insert_char('\n');
+                self.ensure_cursor_visible();
+                true
+            }
+            // Multiline-only: Up/Down navigate lines
+            KeyCode::Up if is_multiline && !has_alt && !has_ctrl => {
+                self.move_up();
+                true
+            }
+            KeyCode::Down if is_multiline && !has_alt && !has_ctrl => {
+                self.move_down();
+                true
+            }
             KeyCode::Backspace if has_alt => {
                 self.backspace_word();
                 true
@@ -167,6 +344,15 @@ impl TextInput {
                 self.move_right();
                 true
             }
+            // Home/End: line-level in multiline, text-level in single-line
+            KeyCode::Home if is_multiline => {
+                self.move_line_home();
+                true
+            }
+            KeyCode::End if is_multiline => {
+                self.move_line_end();
+                true
+            }
             KeyCode::Home => {
                 self.move_home();
                 true
@@ -181,6 +367,9 @@ impl TextInput {
             }
             KeyCode::Char(c) if !has_ctrl => {
                 self.insert_char(c);
+                if is_multiline {
+                    self.ensure_cursor_visible();
+                }
                 true
             }
             _ => false,
@@ -217,6 +406,32 @@ pub(crate) fn clamp_cursor(text: &str, cursor: usize) -> usize {
     } else {
         prev_char_boundary(text, cursor)
     }
+}
+
+/// Compute the byte offset of a given (line, column) position in character units.
+/// If the target line is shorter than `col`, the offset lands at the line's end.
+fn byte_offset_at(text: &str, target_line: usize, target_col: usize) -> usize {
+    let mut line = 0;
+    let mut byte = 0;
+    for (i, ch) in text.char_indices() {
+        if line == target_line {
+            // We're on the target line — count columns.
+            let line_start = byte;
+            for (col, (j, c)) in text[line_start..].char_indices().enumerate() {
+                if c == '\n' || col == target_col {
+                    return line_start + j;
+                }
+            }
+            // Reached end of text on this line.
+            return text.len();
+        }
+        if ch == '\n' {
+            line += 1;
+        }
+        byte = i + ch.len_utf8();
+    }
+    // target_line beyond total lines — return end of text.
+    text.len()
 }
 
 fn is_word_char(c: char) -> bool {
@@ -386,10 +601,8 @@ mod tests {
 
     #[test]
     fn delete_word_deletes_forward() {
-        let mut ti = TextInput {
-            text: "hello world".into(),
-            cursor: 0,
-        };
+        let mut ti = TextInput::with_text("hello world".into());
+        ti.cursor = 0;
         ti.delete_word();
         assert_eq!(ti.text, "world");
         assert_eq!(ti.cursor, 0);
@@ -408,10 +621,8 @@ mod tests {
 
     #[test]
     fn backspace_word_at_start_is_noop() {
-        let mut ti = TextInput {
-            text: "hello".into(),
-            cursor: 0,
-        };
+        let mut ti = TextInput::with_text("hello".into());
+        ti.cursor = 0;
         ti.backspace_word();
         assert_eq!(ti.text, "hello");
         assert_eq!(ti.cursor, 0);
@@ -476,20 +687,16 @@ mod tests {
 
     #[test]
     fn handle_key_alt_delete() {
-        let mut ti = TextInput {
-            text: "hello world".into(),
-            cursor: 0,
-        };
+        let mut ti = TextInput::with_text("hello world".into());
+        ti.cursor = 0;
         assert!(ti.handle_key(key_alt(KeyCode::Delete)));
         assert_eq!(ti.text, "world");
     }
 
     #[test]
     fn handle_key_ctrl_delete() {
-        let mut ti = TextInput {
-            text: "hello world".into(),
-            cursor: 0,
-        };
+        let mut ti = TextInput::with_text("hello world".into());
+        ti.cursor = 0;
         assert!(ti.handle_key(key_ctrl(KeyCode::Delete)));
         assert_eq!(ti.text, "world");
     }
@@ -543,5 +750,216 @@ mod tests {
         ti.insert_char('X');
         assert_eq!(ti.text, "helXlo");
         assert_eq!(ti.cursor, 4);
+    }
+
+    // ── Multiline tests ───────────────────────────────────────────
+
+    fn multiline_input(text: &str, visible: usize) -> TextInput {
+        TextInput::with_text(text.to_string()).with_multiline(visible)
+    }
+
+    #[test]
+    fn multiline_enter_inserts_newline() {
+        let mut ti = TextInput::new().with_multiline(5);
+        assert!(ti.handle_key(key(KeyCode::Char('a'))));
+        assert!(ti.handle_key(key(KeyCode::Enter)));
+        assert!(ti.handle_key(key(KeyCode::Char('b'))));
+        assert_eq!(ti.text, "a\nb");
+        assert_eq!(ti.total_lines(), 2);
+    }
+
+    #[test]
+    fn singleline_enter_not_consumed() {
+        let mut ti = TextInput::new();
+        assert!(!ti.handle_key(key(KeyCode::Enter)));
+        assert!(ti.text.is_empty());
+    }
+
+    #[test]
+    fn multiline_up_down_navigation() {
+        // "hello\nworld\nfoo"
+        let mut ti = multiline_input("hello\nworld\nfoo", 10);
+        // Cursor at end (byte 15), line 2, col 3
+        assert_eq!(ti.cursor_line_col(), (2, 3));
+
+        ti.move_up();
+        // Line 1, col 3 → byte 6 + 3 = 9 ("worl|d")
+        assert_eq!(ti.cursor_line_col(), (1, 3));
+        assert_eq!(ti.cursor, 9);
+
+        ti.move_up();
+        // Line 0, col 3 → byte 3 ("hel|lo")
+        assert_eq!(ti.cursor_line_col(), (0, 3));
+        assert_eq!(ti.cursor, 3);
+
+        // Already at line 0, move_up is a no-op
+        ti.move_up();
+        assert_eq!(ti.cursor_line_col(), (0, 3));
+
+        ti.move_down();
+        assert_eq!(ti.cursor_line_col(), (1, 3));
+
+        ti.move_down();
+        assert_eq!(ti.cursor_line_col(), (2, 3));
+
+        // Already at last line, move_down is a no-op
+        ti.move_down();
+        assert_eq!(ti.cursor_line_col(), (2, 3));
+    }
+
+    #[test]
+    fn multiline_up_clamps_to_shorter_line() {
+        // "hi\nworld" — line 0 has 2 chars, line 1 has 5
+        let mut ti = multiline_input("hi\nworld", 10);
+        // Cursor at end of "world", col 5
+        assert_eq!(ti.cursor_line_col(), (1, 5));
+
+        ti.move_up();
+        // Line 0 only has 2 chars, so clamp to col 2 → end of "hi"
+        assert_eq!(ti.cursor_line_col(), (0, 2));
+        assert_eq!(ti.cursor, 2);
+    }
+
+    #[test]
+    fn multiline_down_clamps_to_shorter_line() {
+        // "world\nhi" — line 0 has 5 chars, line 1 has 2
+        let mut ti = multiline_input("world\nhi", 10);
+        ti.cursor = 5; // end of "world", col 5
+
+        ti.move_down();
+        // Line 1 only has 2 chars, so clamp to col 2 → end of "hi"
+        assert_eq!(ti.cursor_line_col(), (1, 2));
+        assert_eq!(ti.cursor, 8); // "world\nhi".len()
+    }
+
+    #[test]
+    fn singleline_up_down_not_consumed() {
+        let mut ti = TextInput::with_text("hello".into());
+        assert!(!ti.handle_key(key(KeyCode::Up)));
+        assert!(!ti.handle_key(key(KeyCode::Down)));
+    }
+
+    #[test]
+    fn multiline_up_down_consumed() {
+        let mut ti = multiline_input("a\nb", 5);
+        assert!(ti.handle_key(key(KeyCode::Up)));
+        assert!(ti.handle_key(key(KeyCode::Down)));
+    }
+
+    #[test]
+    fn multiline_home_end_line_level() {
+        let mut ti = multiline_input("hello\nworld", 10);
+        ti.cursor = 9; // "world" col 3 → "wor|ld"
+
+        ti.handle_key(key(KeyCode::Home));
+        assert_eq!(ti.cursor, 6); // start of "world"
+
+        ti.handle_key(key(KeyCode::End));
+        assert_eq!(ti.cursor, 11); // end of "world"
+    }
+
+    #[test]
+    fn singleline_home_end_text_level() {
+        let mut ti = TextInput::with_text("hello".into());
+        ti.handle_key(key(KeyCode::Home));
+        assert_eq!(ti.cursor, 0);
+        ti.handle_key(key(KeyCode::End));
+        assert_eq!(ti.cursor, 5);
+    }
+
+    #[test]
+    fn scroll_offset_adjusts_on_move_down() {
+        // 5 lines, visible_lines = 3
+        let mut ti = multiline_input("a\nb\nc\nd\ne", 3);
+        ti.cursor = 0; // line 0
+        assert_eq!(ti.scroll_offset(), 0);
+
+        ti.move_down(); // line 1
+        ti.move_down(); // line 2
+        assert_eq!(ti.scroll_offset(), 0); // still visible
+
+        ti.move_down(); // line 3 — scrolls
+        assert_eq!(ti.scroll_offset(), 1);
+        assert_eq!(ti.cursor_line_col(), (3, 0));
+
+        ti.move_down(); // line 4 — scrolls more
+        assert_eq!(ti.scroll_offset(), 2);
+    }
+
+    #[test]
+    fn scroll_offset_adjusts_on_move_up() {
+        let mut ti = multiline_input("a\nb\nc\nd\ne", 3);
+        // Start at line 4
+        assert_eq!(ti.cursor_line_col(), (4, 1));
+        ti.ensure_cursor_visible();
+        assert_eq!(ti.scroll_offset(), 2); // lines 2,3,4 visible
+
+        ti.move_up(); // line 3
+        assert_eq!(ti.scroll_offset(), 2); // still in window
+
+        ti.move_up(); // line 2
+        assert_eq!(ti.scroll_offset(), 2); // still in window
+
+        ti.move_up(); // line 1 — scrolls up
+        assert_eq!(ti.scroll_offset(), 1);
+
+        ti.move_up(); // line 0 — scrolls up
+        assert_eq!(ti.scroll_offset(), 0);
+    }
+
+    #[test]
+    fn visible_lines_returns_correct_slice() {
+        let mut ti = multiline_input("a\nb\nc\nd\ne", 3);
+        ti.cursor = 0;
+        assert_eq!(ti.visible_lines(), vec!["a", "b", "c"]);
+
+        // Scroll to show lines 1,2,3
+        ti.move_down();
+        ti.move_down();
+        ti.move_down(); // line 3, scroll_offset = 1
+        assert_eq!(ti.visible_lines(), vec!["b", "c", "d"]);
+    }
+
+    #[test]
+    fn cursor_display_position_accounts_for_scroll() {
+        let mut ti = multiline_input("a\nb\nc\nd\ne", 3);
+        ti.cursor = 0; // line 0, col 0
+        assert_eq!(ti.cursor_display_position(), (0, 0));
+
+        // Move to line 3, col 0 — scroll_offset becomes 1
+        ti.move_down();
+        ti.move_down();
+        ti.move_down();
+        assert_eq!(ti.cursor_line_col(), (3, 0));
+        assert_eq!(ti.scroll_offset(), 1);
+        assert_eq!(ti.cursor_display_position(), (2, 0)); // line 3 - offset 1 = display row 2
+    }
+
+    #[test]
+    fn total_lines_count() {
+        assert_eq!(TextInput::new().total_lines(), 1);
+        assert_eq!(TextInput::with_text("a".into()).total_lines(), 1);
+        assert_eq!(TextInput::with_text("a\nb".into()).total_lines(), 2);
+        assert_eq!(TextInput::with_text("a\nb\nc".into()).total_lines(), 3);
+        assert_eq!(TextInput::with_text("\n".into()).total_lines(), 2);
+    }
+
+    #[test]
+    fn byte_offset_at_various() {
+        let text = "hello\nworld\nfoo";
+        assert_eq!(byte_offset_at(text, 0, 0), 0);
+        assert_eq!(byte_offset_at(text, 0, 3), 3);
+        assert_eq!(byte_offset_at(text, 0, 5), 5); // end of "hello" (before \n)
+        assert_eq!(byte_offset_at(text, 1, 0), 6);
+        assert_eq!(byte_offset_at(text, 1, 3), 9);
+        assert_eq!(byte_offset_at(text, 2, 0), 12);
+        assert_eq!(byte_offset_at(text, 2, 3), 15); // end of text
+    }
+
+    #[test]
+    fn byte_offset_at_clamps_col() {
+        // Line "hi" has only 2 chars; requesting col 5 gives end of line
+        let text = "hi\nworld";
+        assert_eq!(byte_offset_at(text, 0, 5), 2); // clamped to end of "hi"
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct Config {
     pub ui: UiConfig,
     pub editor: EditorConfig,
     pub keys: KeysConfig,
+    pub macros: MacrosConfig,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -43,6 +44,56 @@ pub struct KeysConfig {
     pub show_terminal_keys: bool,
     #[serde(flatten)]
     pub bindings: BTreeMap<String, Vec<String>>,
+}
+
+/// A single text macro entry — either a plain text string or a named entry.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MacroEntry {
+    /// Plain string: `a = "some text"`
+    Plain(String),
+    /// Named: `b = { name = "Review", text = "review this code" }`
+    Named { name: String, text: String },
+}
+
+impl MacroEntry {
+    pub fn text(&self) -> &str {
+        match self {
+            Self::Plain(s) => s,
+            Self::Named { text, .. } => text,
+        }
+    }
+
+    pub fn display_name(&self, letter: &str) -> String {
+        match self {
+            Self::Named { name, .. } if !name.is_empty() => name.clone(),
+            _ => letter.to_string(),
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Named { name, .. } if !name.is_empty() => Some(name),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MacrosConfig {
+    pub prefix: String,
+    #[serde(flatten)]
+    pub entries: BTreeMap<String, MacroEntry>,
+}
+
+impl Default for MacrosConfig {
+    fn default() -> Self {
+        Self {
+            prefix: "shift-alt".to_string(),
+            entries: BTreeMap::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -144,6 +195,7 @@ impl Default for Config {
             },
             editor: EditorConfig::default(),
             keys: KeysConfig::default(),
+            macros: MacrosConfig::default(),
         }
     }
 }
@@ -396,6 +448,8 @@ enum ConfigEntry {
     Projects,
     /// Renders the `[keys]` section with all keybindings.
     Keys,
+    /// Renders the `[macros]` section with text macros.
+    Macros,
 }
 
 fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
@@ -504,6 +558,8 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
         ConfigEntry::Blank,
         ConfigEntry::Keys,
         ConfigEntry::Blank,
+        ConfigEntry::Macros,
+        ConfigEntry::Blank,
         ConfigEntry::Projects,
     ]
 }
@@ -562,6 +618,7 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
             ConfigEntry::Terminal => render_terminal_config(&mut out, &config.terminal),
             ConfigEntry::Projects => render_projects(&mut out, &config.projects),
             ConfigEntry::Keys => render_keys_config(&mut out, &config.keys, bindings),
+            ConfigEntry::Macros => render_macros_config(&mut out, &config.macros),
         }
     }
     out
@@ -643,6 +700,44 @@ fn render_keys_config(
         let _ = writeln!(out, "{config_name} = {}", render_string_list(&key_strs));
     }
     out.push('\n');
+}
+
+fn render_macros_config(out: &mut String, macros: &MacrosConfig) {
+    out.push_str("[macros]\n");
+    out.push_str(
+        "# Prefix modifier for triggering macros in interactive mode.\n\
+         # Press this modifier combo + a letter (a-z) to paste the macro text.\n\
+         # Supported: \"shift-alt\" (default), \"ctrl-alt\".\n\
+         # If your terminal multiplexer swallows Shift-Alt, try \"ctrl-alt\".\n",
+    );
+    let _ = writeln!(out, "prefix = \"{}\"", escape_toml_string(&macros.prefix));
+    out.push('\n');
+    if macros.entries.is_empty() {
+        out.push_str(
+            "# Define macros as single lowercase letters mapped to text.\n\
+             # The text is pasted via bracketed paste so newlines are safe.\n\
+             # Use a plain string for simple macros:\n\
+             # a = \"review this code for bugs and security issues\"\n\
+             # Or use an inline table to add a human-readable name:\n\
+             # b = { name = \"Explain function\", text = \"explain what this function does\" }\n",
+        );
+    } else {
+        for (letter, entry) in &macros.entries {
+            match entry {
+                MacroEntry::Plain(text) => {
+                    let _ = writeln!(out, "{letter} = \"{}\"", escape_toml_string(text));
+                }
+                MacroEntry::Named { name, text } => {
+                    let _ = writeln!(
+                        out,
+                        "{letter} = {{ name = \"{}\", text = \"{}\" }}",
+                        escape_toml_string(name),
+                        escape_toml_string(text),
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn render_projects(out: &mut String, projects: &[ProjectConfig]) {
@@ -1493,5 +1588,106 @@ oneshot_output = "stdout"
             msg.contains("new_agent"),
             "error should name second action: {msg}"
         );
+    }
+
+    // ── MacrosConfig tests ────────────────────────────────────────
+
+    #[test]
+    fn macros_config_default_is_empty() {
+        let config = MacrosConfig::default();
+        assert_eq!(config.prefix, "shift-alt");
+        assert!(config.entries.is_empty());
+    }
+
+    #[test]
+    fn macros_config_plain_entry_round_trip() {
+        let toml_str = r#"
+prefix = "shift-alt"
+a = "review this code"
+"#;
+        let config: MacrosConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.prefix, "shift-alt");
+        assert_eq!(config.entries.len(), 1);
+        assert_eq!(config.entries["a"].text(), "review this code");
+    }
+
+    #[test]
+    fn macros_config_named_entry_round_trip() {
+        let toml_str = r#"
+prefix = "ctrl-alt"
+b = { name = "Explain", text = "explain this function" }
+"#;
+        let config: MacrosConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.prefix, "ctrl-alt");
+        let entry = &config.entries["b"];
+        assert_eq!(entry.text(), "explain this function");
+        assert_eq!(entry.display_name("b"), "Explain");
+    }
+
+    #[test]
+    fn macros_config_mixed_entries() {
+        let toml_str = r#"
+prefix = "shift-alt"
+a = "simple"
+b = { name = "Named", text = "complex" }
+"#;
+        let config: MacrosConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.entries.len(), 2);
+        assert_eq!(config.entries["a"].text(), "simple");
+        assert_eq!(config.entries["a"].display_name("a"), "a");
+        assert_eq!(config.entries["b"].text(), "complex");
+        assert_eq!(config.entries["b"].display_name("b"), "Named");
+    }
+
+    #[test]
+    fn macros_config_display_name_falls_back_to_letter() {
+        let entry = MacroEntry::Plain("text".to_string());
+        assert_eq!(entry.display_name("x"), "x");
+
+        let entry_empty_name = MacroEntry::Named {
+            name: String::new(),
+            text: "text".to_string(),
+        };
+        assert_eq!(entry_empty_name.display_name("x"), "x");
+    }
+
+    #[test]
+    fn render_macros_config_empty() {
+        let config = Config::default();
+        let rendered = render_config_default(&config);
+        assert!(rendered.contains("[macros]"));
+        assert!(rendered.contains("prefix = \"shift-alt\""));
+        assert!(rendered.contains("# a = \"review this code"));
+    }
+
+    #[test]
+    fn render_macros_config_with_entries() {
+        let mut config = Config::default();
+        config.macros.entries.insert(
+            "a".to_string(),
+            MacroEntry::Plain("hello world".to_string()),
+        );
+        config.macros.entries.insert(
+            "b".to_string(),
+            MacroEntry::Named {
+                name: "Test".to_string(),
+                text: "foo bar".to_string(),
+            },
+        );
+        let rendered = render_config_default(&config);
+        assert!(rendered.contains("a = \"hello world\""));
+        assert!(rendered.contains("b = { name = \"Test\", text = \"foo bar\" }"));
+    }
+
+    #[test]
+    fn render_macros_config_escapes_special_chars() {
+        let mut config = Config::default();
+        config.macros.entries.insert(
+            "a".to_string(),
+            MacroEntry::Plain("line1\nline2".to_string()),
+        );
+        let rendered = render_config_default(&config);
+        // Newlines must be escaped in the TOML output
+        assert!(rendered.contains("a = \"line1\\nline2\""));
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -73,6 +73,7 @@ pub enum Action {
     SortAgentsByCreated,
     SortAgentsByName,
     RemoveGitPane,
+    EditMacros,
 }
 
 /// Where a binding's key combo is matched.
@@ -209,6 +210,7 @@ impl Action {
             Action::SortAgentsByCreated => "sort_agents_by_created",
             Action::SortAgentsByName => "sort_agents_by_name",
             Action::RemoveGitPane => "remove_git_pane",
+            Action::EditMacros => "edit_macros",
         }
     }
 
@@ -283,6 +285,7 @@ impl Action {
             Action::SortAgentsByCreated => "Sort agents by creation date (newest first).",
             Action::SortAgentsByName => "Sort agents alphabetically by name.",
             Action::RemoveGitPane => "Remove or restore the git pane.",
+            Action::EditMacros => "Open the text macros editor.",
         }
     }
 
@@ -347,7 +350,8 @@ impl Action {
             | Action::SortAgentsByUpdated
             | Action::SortAgentsByCreated
             | Action::SortAgentsByName
-            | Action::RemoveGitPane => None,
+            | Action::RemoveGitPane
+            | Action::EditMacros => None,
         }
     }
 }
@@ -1175,6 +1179,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             description: "Remove or restore the git pane entirely",
         }),
     },
+    BindingDef {
+        action: Action::EditMacros,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "edit-macros",
+            description: "Edit text macros for interactive mode",
+        }),
+    },
 ];
 
 const HELP_SECTION_ORDER: &[&str] = &[
@@ -1582,6 +1597,76 @@ impl InteractiveBytePatterns {
             .iter()
             .find(|b| b.pattern == seq)
             .map(|b| (b.action, b.conditional))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text macro byte patterns — separate from interactive bindings because
+// macros are user-configured in [macros] rather than [keys].
+// ---------------------------------------------------------------------------
+
+/// A single macro byte pattern: the raw bytes that trigger it and the letter ID.
+#[derive(Debug, Clone)]
+pub struct MacroByteBinding {
+    pub pattern: Vec<u8>,
+    pub letter: char,
+}
+
+/// Precomputed byte patterns for all configured text macros.
+/// Built at startup and rebuilt when macros are edited.
+#[derive(Debug, Clone)]
+pub struct MacroBytePatterns {
+    pub bindings: Vec<MacroByteBinding>,
+}
+
+impl MacroBytePatterns {
+    /// Build byte patterns from the macros config.
+    /// Skips entries whose key is not a single lowercase ASCII letter
+    /// or whose text is empty.
+    pub fn build(macros: &crate::config::MacrosConfig) -> Self {
+        let mut bindings = Vec::new();
+        for (key, entry) in &macros.entries {
+            if key.len() != 1 {
+                continue;
+            }
+            let letter = key.chars().next().unwrap();
+            if !letter.is_ascii_lowercase() {
+                continue;
+            }
+            if entry.text().is_empty() {
+                continue;
+            }
+            if let Some(pattern) = macro_prefix_bytes(&macros.prefix, letter) {
+                bindings.push(MacroByteBinding { pattern, letter });
+            }
+        }
+        Self { bindings }
+    }
+
+    /// Match a raw byte sequence against macro patterns.
+    /// Returns the letter ID of the matched macro.
+    pub fn match_sequence(&self, seq: &[u8]) -> Option<char> {
+        self.bindings
+            .iter()
+            .find(|b| b.pattern == seq)
+            .map(|b| b.letter)
+    }
+}
+
+/// Convert a macro prefix string and letter to the raw byte pattern
+/// that a terminal would send for that key combination.
+fn macro_prefix_bytes(prefix: &str, letter: char) -> Option<Vec<u8>> {
+    match prefix.to_lowercase().as_str() {
+        "shift-alt" | "alt-shift" => {
+            // Shift+Alt+letter = ESC + uppercase letter
+            Some(vec![0x1b, letter.to_ascii_uppercase() as u8])
+        }
+        "ctrl-alt" | "alt-ctrl" => {
+            // Ctrl+Alt+letter = ESC + control character (0x01..0x1a)
+            let ctrl = letter as u8 - b'a' + 1;
+            Some(vec![0x1b, ctrl])
+        }
+        _ => None,
     }
 }
 
@@ -2284,5 +2369,83 @@ mod tests {
         let patterns = bindings.interactive_byte_patterns();
         // Random byte sequence should not match
         assert!(patterns.match_sequence(&[0x01]).is_none());
+    }
+
+    // ── Macro byte patterns ──────────────────────────────────────
+
+    #[test]
+    fn macro_prefix_bytes_shift_alt() {
+        assert_eq!(macro_prefix_bytes("shift-alt", 'a'), Some(vec![0x1b, 0x41]));
+        assert_eq!(macro_prefix_bytes("shift-alt", 'z'), Some(vec![0x1b, 0x5a]));
+        assert_eq!(macro_prefix_bytes("alt-shift", 'a'), Some(vec![0x1b, 0x41]));
+    }
+
+    #[test]
+    fn macro_prefix_bytes_ctrl_alt() {
+        assert_eq!(macro_prefix_bytes("ctrl-alt", 'a'), Some(vec![0x1b, 0x01]));
+        assert_eq!(macro_prefix_bytes("ctrl-alt", 'z'), Some(vec![0x1b, 0x1a]));
+        assert_eq!(macro_prefix_bytes("alt-ctrl", 'a'), Some(vec![0x1b, 0x01]));
+    }
+
+    #[test]
+    fn macro_prefix_bytes_unknown_returns_none() {
+        assert_eq!(macro_prefix_bytes("super", 'a'), None);
+        assert_eq!(macro_prefix_bytes("", 'a'), None);
+    }
+
+    #[test]
+    fn macro_byte_patterns_build_and_match() {
+        use crate::config::{MacroEntry, MacrosConfig};
+        use std::collections::BTreeMap;
+
+        let mut entries = BTreeMap::new();
+        entries.insert("a".to_string(), MacroEntry::Plain("hello".to_string()));
+        entries.insert(
+            "b".to_string(),
+            MacroEntry::Named {
+                name: "Test".to_string(),
+                text: "world".to_string(),
+            },
+        );
+        let config = MacrosConfig {
+            prefix: "shift-alt".to_string(),
+            entries,
+        };
+
+        let patterns = MacroBytePatterns::build(&config);
+        assert_eq!(patterns.bindings.len(), 2);
+
+        // Shift+Alt+A = ESC + 'A'
+        assert_eq!(patterns.match_sequence(&[0x1b, 0x41]), Some('a'));
+        // Shift+Alt+B = ESC + 'B'
+        assert_eq!(patterns.match_sequence(&[0x1b, 0x42]), Some('b'));
+        // Shift+Alt+C — not configured
+        assert_eq!(patterns.match_sequence(&[0x1b, 0x43]), None);
+        // Plain Alt+a (lowercase) — should NOT match
+        assert_eq!(patterns.match_sequence(&[0x1b, 0x61]), None);
+    }
+
+    #[test]
+    fn macro_byte_patterns_skips_invalid_keys() {
+        use crate::config::{MacroEntry, MacrosConfig};
+        use std::collections::BTreeMap;
+
+        let mut entries = BTreeMap::new();
+        // Valid
+        entries.insert("a".to_string(), MacroEntry::Plain("ok".to_string()));
+        // Invalid: uppercase
+        entries.insert("B".to_string(), MacroEntry::Plain("skip".to_string()));
+        // Invalid: multi-char
+        entries.insert("ab".to_string(), MacroEntry::Plain("skip".to_string()));
+        // Invalid: empty text
+        entries.insert("c".to_string(), MacroEntry::Plain(String::new()));
+        let config = MacrosConfig {
+            prefix: "shift-alt".to_string(),
+            entries,
+        };
+
+        let patterns = MacroBytePatterns::build(&config);
+        assert_eq!(patterns.bindings.len(), 1);
+        assert_eq!(patterns.bindings[0].letter, 'a');
     }
 }


### PR DESCRIPTION
Introduces a text macro system for interactive mode. Users define macros in `config.toml` under a `[macros]` section, mapping single letters (a-z) to text snippets. Pressing a configurable prefix key combo (default `Shift-Alt`) plus a letter pastes the corresponding text into the agent's PTY using bracketed paste mode, so multi-line content is delivered atomically without triggering premature execution. Each macro can optionally include a human-readable name displayed in the status bar when triggered (e.g., `Pasted macro "Review code"`). The prefix is configurable to accommodate terminal multiplexers like tmux that may not pass `Shift-Alt` through correctly — `ctrl-alt` is available as an alternative.

A new command palette action **edit-macros** provides a full in-app editor for managing macros without leaving dux. The editor supports a list view for browsing, creating (`n`), editing (`Enter`), and deleting (`d`) macros, plus a multi-stage edit flow: pick a letter, set an optional display name, then compose the macro text in a multiline editor where `Enter` inserts newlines and `Esc` saves. Changes are persisted to `config.toml` immediately and the byte-pattern matcher is rebuilt on the fly.

This PR also extends `TextInput` with optional multiline support — `Enter` inserts newlines, `Up`/`Down` navigate between lines, `Home`/`End` operate at line level, and scroll offset keeps the cursor visible within a configurable viewport. Single-line mode remains the default; all existing call sites are unchanged. The multiline capability is used by the macro text editor and is available for future multiline input fields. Includes 29 new unit tests covering byte-pattern matching, config round-trips, rendering, and multiline navigation.