### PR TITLE
Decouple agent rename from git branch rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ The current app provides:
 
 - The app spawns CLI tools directly via PTY (portable-pty) and renders their output using an embedded terminal emulator built on alacritty_terminal. There is no protocol layer (no ACP, no JSON-RPC).
 - Long-running actions should not block the UI thread.
+- All periodic or potentially-blocking work (git commands, file I/O, network) must run in background workers, never on the main UI thread. Even fast operations like `git symbolic-ref` should use workers to prevent UI freezes if the filesystem or git lock stalls.
 - User state lives under `~/.dux/` on macOS and `$XDG_CONFIG_HOME/dux/` (or `~/.config/dux/`) on Linux.
 - Worktrees are user data and should not be removed or mutated casually.
 - Git operations should be explicit and conservative, especially around the source checkout.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1601,7 +1601,9 @@ impl App {
         }
 
         if let PromptState::RenameSession {
-            session_id, input, ..
+            session_id,
+            input,
+            rename_branch,
         } = &mut self.prompt
         {
             let is_plain_char = matches!(key.code, KeyCode::Char(_))
@@ -1619,8 +1621,12 @@ impl App {
                 Some(Action::Confirm) => {
                     let id = session_id.clone();
                     let new_name = input.text.clone();
+                    let also_rename_branch = *rename_branch;
                     self.prompt = PromptState::None;
-                    self.apply_rename_session(&id, new_name);
+                    self.apply_rename_session(&id, new_name, also_rename_branch);
+                }
+                Some(Action::ToggleSelection) => {
+                    *rename_branch = !*rename_branch;
                 }
                 _ => {
                     input.handle_key(key);
@@ -3321,6 +3327,7 @@ mod tests {
             macro_bar: None,
             sigwinch_flag: Arc::new(AtomicBool::new(false)),
             force_redraw: false,
+            branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();
@@ -3492,6 +3499,7 @@ mod tests {
         app.prompt = PromptState::RenameSession {
             session_id: "session-1".to_string(),
             input: TextInput::with_text("agent".to_string()),
+            rename_branch: false,
         };
         app.input_target = InputTarget::Agent;
 
@@ -3513,6 +3521,7 @@ mod tests {
         app.prompt = PromptState::RenameSession {
             session_id: "session-1".to_string(),
             input: TextInput::with_text("agent".to_string()),
+            rename_branch: false,
         };
 
         app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE))
@@ -3533,6 +3542,7 @@ mod tests {
         app.prompt = PromptState::RenameSession {
             session_id: "session-1".to_string(),
             input: TextInput::with_text("agent-branch".to_string()),
+            rename_branch: false,
         };
 
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
@@ -3557,6 +3567,73 @@ mod tests {
         assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
         assert_eq!(app.input_target, InputTarget::None);
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+    }
+
+    #[test]
+    fn rename_title_only_does_not_change_branch_name() {
+        let mut app = test_app(default_bindings());
+        let original_branch = app.sessions[0].branch_name.clone();
+
+        app.apply_rename_session("session-1", "new-title".to_string(), false);
+
+        assert_eq!(
+            app.sessions[0].title.as_deref(),
+            Some("new-title"),
+            "title should be updated"
+        );
+        assert_eq!(
+            app.sessions[0].branch_name, original_branch,
+            "branch_name should remain unchanged when rename_branch is false"
+        );
+    }
+
+    #[test]
+    fn rename_toggle_checkbox_flips_rename_branch() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::RenameSession {
+            session_id: "session-1".to_string(),
+            input: TextInput::with_text("test".to_string()),
+            rename_branch: false,
+        };
+
+        // Tab toggles the checkbox.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::RenameSession { rename_branch, .. } => {
+                assert!(*rename_branch, "Tab should toggle rename_branch to true");
+            }
+            other => panic!("expected RenameSession, got {other:?}"),
+        }
+
+        // Tab again toggles it back.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::RenameSession { rename_branch, .. } => {
+                assert!(
+                    !*rename_branch,
+                    "second Tab should toggle rename_branch back to false"
+                );
+            }
+            other => panic!("expected RenameSession, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_rename_session_initializes_rename_branch_false() {
+        let mut app = test_app(default_bindings());
+
+        app.open_rename_session().unwrap();
+
+        match &app.prompt {
+            PromptState::RenameSession { rename_branch, .. } => {
+                assert!(!*rename_branch, "rename_branch should default to false");
+            }
+            other => panic!("expected RenameSession, got {other:?}"),
+        }
     }
 
     #[test]
@@ -5535,6 +5612,7 @@ mod tests {
         app.prompt = PromptState::RenameSession {
             session_id: sid,
             input: TextInput::with_text("rename me".to_string()),
+            rename_branch: false,
         };
         install_rename_overlay(&mut app);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -112,6 +112,15 @@ pub struct App {
     pub(crate) macro_bar: Option<MacroBarState>,
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
     pub(crate) force_redraw: bool,
+    pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
+}
+
+/// Snapshot of session data shared with the branch-sync background worker.
+#[derive(Clone, Debug)]
+pub(crate) struct BranchSyncEntry {
+    pub(crate) session_id: String,
+    pub(crate) worktree_path: String,
+    pub(crate) branch_name: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -342,6 +351,7 @@ pub(crate) enum PromptState {
     RenameSession {
         session_id: String,
         input: TextInput,
+        rename_branch: bool,
     },
     PickEditor {
         session_label: String,
@@ -581,6 +591,13 @@ pub(crate) enum WorkerEvent {
         path: String,
         result: Result<(), String>,
     },
+    BranchSyncReady(Vec<(String, String)>),
+    BranchRenameCompleted {
+        session_id: String,
+        new_branch: String,
+        previous_title: Option<String>,
+        result: Result<(), String>,
+    },
 }
 
 mod input;
@@ -689,15 +706,18 @@ impl App {
             macro_bar: None,
             sigwinch_flag,
             force_redraw: false,
+            branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
         };
         app.restore_sessions();
         app.rebuild_left_items();
         app.reload_changed_files();
+        app.update_branch_sync_sessions();
         Ok(app)
     }
 
     pub fn run(&mut self) -> Result<()> {
         self.spawn_changed_files_poller();
+        self.spawn_branch_sync_worker();
         let mut terminal = ratatui::init();
         execute!(stdout(), EnableMouseCapture)?;
 
@@ -1225,6 +1245,7 @@ impl App {
             self.prompt = PromptState::RenameSession {
                 session_id: session.id,
                 input: TextInput::with_text(current_name),
+                rename_branch: false,
             };
         } else {
             self.set_error("No agent session selected.");
@@ -1232,39 +1253,65 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn apply_rename_session(&mut self, session_id: &str, new_name: String) {
+    pub(crate) fn apply_rename_session(
+        &mut self,
+        session_id: &str,
+        new_name: String,
+        rename_branch: bool,
+    ) {
         let name = new_name.trim().to_string();
         if name.is_empty() {
             self.set_error("Name cannot be empty.");
             return;
         }
 
-        // Gather session info we need before mutating.
-        let Some(session) = self.sessions.iter().find(|s| s.id == session_id) else {
-            return;
-        };
-        let old_branch = session.branch_name.clone();
-        let worktree = session.worktree_path.clone();
+        // Capture the previous title before mutating, in case we need to
+        // revert on a failed branch rename.
+        let previous_title = self
+            .sessions
+            .iter()
+            .find(|s| s.id == session_id)
+            .and_then(|s| s.title.clone());
 
-        // Skip the git rename if the branch name is unchanged.
-        if name != old_branch
-            && let Err(e) = git::rename_branch(Path::new(&worktree), &old_branch, &name)
-        {
-            self.set_error(format!("Rename failed: {e}"));
-            return;
-        }
-
-        // Git rename succeeded — update the session.
+        // Always update the display title immediately.
         if let Some(session) = self.sessions.iter_mut().find(|s| s.id == session_id) {
-            session.branch_name = name.clone();
             session.title = Some(name.clone());
             session.updated_at = Utc::now();
         }
         if let Some(session) = self.sessions.iter().find(|s| s.id == session_id) {
             let _ = self.session_store.upsert_session(session);
         }
-        self.set_info(format!("Renamed agent to \"{name}\" (branch updated)."));
         self.rebuild_left_items();
+
+        // Optionally rename the git branch in a background worker.
+        if rename_branch {
+            let Some(session) = self.sessions.iter().find(|s| s.id == session_id) else {
+                return;
+            };
+            let old_branch = session.branch_name.clone();
+            if name == old_branch {
+                self.set_info(format!("Renamed agent to \"{name}\"."));
+                return;
+            }
+            let worktree = session.worktree_path.clone();
+            let sid = session.id.clone();
+            let new_branch = name.clone();
+            let tx = self.worker_tx.clone();
+            std::thread::spawn(move || {
+                let result = git::rename_branch(Path::new(&worktree), &old_branch, &new_branch)
+                    .map_err(|e| e.to_string());
+                let _ = tx.send(WorkerEvent::BranchRenameCompleted {
+                    session_id: sid,
+                    new_branch,
+                    previous_title,
+                    result,
+                });
+            });
+            self.set_busy(format!("Renaming branch to \"{name}\"\u{2026}"));
+        } else {
+            self.set_info(format!("Renamed agent to \"{name}\"."));
+            self.update_branch_sync_sessions();
+        }
     }
 
     pub(crate) fn mark_session_status(&mut self, session_id: &str, status: SessionStatus) {
@@ -1279,6 +1326,21 @@ impl App {
             session.status = status;
             session.updated_at = Utc::now();
             let _ = self.session_store.upsert_session(session);
+        }
+    }
+
+    /// Refreshes the shared session snapshot used by the branch-sync worker.
+    pub(crate) fn update_branch_sync_sessions(&self) {
+        if let Ok(mut guard) = self.branch_sync_sessions.lock() {
+            *guard = self
+                .sessions
+                .iter()
+                .map(|s| BranchSyncEntry {
+                    session_id: s.id.clone(),
+                    worktree_path: s.worktree_path.clone(),
+                    branch_name: s.branch_name.clone(),
+                })
+                .collect();
         }
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -114,15 +114,17 @@ impl App {
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
             if let Some(session) = self.selected_session() {
-                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
-                spans.push(Span::styled(
-                    "agent: ",
-                    Style::default().fg(label_fg).bg(bg),
-                ));
-                spans.push(Span::styled(
-                    session.branch_name.clone(),
-                    Style::default().fg(self.theme.branch_fg).bg(bg),
-                ));
+                if session.branch_name != project.current_branch {
+                    spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                    spans.push(Span::styled(
+                        "agent: ",
+                        Style::default().fg(label_fg).bg(bg),
+                    ));
+                    spans.push(Span::styled(
+                        session.branch_name.clone(),
+                        Style::default().fg(self.theme.branch_fg).bg(bg),
+                    ));
+                }
             }
             spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
             spans.push(Span::styled(

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -113,6 +113,17 @@ impl App {
                 project.current_branch.clone(),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
+            if let Some(session) = self.selected_session() {
+                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                spans.push(Span::styled(
+                    "agent: ",
+                    Style::default().fg(label_fg).bg(bg),
+                ));
+                spans.push(Span::styled(
+                    session.branch_name.clone(),
+                    Style::default().fg(self.theme.branch_fg).bg(bg),
+                ));
+            }
             spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
             spans.push(Span::styled(
                 "provider: ",
@@ -2680,20 +2691,25 @@ impl App {
                     discard_button: discard_area,
                 };
             }
-            PromptState::RenameSession { input, .. } => {
+            PromptState::RenameSession {
+                input,
+                rename_branch,
+                ..
+            } => {
                 self.render_dim_overlay(frame);
-                let area = centered_rect_exact(56, 9, frame.area());
+                let area = centered_rect_exact(60, 11, frame.area());
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                let [label_area, input_area, hint_area] = Layout::default()
+                let [label_area, input_area, checkbox_area, hint_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Length(1),
                         Constraint::Length(3),
+                        Constraint::Length(2),
                         Constraint::Min(1),
                     ])
                     .areas(inner);
@@ -2738,12 +2754,33 @@ impl App {
                     .block(input_block)
                     .render(input_area, frame.buffer_mut());
 
+                // Checkbox for optional branch rename.
+                let check = if *rename_branch { "x" } else { " " };
+                let checkbox_line = Line::from(vec![
+                    Span::raw(" "),
+                    Span::styled(
+                        format!("[{check}]"),
+                        Style::default().fg(self.theme.hint_key_fg),
+                    ),
+                    Span::styled(
+                        " Also rename git branch (use with care if a PR is open)",
+                        Style::default().fg(self.theme.input_label_fg),
+                    ),
+                ]);
+                Paragraph::new(checkbox_line).render(checkbox_area, frame.buffer_mut());
+
                 let confirm_key = self.bindings.label_for(Action::Confirm);
                 let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let toggle_key = self.bindings.label_for(Action::ToggleSelection);
                 let mut hints = vec![Span::raw(" ")];
                 hints.extend(self.theme.key_badge_default(&confirm_key));
                 hints.push(Span::styled(
                     " confirm  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                hints.extend(self.theme.key_badge_default(&toggle_key));
+                hints.push(Span::styled(
+                    " toggle  ",
                     Style::default().fg(self.theme.hint_desc_fg),
                 ));
                 hints.extend(self.theme.key_badge_default(&close_key));

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -361,6 +361,7 @@ impl App {
         self.clear_companion_terminals_for_session(&session.id);
         self.sessions.retain(|candidate| candidate.id != session.id);
         self.session_store.delete_session(&session.id)?;
+        self.update_branch_sync_sessions();
         self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -24,6 +24,7 @@ impl App {
                     }
                     self.providers.insert(session.id.clone(), client);
                     self.sessions.insert(0, session.clone());
+                    self.update_branch_sync_sessions();
                     self.rebuild_left_items();
                     self.selected_left = self
                         .left_items()
@@ -88,6 +89,66 @@ impl App {
                     }
                     Err(e) => self.set_error(format!("Copy path failed: {e}")),
                 },
+                WorkerEvent::BranchRenameCompleted {
+                    session_id,
+                    new_branch,
+                    previous_title,
+                    result,
+                } => match result {
+                    Ok(()) => {
+                        if let Some(session) =
+                            self.sessions.iter_mut().find(|s| s.id == session_id)
+                        {
+                            session.branch_name = new_branch.clone();
+                            session.updated_at = Utc::now();
+                            let _ = self.session_store.upsert_session(session);
+                        }
+                        self.update_branch_sync_sessions();
+                        self.rebuild_left_items();
+                        self.set_info(format!(
+                            "Renamed agent and branch to \"{new_branch}\"."
+                        ));
+                    }
+                    Err(e) => {
+                        // Revert the title so the session doesn't stay in a
+                        // mixed state where the display name changed but the
+                        // branch didn't.
+                        if let Some(session) =
+                            self.sessions.iter_mut().find(|s| s.id == session_id)
+                        {
+                            session.title = previous_title;
+                            session.updated_at = Utc::now();
+                            let _ = self.session_store.upsert_session(session);
+                        }
+                        self.rebuild_left_items();
+                        self.set_error(format!(
+                            "Branch rename failed, reverted agent name: {e}"
+                        ));
+                    }
+                },
+                WorkerEvent::BranchSyncReady(updates) => {
+                    let mut changed = false;
+                    for (session_id, actual_branch) in updates {
+                        if let Some(session) =
+                            self.sessions.iter_mut().find(|s| s.id == session_id)
+                        {
+                            if session.branch_name != actual_branch {
+                                logger::info(&format!(
+                                    "branch sync: session {} branch changed {} -> {}",
+                                    session_id, session.branch_name, actual_branch,
+                                ));
+                                session.branch_name = actual_branch;
+                                session.updated_at = Utc::now();
+                                let _ = self.session_store.upsert_session(session);
+                                changed = true;
+                            }
+                        }
+                    }
+                    if changed {
+                        self.update_branch_sync_sessions();
+                        self.rebuild_left_items();
+                    }
+                }
                 WorkerEvent::BrowserEntriesReady { dir, entries } => {
                     if let PromptState::BrowseProjects {
                         current_dir,
@@ -188,6 +249,36 @@ impl App {
                 dir: dir.clone(),
                 entries,
             });
+        });
+    }
+
+    pub(crate) fn spawn_branch_sync_worker(&self) {
+        let interval_secs = self.config.ui.branch_sync_interval;
+        if interval_secs == 0 {
+            return; // disabled by config
+        }
+        let tx = self.worker_tx.clone();
+        let sessions = Arc::clone(&self.branch_sync_sessions);
+        thread::spawn(move || {
+            let interval = Duration::from_secs(u64::from(interval_secs));
+            loop {
+                thread::sleep(interval);
+                let snapshot = match sessions.lock() {
+                    Ok(guard) => guard.clone(),
+                    Err(_) => continue,
+                };
+                let mut updates = Vec::new();
+                for entry in &snapshot {
+                    if let Ok(actual) = git::current_branch(Path::new(&entry.worktree_path)) {
+                        if actual != entry.branch_name {
+                            updates.push((entry.session_id.clone(), actual));
+                        }
+                    }
+                }
+                if !updates.is_empty() && tx.send(WorkerEvent::BranchSyncReady(updates)).is_err() {
+                    break; // receiver dropped, app is shutting down
+                }
+            }
         });
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,7 @@ pub struct UiConfig {
     pub staged_pane_height_pct: u16,
     pub commit_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
+    pub branch_sync_interval: u16,
 }
 
 impl Default for Config {
@@ -211,6 +212,7 @@ impl Default for Config {
                 staged_pane_height_pct: 50,
                 commit_pane_height_pct: 40,
                 agent_scrollback_lines: 10_000,
+                branch_sync_interval: 30,
             },
             editor: EditorConfig::default(),
             keys: KeysConfig::default(),
@@ -327,6 +329,7 @@ impl Default for UiConfig {
             staged_pane_height_pct: 50,
             commit_pane_height_pct: 40,
             agent_scrollback_lines: 10_000,
+            branch_sync_interval: 30,
         }
     }
 }
@@ -564,6 +567,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
                 "# Maximum number of lines retained in the embedded agent terminal scrollback.",
             )),
             value_fn: |c| FieldValue::Usize(c.ui.agent_scrollback_lines),
+        },
+        ConfigEntry::Field {
+            key: "branch_sync_interval",
+            comment: Some(CommentSource::Static(
+                "# Interval in seconds for syncing git branch names in the background.\n# Keeps dux in sync if a branch is renamed outside the app.\n# Set to 0 to disable.",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.branch_sync_interval),
         },
         ConfigEntry::Blank,
         ConfigEntry::Section("editor"),


### PR DESCRIPTION
Renaming an agent previously also renamed the underlying git branch via `git branch -m`. This caused a problem when the agent had an active pull request: renaming the agent moved the branch, so subsequent pushes landed on a new standalone branch instead of the PR's source branch. The rename dialog now updates only the display title by default and includes an opt-in **"Also rename git branch"** checkbox with a warning about active PRs. When checked, the branch rename runs in a background worker — if it fails, the title reverts automatically to avoid leaving the session in a mixed state.

A new background worker periodically checks each session's actual git branch (via `git symbolic-ref --short HEAD`) and silently corrects any drift. This keeps dux in sync if a branch is renamed outside the app, for example from a terminal inside the worktree. The sync interval is configurable via `branch_sync_interval` in the `[ui]` config section (default: `30` seconds, set to `0` to disable). A new tenet in `CLAUDE.md` codifies that all periodic or potentially-blocking work must run in background workers to prevent UI freezes.

The header bar now displays the selected agent's worktree branch (`agent: <branch>`) between the project source branch and the provider, giving better visibility into which branch the agent is working on. When the agent branch matches the project branch, the agent segment is omitted to avoid redundancy. Three new unit tests cover the title-only rename, checkbox toggle behavior, and default initialization.