### PR TITLE
Add OpenCode and Gemini CLI as built-in providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 
 - **A provider is supported if and only if it supports PTY and oneshot mode.** PTY for interactive sessions; oneshot (headless: send a prompt, get one response) for automated tasks like commit message generation.
 - **Any CLI tool can be a provider.** Configure `command` in `config.toml` and dux spawns it. No adapters, no protocol layer. Adding a new provider is a config-only change, not a code change.
-- **Claude and Codex are the defaults.**
+- **Claude, Codex, OpenCode, and Gemini CLI are the defaults.**
 - **No protocol layer.** No JSON-RPC, no custom message format, no adapter binaries. The CLI runs exactly as it would in a normal terminal.
 
 ### Git and Data Safety
@@ -47,7 +47,7 @@ The current app provides:
 - Commented user config in the platform-specific dux config directory (`~/.dux/` on macOS, `~/.config/dux/` on Linux)
 - Session persistence in `sessions.sqlite3` alongside the config
 - Logging in `dux.log` alongside the config
-- PTY-based agent startup: spawns CLI tools (`claude`, `codex`) directly in a pseudo-terminal
+- PTY-based agent startup: spawns CLI tools (`claude`, `codex`, `opencode`, `gemini`) directly in a pseudo-terminal
 
 ## Important Constraints
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 ## How It Works
 
-`dux` spawns AI CLI tools (`claude`, `codex`, or any terminal command) directly in a pseudo-terminal (PTY) and renders their output in real time. There is no protocol layer, no adapter binaries, and no JSON-RPC — just the official CLI running exactly as it would in your terminal.
+`dux` spawns AI CLI tools (`claude`, `codex`, `opencode`, `gemini`, or any terminal command) directly in a pseudo-terminal (PTY) and renders their output in real time. There is no protocol layer, no adapter binaries, and no JSON-RPC — just the official CLI running exactly as it would in your terminal.
 
 This means:
 
 - **Bring any CLI.** Any AI coding tool that runs in a terminal works with dux. Configure the command and args in `config.toml` and you're set.
 - **No banning risks.** You're running the official CLI the way it was designed to be used — the same binary, the same auth, the same API calls.
 - **Full CLI feature support.** Hooks, MCP servers, skills, slash commands, permission dialogs, thinking indicators — everything the CLI supports works out of the box because dux is just hosting the real terminal session.
-- **Crash recovery.** If dux crashes, the agent process dies, but dux can reconnect in the same worktree. Providers with configured `resume_args` (like the built-in Claude and Codex defaults) can resume the CLI conversation for that folder/worktree.
+- **Crash recovery.** If dux crashes, the agent process dies, but dux can reconnect in the same worktree. Providers with configured `resume_args` (like the built-in Claude, Codex, OpenCode, and Gemini defaults) can resume the CLI conversation for that folder/worktree.
 
 ## Features
 
