### PR TITLE
Add surface selector to text macros

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1648,6 +1648,10 @@ impl App {
                         edit_state.surface = edit_state.surface.next();
                         return Ok(false);
                     }
+                    if key.code == KeyCode::BackTab {
+                        edit_state.surface = edit_state.surface.prev();
+                        return Ok(false);
+                    }
                     if key.code == KeyCode::Enter && !edit_state.name_input.is_empty() {
                         let name = edit_state.name_input.text.clone();
                         // For new macros, check for duplicate names

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -964,6 +964,11 @@ impl App {
         for action in actions {
             match action {
                 SeqAction::Intercept(Action::OpenMacroBar, _, _) => {
+                    if self.filtered_macros("").is_empty() {
+                        self.set_info("No macros defined for this surface.");
+                        self.raw_input_buf.clear();
+                        return Ok(false);
+                    }
                     let prev = self.input_target;
                     self.macro_bar = Some(MacroBarState {
                         input: TextInput::new(),
@@ -1639,10 +1644,14 @@ impl App {
                         *editing = None;
                         return Ok(false);
                     }
+                    if key.code == KeyCode::Tab {
+                        edit_state.surface = edit_state.surface.next();
+                        return Ok(false);
+                    }
                     if key.code == KeyCode::Enter && !edit_state.name_input.is_empty() {
                         let name = edit_state.name_input.text.clone();
                         // For new macros, check for duplicate names
-                        if edit_state.id.is_none() && entries.iter().any(|(n, _)| *n == name) {
+                        if edit_state.id.is_none() && entries.iter().any(|(n, _, _)| *n == name) {
                             self.set_warning(format!(
                                 "Name \"{name}\" is already in use. Choose another."
                             ));
@@ -1658,6 +1667,7 @@ impl App {
                         // Save the macro
                         let name = edit_state.name_input.text.clone();
                         let text = edit_state.text_input.text.clone();
+                        let surface = edit_state.surface;
                         let old_id = edit_state.id.clone();
 
                         if text.is_empty() {
@@ -1674,10 +1684,13 @@ impl App {
                         }
 
                         // Update config
-                        self.config
-                            .macros
-                            .entries
-                            .insert(name.clone(), text.clone());
+                        self.config.macros.entries.insert(
+                            name.clone(),
+                            crate::config::MacroEntry {
+                                text: text.clone(),
+                                surface,
+                            },
+                        );
 
                         // Update the entries snapshot in PromptState
                         let PromptState::EditMacros {
@@ -1690,17 +1703,19 @@ impl App {
 
                         // Update entries list
                         if let Some(old_name) = old_id {
-                            if let Some(existing) = entries.iter_mut().find(|(n, _)| *n == old_name)
+                            if let Some(existing) =
+                                entries.iter_mut().find(|(n, _, _)| *n == old_name)
                             {
                                 existing.0 = name.clone();
                                 existing.1 = text;
+                                existing.2 = surface;
                             } else {
-                                entries.push((name.clone(), text));
+                                entries.push((name.clone(), text, surface));
                             }
                         } else {
-                            entries.push((name.clone(), text));
+                            entries.push((name.clone(), text, surface));
                         }
-                        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+                        entries.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
 
                         // Persist
                         let _ = crate::config::save_config(
@@ -1735,13 +1750,15 @@ impl App {
             }
             KeyCode::Enter => {
                 // Edit selected macro
-                if let Some((name, text)) = entries.get(*selected) {
+                if let Some((name, text, surface)) = entries.get(*selected) {
                     let name = name.clone();
                     let text = text.clone();
+                    let surface = *surface;
                     *editing = Some(MacroEditState {
                         id: Some(name.clone()),
                         name_input: TextInput::with_text(name),
                         text_input: TextInput::with_text(text).with_multiline(8),
+                        surface,
                         stage: MacroEditStage::EditName,
                     });
                 }
@@ -1752,12 +1769,13 @@ impl App {
                     id: None,
                     name_input: TextInput::new(),
                     text_input: TextInput::new().with_multiline(8),
+                    surface: MacroSurface::default(),
                     stage: MacroEditStage::EditName,
                 });
             }
             KeyCode::Char('d') | KeyCode::Delete => {
                 // Delete selected macro
-                if let Some((name, _)) = entries.get(*selected) {
+                if let Some((name, _, _)) = entries.get(*selected) {
                     let name = name.clone();
                     self.config.macros.entries.remove(&name);
 
@@ -1767,7 +1785,7 @@ impl App {
                     else {
                         return Ok(false);
                     };
-                    entries.retain(|(n, _)| *n != name);
+                    entries.retain(|(n, _, _)| *n != name);
                     if *selected > 0 && *selected >= entries.len() {
                         *selected = entries.len().saturating_sub(1);
                     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3905,6 +3905,9 @@ mod tests {
         app.clipboard = Clipboard::from_fn(clipboard_ok);
 
         app.copy_selected_path().unwrap();
+        // Result arrives via WorkerEvent; drain it.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert!(app.status.text().contains(&worktree_path));
@@ -3918,6 +3921,8 @@ mod tests {
         app.clipboard = Clipboard::from_fn(clipboard_ok);
 
         app.copy_selected_path().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert!(app.status.text().contains(&project_path));
@@ -3945,6 +3950,8 @@ mod tests {
         app.clipboard = Clipboard::from_fn(clipboard_fail);
 
         app.copy_selected_path().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
         assert!(app.status.text().contains("Copy path failed"));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use crate::clipboard::Clipboard;
 use crate::config::{
-    Config, DuxPaths, ProjectConfig, ProviderCommandConfig, check_provider_available,
+    Config, DuxPaths, MacroSurface, ProjectConfig, ProviderCommandConfig, check_provider_available,
     ensure_config, save_config, validate_keys,
 };
 use crate::editor::DetectedEditor;
@@ -348,7 +348,7 @@ pub(crate) enum PromptState {
         selected: usize,
     },
     EditMacros {
-        entries: Vec<(String, String)>,
+        entries: Vec<(String, String, MacroSurface)>,
         selected: usize,
         editing: Option<MacroEditState>,
     },
@@ -366,6 +366,7 @@ pub(crate) struct MacroEditState {
     pub(crate) id: Option<String>,
     pub(crate) name_input: TextInput,
     pub(crate) text_input: TextInput,
+    pub(crate) surface: MacroSurface,
     pub(crate) stage: MacroEditStage,
 }
 
@@ -942,14 +943,14 @@ impl App {
     }
 
     pub(crate) fn open_edit_macros(&mut self) {
-        let mut entries: Vec<(String, String)> = self
+        let mut entries: Vec<(String, String, MacroSurface)> = self
             .config
             .macros
             .entries
             .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (k.clone(), v.text.clone(), v.surface))
             .collect();
-        entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+        entries.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
         self.prompt = PromptState::EditMacros {
             entries,
             selected: 0,
@@ -957,9 +958,11 @@ impl App {
         };
     }
 
-    /// Return macros matching `query`, searching name first then text content.
-    /// If `query` is empty, returns all macros in their config order.
+    /// Return macros matching `query` and the current session surface,
+    /// searching name first then text content.
+    /// If `query` is empty, returns all surface-matching macros in config order.
     pub(crate) fn filtered_macros(&self, query: &str) -> Vec<(&str, &str)> {
+        let surface = self.session_surface;
         let needle = query.trim().to_lowercase();
         if needle.is_empty() {
             return self
@@ -967,16 +970,20 @@ impl App {
                 .macros
                 .entries
                 .iter()
-                .map(|(name, text)| (name.as_str(), text.as_str()))
+                .filter(|(_, entry)| entry.surface.matches(surface))
+                .map(|(name, entry)| (name.as_str(), entry.text.as_str()))
                 .collect();
         }
         let mut name_matches = Vec::new();
         let mut text_matches = Vec::new();
-        for (name, text) in &self.config.macros.entries {
+        for (name, entry) in &self.config.macros.entries {
+            if !entry.surface.matches(surface) {
+                continue;
+            }
             if name.to_lowercase().contains(&needle) {
-                name_matches.push((name.as_str(), text.as_str()));
-            } else if text.to_lowercase().contains(&needle) {
-                text_matches.push((name.as_str(), text.as_str()));
+                name_matches.push((name.as_str(), entry.text.as_str()));
+            } else if entry.text.to_lowercase().contains(&needle) {
+                text_matches.push((name.as_str(), entry.text.as_str()));
             }
         }
         name_matches.extend(text_matches);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -573,6 +573,10 @@ pub(crate) enum WorkerEvent {
         dir: PathBuf,
         entries: Vec<BrowserEntry>,
     },
+    ClipboardCopyCompleted {
+        path: String,
+        result: Result<(), String>,
+    },
 }
 
 mod input;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2885,9 +2885,9 @@ impl App {
                         .areas(inner);
 
                     let surface_desc = match edit_state.surface {
-                        MacroSurface::Agent => "given to agent",
-                        MacroSurface::Terminal => "given to terminal",
-                        MacroSurface::Both => "given to agent + terminal",
+                        MacroSurface::Agent => "agent macro",
+                        MacroSurface::Terminal => "terminal macro",
+                        MacroSurface::Both => "agent + terminal macro",
                     };
                     Paragraph::new(Line::from(Span::styled(
                         format!(" Text ({surface_desc}):"),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2884,8 +2884,13 @@ impl App {
                         ])
                         .areas(inner);
 
+                    let surface_desc = match edit_state.surface {
+                        MacroSurface::Agent => "given to agent",
+                        MacroSurface::Terminal => "given to terminal",
+                        MacroSurface::Both => "given to agent + terminal",
+                    };
                     Paragraph::new(Line::from(Span::styled(
-                        " Text (pasted via bracketed paste):",
+                        format!(" Text ({surface_desc}):"),
                         Style::default().fg(self.theme.input_label_fg),
                     )))
                     .render(label_area, frame.buffer_mut());

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2890,7 +2890,7 @@ impl App {
                         MacroSurface::Both => "agent + terminal macro",
                     };
                     Paragraph::new(Line::from(Span::styled(
-                        format!(" Text ({surface_desc}):"),
+                        format!(" Text for the {surface_desc}:"),
                         Style::default().fg(self.theme.input_label_fg),
                     )))
                     .render(label_area, frame.buffer_mut());

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2869,7 +2869,7 @@ impl App {
 
                     let hints = self.edit_macro_hints(&[
                         ("Enter", "next"),
-                        ("Tab", "surface"),
+                        ("Tab/Shift-Tab", "surface"),
                         ("Esc", "cancel"),
                     ]);
                     Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -778,7 +778,7 @@ impl App {
                 } else {
                     spans.push(Span::styled(" down", desc_style));
                 }
-                if !self.config.macros.entries.is_empty() && !macro_key.is_empty() {
+                if !self.filtered_macros("").is_empty() && !macro_key.is_empty() {
                     spans.push(Span::styled(" ", desc_style));
                     spans.extend(self.theme.dim_key_badge_default(&macro_key));
                     spans.push(Span::styled(" macros.", desc_style));
@@ -2820,11 +2820,13 @@ impl App {
 
             match edit_state.stage {
                 MacroEditStage::EditName => {
-                    let [label_area, input_area, _, hint_area] = Layout::default()
+                    let [label_area, input_area, _, surface_area, _, hint_area] = Layout::default()
                         .direction(Direction::Vertical)
                         .constraints([
                             Constraint::Length(1),
                             Constraint::Length(3),
+                            Constraint::Length(1),
+                            Constraint::Length(1),
                             Constraint::Min(1),
                             Constraint::Length(1),
                         ])
@@ -2838,7 +2840,38 @@ impl App {
 
                     self.render_single_line_input(&edit_state.name_input, input_area, frame);
 
-                    let hints = self.edit_macro_hints(&[("Enter", "next"), ("Esc", "cancel")]);
+                    // Surface radio buttons
+                    let current = edit_state.surface;
+                    let options = [
+                        (MacroSurface::Agent, "Agent"),
+                        (MacroSurface::Terminal, "Terminal"),
+                        (MacroSurface::Both, "Both"),
+                    ];
+                    let mut radio_spans: Vec<Span> = vec![Span::styled(
+                        " Surface:  ",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )];
+                    for (i, (variant, label)) in options.iter().enumerate() {
+                        if i > 0 {
+                            radio_spans.push(Span::styled("    ", Style::default()));
+                        }
+                        let bullet = if *variant == current { "● " } else { "○ " };
+                        let style = if *variant == current {
+                            Style::default().fg(self.theme.input_label_fg)
+                        } else {
+                            Style::default().fg(self.theme.hint_desc_fg)
+                        };
+                        radio_spans.push(Span::styled(bullet, style));
+                        radio_spans.push(Span::styled(*label, style));
+                    }
+                    Paragraph::new(Line::from(radio_spans))
+                        .render(surface_area, frame.buffer_mut());
+
+                    let hints = self.edit_macro_hints(&[
+                        ("Enter", "next"),
+                        ("Tab", "surface"),
+                        ("Esc", "cancel"),
+                    ]);
                     Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
                 }
                 MacroEditStage::EditText => {
@@ -2852,7 +2885,7 @@ impl App {
                         .areas(inner);
 
                     Paragraph::new(Line::from(Span::styled(
-                        " Text (pasted to agent via bracketed paste):",
+                        " Text (pasted via bracketed paste):",
                         Style::default().fg(self.theme.input_label_fg),
                     )))
                     .render(label_area, frame.buffer_mut());
@@ -2907,13 +2940,22 @@ impl App {
 
                 let items: Vec<ListItem> = entries
                     .iter()
-                    .map(|(name, text)| {
-                        let mut spans = vec![Span::styled(
-                            format!(" {name} — "),
-                            Style::default().fg(self.theme.input_label_fg),
-                        )];
+                    .map(|(name, text, surface)| {
+                        let surface_label = format!(" ({})", surface.label());
+                        let mut spans = vec![
+                            Span::styled(
+                                format!(" {name}"),
+                                Style::default().fg(self.theme.input_label_fg),
+                            ),
+                            Span::styled(
+                                surface_label.clone(),
+                                Style::default().fg(self.theme.hint_dim_desc_fg),
+                            ),
+                            Span::styled(" — ", Style::default().fg(self.theme.input_label_fg)),
+                        ];
                         let text_preview = text.replace('\n', "↵");
-                        let prefix_len = name.len() + 4; // " " + name + " — "
+                        // " " + name + " (label)" + " — "
+                        let prefix_len = 1 + name.len() + surface_label.len() + 3;
                         let max_len = (list_area.width as usize).saturating_sub(prefix_len + 2);
                         let truncated = if text_preview.len() > max_len {
                             format!("{}…", &text_preview[..max_len.saturating_sub(1)])
@@ -3155,11 +3197,7 @@ impl App {
         let gap = 2usize;
 
         let items: Vec<ListItem> = if filtered.is_empty() {
-            let msg = if self.config.macros.entries.is_empty() {
-                "No macros configured. Use \"edit-macros\" in the command palette."
-            } else {
-                "No matching macros."
-            };
+            let msg = "No matching macros.";
             vec![ListItem::new(Span::styled(
                 msg,
                 Style::default().fg(self.theme.hint_desc_fg),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -568,10 +568,14 @@ impl App {
         };
         match path {
             Some(p) => {
-                match self.clipboard.copy_text(&p) {
-                    Ok(()) => self.set_info(format!("Copied path to clipboard: \"{p}\"")),
-                    Err(err) => self.set_error(format!("Copy path failed: {err}")),
-                }
+                let clipboard = self.clipboard;
+                let tx = self.worker_tx.clone();
+                let path = p.clone();
+                std::thread::spawn(move || {
+                    let result = clipboard.copy_text(&path).map_err(|e| e.to_string());
+                    let _ = tx.send(WorkerEvent::ClipboardCopyCompleted { path, result });
+                });
+                self.set_busy(format!("Copying path to clipboard: \"{p}\"…"));
                 Ok(())
             }
             None => {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -82,6 +82,12 @@ impl App {
                     }
                     Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
                 },
+                WorkerEvent::ClipboardCopyCompleted { path, result } => match result {
+                    Ok(()) => {
+                        self.set_info(format!("Copied path to clipboard: \"{path}\""))
+                    }
+                    Err(e) => self.set_error(format!("Copy path failed: {e}")),
+                },
                 WorkerEvent::BrowserEntriesReady { dir, entries } => {
                     if let PromptState::BrowseProjects {
                         current_dir,

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,3 +1,6 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
 use anyhow::{Result, anyhow};
 
 #[cfg(target_os = "linux")]
@@ -16,6 +19,9 @@ use std::process::{Command, Stdio};
 #[cfg(target_os = "linux")]
 use anyhow::Context;
 
+const CLIPBOARD_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Copy)]
 pub(crate) struct Clipboard {
     copy_text_fn: fn(&str) -> Result<()>,
 }
@@ -50,6 +56,20 @@ fn copy_text_impl(text: &str) -> Result<()> {
 }
 
 fn copy_text_arboard(text: &str) -> Result<()> {
+    let text = text.to_string();
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(copy_text_arboard_inner(&text));
+    });
+    rx.recv_timeout(CLIPBOARD_TIMEOUT).map_err(|_| {
+        anyhow!(
+            "Clipboard access timed out after {}ms",
+            CLIPBOARD_TIMEOUT.as_millis()
+        )
+    })?
+}
+
+fn copy_text_arboard_inner(text: &str) -> Result<()> {
     let mut clipboard =
         arboard::Clipboard::new().map_err(|e| anyhow!("Failed to access clipboard: {e}"))?;
     clipboard
@@ -217,10 +237,23 @@ fn run_linux_clipboard_command(command: LinuxClipboardCommand, text: &str) -> Re
             .write_all(text.as_bytes())
             .with_context(|| format!("Failed to write to {}", command.program))?;
     }
+    // stdin is dropped here, closing the pipe so the child can proceed.
 
-    let output = child
-        .wait_with_output()
-        .with_context(|| format!("Failed to wait for {}", command.program))?;
+    let program = command.program;
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+
+    let output = rx
+        .recv_timeout(CLIPBOARD_TIMEOUT)
+        .map_err(|_| {
+            anyhow!(
+                "{program} timed out after {}ms",
+                CLIPBOARD_TIMEOUT.as_millis()
+            )
+        })?
+        .with_context(|| format!("Failed to wait for {program}"))?;
 
     if output.status.success() {
         return Ok(());
@@ -344,5 +377,34 @@ mod tests {
             })
         );
         assert_eq!(LinuxClipboardBackend::Arboard.command_spec(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_linux_clipboard_command_times_out_for_slow_process() {
+        let cmd = LinuxClipboardCommand {
+            program: "sleep",
+            args: &["60"],
+        };
+        let start = std::time::Instant::now();
+        let result = run_linux_clipboard_command(cmd, "test");
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("timed out"));
+        // Should complete well under the 60s sleep — within ~1s of the 500ms timeout.
+        assert!(elapsed < Duration::from_secs(2));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_linux_clipboard_command_succeeds_for_fast_command() {
+        // `cat` reads stdin to stdout (which is /dev/null here) and exits 0.
+        let cmd = LinuxClipboardCommand {
+            program: "cat",
+            args: &[],
+        };
+        let result = run_linux_clipboard_command(cmd, "hello");
+        assert!(result.is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,15 @@ impl MacroSurface {
         }
     }
 
+    /// Cycle to the previous variant: Agent -> Both -> Terminal -> Agent.
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Agent => Self::Both,
+            Self::Both => Self::Terminal,
+            Self::Terminal => Self::Agent,
+        }
+    }
+
     /// Whether this surface matches the given session surface.
     pub fn matches(self, session: crate::model::SessionSurface) -> bool {
         match self {
@@ -1661,6 +1670,13 @@ oneshot_output = "stdout"
         assert_eq!(MacroSurface::Agent.next(), MacroSurface::Terminal);
         assert_eq!(MacroSurface::Terminal.next(), MacroSurface::Both);
         assert_eq!(MacroSurface::Both.next(), MacroSurface::Agent);
+    }
+
+    #[test]
+    fn macros_surface_prev_cycles() {
+        assert_eq!(MacroSurface::Agent.prev(), MacroSurface::Both);
+        assert_eq!(MacroSurface::Both.prev(), MacroSurface::Terminal);
+        assert_eq!(MacroSurface::Terminal.prev(), MacroSurface::Agent);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,13 +46,64 @@ pub struct KeysConfig {
     pub bindings: BTreeMap<String, Vec<String>>,
 }
 
-/// Text macros: a map from name to text.
+/// Which surface(s) a macro is available on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MacroSurface {
+    Agent,
+    Terminal,
+    Both,
+}
+
+impl Default for MacroSurface {
+    fn default() -> Self {
+        Self::Agent
+    }
+}
+
+impl MacroSurface {
+    /// Human-readable label for UI display.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Agent => "agent only",
+            Self::Terminal => "terminal only",
+            Self::Both => "agent + terminal",
+        }
+    }
+
+    /// Cycle to the next variant: Agent -> Terminal -> Both -> Agent.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Agent => Self::Terminal,
+            Self::Terminal => Self::Both,
+            Self::Both => Self::Agent,
+        }
+    }
+
+    /// Whether this surface matches the given session surface.
+    pub fn matches(self, session: crate::model::SessionSurface) -> bool {
+        match self {
+            Self::Both => true,
+            Self::Agent => session == crate::model::SessionSurface::Agent,
+            Self::Terminal => session == crate::model::SessionSurface::Terminal,
+        }
+    }
+}
+
+/// A single text macro entry with surface restriction.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MacroEntry {
+    pub text: String,
+    pub surface: MacroSurface,
+}
+
+/// Text macros: a map from name to entry.
 /// Each entry is triggered from the macro bar (Ctrl+\).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MacrosConfig {
     #[serde(flatten)]
-    pub entries: BTreeMap<String, String>,
+    pub entries: BTreeMap<String, MacroEntry>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -671,22 +722,32 @@ fn render_macros_config(
     let _ = writeln!(
         out,
         "# Text macros: press {macro_key} to open the macro bar and select one to paste.\n\
-         # Each entry is a name mapped to the text that will be pasted via bracketed paste.\n\
+         # Each entry is a name mapped to its text and a surface restriction.\n\
+         # surface = \"agent\"    — only shown when the agent pane is focused.\n\
+         # surface = \"terminal\" — only shown when the terminal pane is focused.\n\
+         # surface = \"both\"     — shown on both surfaces.\n\
          # Newlines in text values are safe — they are sent atomically and not interpreted as Enter.",
     );
     if macros.entries.is_empty() {
         out.push_str(
-            "# \"Review\" = \"review this code for bugs and security issues\"\n\
-             # \"Explain\" = \"explain what this function does\"\n",
+            "# \"Review\" = { text = \"review this code for bugs\", surface = \"agent\" }\n\
+             # \"Build\" = { text = \"cargo build --release\", surface = \"terminal\" }\n",
         );
     } else {
         out.push('\n');
-        for (name, text) in &macros.entries {
+        for (name, entry) in &macros.entries {
+            let text = escape_toml_string(&entry.text);
+            let surface = match entry.surface {
+                MacroSurface::Agent => "agent",
+                MacroSurface::Terminal => "terminal",
+                MacroSurface::Both => "both",
+            };
             let _ = writeln!(
                 out,
-                "\"{}\" = \"{}\"",
+                "\"{}\" = {{ text = \"{}\", surface = \"{}\" }}",
                 escape_toml_string(name),
-                escape_toml_string(text)
+                text,
+                surface
             );
         }
     }
@@ -1551,25 +1612,55 @@ oneshot_output = "stdout"
     }
 
     #[test]
-    fn macros_config_string_entry_round_trip() {
+    fn macros_config_entry_round_trip() {
         let toml_str = r#"
-"Review" = "review this code"
+"Review" = { text = "review this code", surface = "agent" }
 "#;
         let config: MacrosConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.entries.len(), 1);
-        assert_eq!(config.entries["Review"], "review this code");
+        assert_eq!(config.entries["Review"].text, "review this code");
+        assert_eq!(config.entries["Review"].surface, MacroSurface::Agent);
     }
 
     #[test]
     fn macros_config_multiple_entries() {
         let toml_str = r#"
-"Explain" = "explain what this function does"
-"Review" = "review this code for bugs"
+"Explain" = { text = "explain what this function does", surface = "agent" }
+"Review" = { text = "review this code for bugs", surface = "both" }
+"Build" = { text = "cargo build", surface = "terminal" }
 "#;
         let config: MacrosConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.entries.len(), 2);
-        assert_eq!(config.entries["Explain"], "explain what this function does");
-        assert_eq!(config.entries["Review"], "review this code for bugs");
+        assert_eq!(config.entries.len(), 3);
+        assert_eq!(
+            config.entries["Explain"].text,
+            "explain what this function does"
+        );
+        assert_eq!(config.entries["Explain"].surface, MacroSurface::Agent);
+        assert_eq!(config.entries["Review"].surface, MacroSurface::Both);
+        assert_eq!(config.entries["Build"].surface, MacroSurface::Terminal);
+    }
+
+    #[test]
+    fn macros_surface_default_is_agent() {
+        assert_eq!(MacroSurface::default(), MacroSurface::Agent);
+    }
+
+    #[test]
+    fn macros_surface_matches() {
+        use crate::model::SessionSurface;
+        assert!(MacroSurface::Both.matches(SessionSurface::Agent));
+        assert!(MacroSurface::Both.matches(SessionSurface::Terminal));
+        assert!(MacroSurface::Agent.matches(SessionSurface::Agent));
+        assert!(!MacroSurface::Agent.matches(SessionSurface::Terminal));
+        assert!(MacroSurface::Terminal.matches(SessionSurface::Terminal));
+        assert!(!MacroSurface::Terminal.matches(SessionSurface::Agent));
+    }
+
+    #[test]
+    fn macros_surface_next_cycles() {
+        assert_eq!(MacroSurface::Agent.next(), MacroSurface::Terminal);
+        assert_eq!(MacroSurface::Terminal.next(), MacroSurface::Both);
+        assert_eq!(MacroSurface::Both.next(), MacroSurface::Agent);
     }
 
     #[test]
@@ -1577,34 +1668,43 @@ oneshot_output = "stdout"
         let config = Config::default();
         let rendered = render_config_default(&config);
         assert!(rendered.contains("[macros]"));
-        assert!(rendered.contains("# \"Review\" = \"review this code"));
+        assert!(rendered.contains("# \"Review\" = { text = \"review this code"));
+        assert!(rendered.contains("surface = \"agent\""));
     }
 
     #[test]
     fn render_macros_config_with_entries() {
         let mut config = Config::default();
-        config
-            .macros
-            .entries
-            .insert("Review".to_string(), "hello world".to_string());
-        config
-            .macros
-            .entries
-            .insert("Test".to_string(), "foo bar".to_string());
+        config.macros.entries.insert(
+            "Review".to_string(),
+            MacroEntry {
+                text: "hello world".to_string(),
+                surface: MacroSurface::Agent,
+            },
+        );
+        config.macros.entries.insert(
+            "Test".to_string(),
+            MacroEntry {
+                text: "foo bar".to_string(),
+                surface: MacroSurface::Terminal,
+            },
+        );
         let rendered = render_config_default(&config);
-        assert!(rendered.contains("\"Review\" = \"hello world\""));
-        assert!(rendered.contains("\"Test\" = \"foo bar\""));
+        assert!(rendered.contains("\"Review\" = { text = \"hello world\", surface = \"agent\" }"));
+        assert!(rendered.contains("\"Test\" = { text = \"foo bar\", surface = \"terminal\" }"));
     }
 
     #[test]
     fn render_macros_config_escapes_special_chars() {
         let mut config = Config::default();
-        config
-            .macros
-            .entries
-            .insert("Multi".to_string(), "line1\nline2".to_string());
+        config.macros.entries.insert(
+            "Multi".to_string(),
+            MacroEntry {
+                text: "line1\nline2".to_string(),
+                surface: MacroSurface::Both,
+            },
+        );
         let rendered = render_config_default(&config);
-        // Newlines must be escaped in the TOML output
-        assert!(rendered.contains("\"Multi\" = \"line1\\nline2\""));
+        assert!(rendered.contains("\"Multi\" = { text = \"line1\\nline2\", surface = \"both\" }"));
     }
 }


### PR DESCRIPTION
Text macros previously fired on both agent and terminal surfaces indiscriminately, meaning an agent prompt like "review this code" would also paste into a shell session where it makes no sense. This change adds a `surface` field to each macro entry (`agent`, `terminal`, or `both`) so users control where each macro appears. The default is `agent` since most macros are natural-language prompts.

The macro bar now filters entries by the active surface before displaying them. When no macros match the current surface, the hint bar hides the macro keybinding and attempting to open the bar shows an informational message instead. The config format moves from plain `"Name" = "text"` strings to inline tables: `"Name" = { text = "...", surface = "agent" }`, with updated comments explaining each surface option.

The edit-macros dialog gains a surface radio selector on the same screen as the name input — `Tab` cycles through Agent, Terminal, and Both — keeping macro creation to two steps (name+surface, then text). The list view shows each macro's surface as a parenthetical label like `(agent only)` or `(terminal only)` for quick scanning.