### PR TITLE
Show provider name in agent titles and shorten interactive hint bar

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -5239,10 +5239,12 @@ mod tests {
         let mut app = test_app(default_bindings());
         assert!(!app.right_hidden);
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
         assert!(app.right_hidden);
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
         assert!(!app.right_hidden);
     }
 
@@ -5251,7 +5253,8 @@ mod tests {
         let mut app = test_app(default_bindings());
         app.focus = FocusPane::Files;
 
-        app.execute_command("toggle-remove-git-pane".to_string()).unwrap();
+        app.execute_command("toggle-remove-git-pane".to_string())
+            .unwrap();
 
         assert!(app.right_hidden);
         assert_eq!(app.focus, FocusPane::Center);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -673,8 +673,7 @@ impl App {
                 // Check SIGWINCH — needed when bypassing crossterm's event
                 // reader (which would otherwise deliver Resize events).
                 if self.sigwinch_flag.swap(false, Ordering::Relaxed) {
-                    if let Err(err) =
-                        crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
+                    if let Err(err) = crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
                     {
                         self.report_runtime_error("terminal resize failed", &err);
                     }
@@ -709,19 +708,18 @@ impl App {
                     }
                 } else {
                     // Normal UI mode: use crossterm's structured event reader.
-                    let ready =
-                        match crate::io_retry::retry_on_interrupt(|| {
-                            event::poll(Duration::from_millis(100))
-                        }) {
-                            Ok(ready) => ready,
-                            Err(err) => {
-                                self.report_runtime_error(
-                                    "event polling failed; input handling was skipped",
-                                    &err,
-                                );
-                                false
-                            }
-                        };
+                    let ready = match crate::io_retry::retry_on_interrupt(|| {
+                        event::poll(Duration::from_millis(100))
+                    }) {
+                        Ok(ready) => ready,
+                        Err(err) => {
+                            self.report_runtime_error(
+                                "event polling failed; input handling was skipped",
+                                &err,
+                            );
+                            false
+                        }
+                    };
                     if ready {
                         let event = match crate::io_retry::retry_on_interrupt(event::read) {
                             Ok(event) => event,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,6 +15,15 @@ const ASCII_LOGO_WIDTH: u16 = 33;
 /// Number of lines in `ASCII_LOGO`.
 const ASCII_LOGO_HEIGHT: u16 = 7;
 
+/// Capitalize the first character of a string.
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        Some(first) => format!("{}{}", first.to_uppercase(), c.as_str()),
+        None => String::new(),
+    }
+}
+
 impl App {
     pub(crate) fn render(&mut self, frame: &mut Frame) {
         let term_w = frame.area().width as usize;
@@ -750,34 +759,17 @@ impl App {
             let hint_line = if is_input {
                 let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
                 let mut spans: Vec<Span> = Vec::new();
-                let cli_name = session_provider_name
-                    .as_deref()
-                    .unwrap_or(match active_surface {
-                        SessionSurface::Agent => "agent",
-                        SessionSurface::Terminal => "terminal",
-                    });
-                let capitalized = {
-                    let mut c = cli_name.chars();
-                    match c.next() {
-                        Some(first) => format!("{}{}", first.to_uppercase(), c.as_str()),
-                        None => String::new(),
-                    }
-                };
-                spans.push(Span::styled(
-                    format!("{capitalized} is holding focus. Press "),
-                    desc_style,
-                ));
                 spans.extend(self.theme.dim_key_badge_default(&exit_key));
-                spans.push(Span::styled(" to return to the app. ", desc_style));
+                spans.push(Span::styled(" return  ", desc_style));
                 spans.extend(self.theme.dim_key_badge_default(&scroll_up));
-                spans.push(Span::styled(" up, ", desc_style));
+                spans.push(Span::styled(" up  ", desc_style));
                 spans.extend(self.theme.dim_key_badge_default(&scroll_down));
                 if scrollback_offset > 0 {
-                    spans.push(Span::styled(" page down, or ", desc_style));
+                    spans.push(Span::styled(" down  ", desc_style));
                     spans.extend(self.theme.dim_key_badge_default(&scroll_line));
-                    spans.push(Span::styled(" down one line.", desc_style));
+                    spans.push(Span::styled(" down one line", desc_style));
                 } else {
-                    spans.push(Span::styled(" page down.", desc_style));
+                    spans.push(Span::styled(" down", desc_style));
                 }
                 Line::from(spans)
             } else if scrollback_offset > 0 {
@@ -2780,9 +2772,13 @@ impl App {
         self.render_dim_overlay(frame);
         let area = centered_rect(96, 94, frame.area());
         Clear.render(area, frame.buffer_mut());
+        let title = match self.selected_session() {
+            Some(session) => format!(" {} agent ", capitalize(session.provider.as_str())),
+            None => " Agent ".to_string(),
+        };
         let saved = self.session_surface;
         self.session_surface = SessionSurface::Agent;
-        self.render_agent_terminal(frame, area, " Agent (fullscreen) ", true);
+        self.render_agent_terminal(frame, area, &title, true);
         self.session_surface = saved;
     }
 
@@ -2822,12 +2818,15 @@ impl App {
 
     fn center_pane_agent_title(&self) -> String {
         if let Some(session) = self.selected_session() {
+            let provider = capitalize(session.provider.as_str());
+            let base = format!("{provider} agent");
             let count = self.session_terminal_count(&session.id);
             if count == 1 {
-                return "Agent (+ 1 terminal)".to_string();
+                return format!("{base} (+ 1 terminal)");
             } else if count > 1 {
-                return format!("Agent (+ {count} terminals)");
+                return format!("{base} (+ {count} terminals)");
             }
+            return base;
         }
         "Agent".to_string()
     }
@@ -3466,5 +3465,32 @@ mod tests {
             "After deletion: cursor at ({crow},{ccol}) should show {expected_char:?}, got {:?}",
             cell.symbol()
         );
+    }
+
+    // ── Unit tests for capitalize ─────────────────────────────────
+
+    #[test]
+    fn capitalize_normal_string() {
+        assert_eq!(capitalize("claude"), "Claude");
+    }
+
+    #[test]
+    fn capitalize_already_capitalized() {
+        assert_eq!(capitalize("Claude"), "Claude");
+    }
+
+    #[test]
+    fn capitalize_single_char() {
+        assert_eq!(capitalize("c"), "C");
+    }
+
+    #[test]
+    fn capitalize_empty_string() {
+        assert_eq!(capitalize(""), "");
+    }
+
+    #[test]
+    fn capitalize_all_uppercase() {
+        assert_eq!(capitalize("CODEX"), "CODEX");
     }
 }


### PR DESCRIPTION
The agent pane previously showed generic labels like "Agent" and "Agent (fullscreen)" regardless of which provider was running. These titles now display the actual provider name — for example, "Claude agent" or "Codex agent" — in both the center pane and the fullscreen overlay, making it immediately clear which tool is active.

The hint bar shown during interactive mode used to read `"{Agent} is holding focus. Press ^G to return to the app."` followed by scroll hints. Since the provider identity is now in the pane title, this message was redundant and verbose. It has been replaced with compact key-only hints (`^G return  PgUp up  PgDn down`), reducing visual noise while preserving all the same keybinding information.

A `capitalize()` helper was extracted to avoid duplicating the first-character uppercasing logic across the title builder and the hint bar. Five unit tests cover its edge cases (empty string, single character, already capitalized, all uppercase, and normal input). The remaining changes in `input.rs` and `mod.rs` are `cargo fmt` reformatting only.