@@ -40,7 +40,7 @@ If you want a full wipe, run `dux reset --delete-agent-data` to also remove `ses
 
 ## Provider Setup
 
-The provider commands in `config.toml` point to the CLI tools you want dux to run. By default, `claude` and `codex` are configured, and new sessions start with `claude` unless you override it per project or in `[defaults]`. dux launches the configured command in a PTY inside the session's worktree directory, so the CLI tool sees the worktree as its working directory.
+The provider commands in `config.toml` point to the CLI tools you want dux to run. By default, `claude`, `codex`, `opencode`, and `gemini` are configured, and new sessions start with `claude` unless you override it per project or in `[defaults]`. dux launches the configured command in a PTY inside the session's worktree directory, so the CLI tool sees the worktree as its working directory.
 
 To use a different CLI tool, set the `command` field in the `[providers.<name>]` section of your config.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -5124,14 +5124,19 @@ mod tests {
         app.cycle_selected_project_provider()
             .expect("cycle provider");
 
-        assert_eq!(app.projects[0].default_provider.as_str(), "claude");
+        // With providers [claude, codex, opencode, gemini], cycling from codex
+        // advances to the next provider: opencode.
+        assert_eq!(app.projects[0].default_provider.as_str(), "opencode");
         assert_eq!(
             app.config.projects[0].default_provider.as_deref(),
-            Some("claude")
+            Some("opencode")
         );
+        // Active session keeps its original provider.
         assert_eq!(app.sessions[0].provider.as_str(), "codex");
-        assert_eq!(app.sessions[1].provider.as_str(), "claude");
-        assert_eq!(app.sessions[2].provider.as_str(), "claude");
+        // Non-active sessions are updated to the new default.
+        assert_eq!(app.sessions[1].provider.as_str(), "opencode");
+        assert_eq!(app.sessions[2].provider.as_str(), "opencode");
+        // Session belonging to a different project is untouched.
         assert_eq!(app.sessions[3].provider.as_str(), "codex");
 
         let persisted = app.session_store.load_sessions().expect("load sessions");
@@ -5142,14 +5147,14 @@ mod tests {
                 .map(|session| session.provider.as_str())
         };
         assert_eq!(provider_for("session-1"), Some("codex"));
-        assert_eq!(provider_for("session-2"), Some("claude"));
-        assert_eq!(provider_for("session-3"), Some("claude"));
+        assert_eq!(provider_for("session-2"), Some("opencode"));
+        assert_eq!(provider_for("session-3"), Some("opencode"));
         assert_eq!(provider_for("session-4"), Some("codex"));
 
         assert!(
             app.status
                 .text()
-                .contains("Changed default CLI agent to \"claude\"")
+                .contains("Changed default CLI agent to \"opencode\"")
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -772,7 +772,7 @@ fn default_terminal_args() -> Vec<String> {
     vec!["-l".to_string()]
 }
 
-fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
+fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
     [
         (
             "claude",
@@ -811,6 +811,28 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 2] {
                 ],
                 oneshot_output: OneshotOutput::Tempfile,
                 install_hint: Some("npm install -g @openai/codex".to_string()),
+            },
+        ),
+        (
+            "opencode",
+            ProviderCommandConfig {
+                command: "opencode".to_string(),
+                args: Vec::new(),
+                resume_args: Some(vec!["--continue".to_string()]),
+                oneshot_args: vec!["run".to_string(), "{prompt}".to_string()],
+                oneshot_output: OneshotOutput::Stdout,
+                install_hint: Some("npm install -g opencode-ai".to_string()),
+            },
+        ),
+        (
+            "gemini",
+            ProviderCommandConfig {
+                command: "gemini".to_string(),
+                args: Vec::new(),
+                resume_args: Some(vec!["--resume".to_string()]),
+                oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+                oneshot_output: OneshotOutput::Stdout,
+                install_hint: Some("npm install -g @google/gemini-cli".to_string()),
             },
         ),
     ]
@@ -1503,6 +1525,56 @@ oneshot_output = "stdout"
             claude.oneshot_args.contains(&"--max-turns".to_string()),
             "claude oneshot_args should include --max-turns"
         );
+    }
+
+    #[test]
+    fn default_opencode_oneshot_uses_run_subcommand() {
+        let providers = default_provider_commands();
+        let opencode = providers.iter().find(|(n, _)| *n == "opencode").unwrap();
+        let cfg = &opencode.1;
+        assert_eq!(cfg.command, "opencode");
+        assert_eq!(cfg.oneshot_args, vec!["run", "{prompt}"]);
+        assert!(matches!(cfg.oneshot_output, OneshotOutput::Stdout));
+        assert!(cfg.resume_args.is_some());
+    }
+
+    #[test]
+    fn default_gemini_oneshot_uses_prompt_flag() {
+        let providers = default_provider_commands();
+        let gemini = providers.iter().find(|(n, _)| *n == "gemini").unwrap();
+        let cfg = &gemini.1;
+        assert_eq!(cfg.command, "gemini");
+        assert_eq!(cfg.oneshot_args, vec!["-p", "{prompt}"]);
+        assert!(matches!(cfg.oneshot_output, OneshotOutput::Stdout));
+        assert!(cfg.resume_args.is_some());
+    }
+
+    #[test]
+    fn ensure_defaults_adds_opencode_and_gemini() {
+        let mut providers = ProvidersConfig {
+            commands: indexmap::IndexMap::from([(
+                "claude".to_string(),
+                ProviderCommandConfig {
+                    command: "claude".to_string(),
+                    args: Vec::new(),
+                    resume_args: Some(vec!["--continue".to_string()]),
+                    oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+                    oneshot_output: OneshotOutput::Stdout,
+                    install_hint: None,
+                },
+            )]),
+        };
+
+        providers.ensure_defaults();
+
+        assert!(
+            providers.get("opencode").is_some(),
+            "opencode should be added"
+        );
+        assert!(providers.get("gemini").is_some(), "gemini should be added");
+        assert!(providers.get("codex").is_some(), "codex should be added");
+        assert_eq!(providers.get("opencode").unwrap().command, "opencode");
+        assert_eq!(providers.get("gemini").unwrap().command, "gemini");
     }
 
     #[test]


### PR DESCRIPTION
Both [OpenCode](https://github.com/anomalyco/opencode) (`opencode`) and [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`gemini`) support interactive PTY sessions and non-interactive oneshot mode, making them a natural fit for dux's provider model. This adds them as built-in defaults alongside Claude and Codex so they're available out of the box — existing users pick them up automatically via `ensure_defaults()` on next launch, and new users see all four in their generated `config.toml`.

OpenCode uses `opencode run "{prompt}"` for oneshot and `--continue` for session resume. Gemini CLI uses `gemini -p "{prompt}"` for oneshot and `--resume` for session resume. Both read responses from stdout. The provider cycling test is updated to reflect the new four-provider ordering, and three new tests verify the default configurations and `ensure_defaults` backfill behavior.

`CLAUDE.md` and `README.md` are updated to reflect the expanded set of built-in providers in all places that previously listed only Claude and Codex.