### PR TITLE
Gate mouse event forwarding on child process mouse mode

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1039,16 +1039,33 @@ impl App {
                             | MouseEventKind::ScrollRight
                     );
                     if is_scroll {
-                        // Scroll is always handled as host scrollback.
-                        if self.handle_mouse(mouse_ev) {
+                        // Check if the provider has forward_scroll enabled
+                        // (only applies to agents, not companion terminals).
+                        let forward = matches!(self.input_target, InputTarget::Agent)
+                            && self
+                                .selected_session()
+                                .map(|s| provider_config(&self.config, &s.provider).forward_scroll)
+                                .unwrap_or(false);
+                        if forward {
+                            if let Some(provider) = self.selected_terminal_surface_client() {
+                                let _ = provider.write_bytes(&raw);
+                            }
+                        } else if self.handle_mouse(mouse_ev) {
                             return Ok(true);
                         }
                     } else {
-                        // Positional events (clicks, drags, releases) are
-                        // forwarded to the PTY so the agent can use them
-                        // (e.g. cursor repositioning in an input field).
-                        if let Some(provider) = self.selected_terminal_surface_client() {
-                            let _ = provider.write_bytes(&raw);
+                        // Non-scroll events (clicks, drags, moves,
+                        // releases): only forward when the child process
+                        // has opted into mouse tracking (e.g. vim, htop).
+                        // Otherwise drop — the child would echo the raw
+                        // SGR bytes as garbage text.
+                        let child_wants_mouse = self
+                            .selected_terminal_surface_client()
+                            .is_some_and(|p| p.has_mouse_mode());
+                        if child_wants_mouse {
+                            if let Some(provider) = self.selected_terminal_surface_client() {
+                                let _ = provider.write_bytes(&raw);
+                            }
                         }
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ pub struct ProviderCommandConfig {
     pub oneshot_args: Vec<String>,
     pub oneshot_output: OneshotOutput,
     pub install_hint: Option<String>,
+    pub forward_scroll: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -210,6 +211,7 @@ impl Default for ProviderCommandConfig {
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         }
     }
 }
@@ -791,6 +793,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
                 ],
                 oneshot_output: OneshotOutput::Stdout,
                 install_hint: Some("npm install -g @anthropic-ai/claude-code".to_string()),
+                forward_scroll: false,
             },
         ),
         (
@@ -811,6 +814,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
                 ],
                 oneshot_output: OneshotOutput::Tempfile,
                 install_hint: Some("npm install -g @openai/codex".to_string()),
+                forward_scroll: false,
             },
         ),
         (
@@ -822,6 +826,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
                 oneshot_args: vec!["run".to_string(), "{prompt}".to_string()],
                 oneshot_output: OneshotOutput::Stdout,
                 install_hint: Some("npm install -g opencode-ai".to_string()),
+                forward_scroll: true,
             },
         ),
         (
@@ -833,6 +838,7 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
                 oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
                 oneshot_output: OneshotOutput::Stdout,
                 install_hint: Some("npm install -g @google/gemini-cli".to_string()),
+                forward_scroll: false,
             },
         ),
     ]
@@ -900,6 +906,12 @@ fn render_provider_config(out: &mut String, name: &str, config: &ProviderCommand
             escape_toml_string(hint)
         ));
     }
+    out.push_str(
+        "# When true, scroll events are forwarded to the provider instead of being\n\
+         # handled as dux host scrollback. Enable this for agents that manage their\n\
+         # own scrollback buffer (e.g. opencode).\n",
+    );
+    out.push_str(&format!("forward_scroll = {}\n", config.forward_scroll));
     out.push('\n');
 }
 
@@ -1212,6 +1224,7 @@ agent_scrollback_lines = 10000
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         };
         assert_eq!(cfg.interactive_args(false), ["--interactive"]);
         assert_eq!(cfg.interactive_args(true), ["--resume", "--last"]);
@@ -1223,6 +1236,7 @@ agent_scrollback_lines = 10000
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         };
         assert_eq!(unsupported.interactive_args(true), ["--interactive"]);
         assert!(!unsupported.supports_session_resume());
@@ -1240,6 +1254,7 @@ agent_scrollback_lines = 10000
                     oneshot_args: Vec::new(),
                     oneshot_output: OneshotOutput::Stdout,
                     install_hint: None,
+                    forward_scroll: false,
                 },
             )]),
         };
@@ -1267,6 +1282,7 @@ agent_scrollback_lines = 10000
                     oneshot_args: Vec::new(),
                     oneshot_output: OneshotOutput::Stdout,
                     install_hint: None,
+                    forward_scroll: false,
                 },
             )]),
         };
@@ -1561,6 +1577,7 @@ oneshot_output = "stdout"
                     oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
                     oneshot_output: OneshotOutput::Stdout,
                     install_hint: None,
+                    forward_scroll: false,
                 },
             )]),
         };

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -86,6 +86,7 @@ mod tests {
             oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         }
     }
 
@@ -97,6 +98,7 @@ mod tests {
             oneshot_args: vec!["-c".to_string(), "echo {prompt} > {tempfile}".to_string()],
             oneshot_output: OneshotOutput::Tempfile,
             install_hint: None,
+            forward_scroll: false,
         }
     }
 
@@ -167,6 +169,7 @@ mod tests {
             oneshot_args: Vec::new(),
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         };
         let prov = create_provider("bad", config);
         let cwd = std::env::temp_dir();
@@ -188,6 +191,7 @@ mod tests {
             ],
             oneshot_output: OneshotOutput::Stdout,
             install_hint: None,
+            forward_scroll: false,
         };
         let prov = create_provider("custom", config);
         let cwd = std::env::temp_dir();

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -9,7 +9,7 @@ use std::thread;
 use alacritty_terminal::event::{Event, EventListener, WindowSize};
 use alacritty_terminal::grid::{Dimensions, Scroll};
 use alacritty_terminal::term::cell::Flags;
-use alacritty_terminal::term::{self, Config, Term};
+use alacritty_terminal::term::{self, Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{
     Color as TermColor, CursorShape, NamedColor, Processor, Rgb, StdSyncHandler,
 };
@@ -222,6 +222,13 @@ impl PtyClient {
         self.has_output.load(Ordering::Acquire)
     }
 
+    /// Whether the child process has enabled any mouse tracking mode
+    /// (e.g. via DECSET 1000/1002/1003). When true, non-scroll mouse
+    /// events should be forwarded to the PTY rather than dropped.
+    pub fn has_mouse_mode(&self) -> bool {
+        self.terminal.lock().map_or(false, |t| t.has_mouse_mode())
+    }
+
     /// Non-blocking check of the child's exit status.
     pub fn try_wait(&mut self) -> Option<portable_pty::ExitStatus> {
         self.child.try_wait().ok().flatten()
@@ -334,6 +341,12 @@ impl TerminalState {
             .renderable_content()
             .display_iter
             .any(|indexed| !indexed.cell.c.is_whitespace())
+    }
+
+    /// Whether the child process has enabled any mouse tracking mode
+    /// (e.g. via DECSET 1000/1002/1003).
+    fn has_mouse_mode(&self) -> bool {
+        self.term.mode().intersects(TermMode::MOUSE_MODE)
     }
 
     fn snapshot(&self) -> TerminalSnapshot {
@@ -857,6 +870,40 @@ mod tests {
         assert_eq!(
             cmd.get_env("COLORTERM").and_then(|value| value.to_str()),
             Some("truecolor")
+        );
+    }
+
+    #[test]
+    fn mouse_mode_off_by_default() {
+        let terminal = TerminalState::with_scrollback(24, 80, 100);
+        assert!(
+            !terminal.has_mouse_mode(),
+            "plain shell should not have mouse mode enabled"
+        );
+    }
+
+    #[test]
+    fn mouse_mode_on_after_enable_sequence() {
+        let mut terminal = TerminalState::with_scrollback(24, 80, 100);
+        // DECSET 1000: enable basic mouse reporting.
+        terminal.process(b"\x1b[?1000h");
+        assert!(
+            terminal.has_mouse_mode(),
+            "mouse mode should be enabled after DECSET 1000"
+        );
+    }
+
+    #[test]
+    fn mouse_mode_off_after_disable_sequence() {
+        let mut terminal = TerminalState::with_scrollback(24, 80, 100);
+        terminal.process(b"\x1b[?1000h");
+        assert!(terminal.has_mouse_mode());
+
+        // DECRST 1000: disable basic mouse reporting.
+        terminal.process(b"\x1b[?1000l");
+        assert!(
+            !terminal.has_mouse_mode(),
+            "mouse mode should be disabled after DECRST 1000"
         );
     }
 }


### PR DESCRIPTION
In interactive mode, dux was forwarding all non-scroll mouse events (clicks, drags, moves) as raw SGR escape sequences to the PTY child process unconditionally. When the child — such as a plain shell or an AI agent — hadn't enabled mouse tracking, it would echo these bytes back as garbage text like `35;17;22M35;18;22M...`. This change checks the child's `TermMode::MOUSE_MODE` flags via alacritty_terminal before forwarding: non-scroll events are only sent when the child has opted in (e.g. `vim`, `htop`), and silently dropped otherwise.

Scroll events remain under dux's control as host scrollback by default, since many agents that claim mouse support don't actually handle scroll in their own buffer. A new `forward_scroll` boolean in `[providers.<name>]` config allows opting specific providers into receiving scroll events directly. OpenCode ships with `forward_scroll = true` since it manages its own scrollback buffer; all other providers default to `false`.

Three new tests in `src/pty.rs` verify that `has_mouse_mode()` correctly reflects the child's mouse tracking state: off by default, on after DECSET 1000, and off again after DECRST 1000. The `forward_scroll` field is added to `ProviderCommandConfig` with serde default support, and the generated config file includes a commented explanation of the option.