### PR TITLE
Add force-redraw action with Ctrl-L and command palette

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -196,6 +196,10 @@ impl App {
                         Some(0)
                     };
                 }
+                Action::ForceRedraw => {
+                    self.force_redraw = true;
+                    self.set_info("Interface redrawn. All screen contents have been repainted.");
+                }
                 Action::OpenPalette => {
                     self.prompt = PromptState::Command {
                         input: TextInput::new(),
@@ -3316,6 +3320,7 @@ mod tests {
             raw_input_buf: Vec::new(),
             macro_bar: None,
             sigwinch_flag: Arc::new(AtomicBool::new(false)),
+            force_redraw: false,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -111,6 +111,7 @@ pub struct App {
     pub(crate) raw_input_buf: Vec<u8>,
     pub(crate) macro_bar: Option<MacroBarState>,
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
+    pub(crate) force_redraw: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -687,6 +688,7 @@ impl App {
             raw_input_buf: Vec::new(),
             macro_bar: None,
             sigwinch_flag,
+            force_redraw: false,
         };
         app.restore_sessions();
         app.rebuild_left_items();
@@ -710,6 +712,13 @@ impl App {
                     && let Err(err) = crate::io_retry::retry_on_interrupt(|| terminal.autoresize())
                 {
                     self.report_runtime_error("terminal resize failed", &err);
+                }
+
+                if self.force_redraw {
+                    self.force_redraw = false;
+                    if let Err(err) = terminal.clear() {
+                        self.report_runtime_error("force redraw failed", &err);
+                    }
                 }
 
                 if let Err(err) = terminal.draw(|frame| self.render(frame)) {
@@ -935,6 +944,11 @@ impl App {
             }
             "edit-macros" => {
                 self.open_edit_macros();
+                Ok(())
+            }
+            "force-redraw" => {
+                self.force_redraw = true;
+                self.set_info("Interface redrawn. All screen contents have been repainted.");
                 Ok(())
             }
             "" => Ok(()),

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -52,6 +52,7 @@ pub enum Action {
     ToggleSidebar,
     ToggleGitPane,
     ToggleHelp,
+    ForceRedraw,
     Quit,
     CloseOverlay,
     // Resize mode
@@ -211,6 +212,7 @@ impl Action {
             Action::SortAgentsByUpdated => "sort_agents_by_updated",
             Action::SortAgentsByCreated => "sort_agents_by_created",
             Action::SortAgentsByName => "sort_agents_by_name",
+            Action::ForceRedraw => "force_redraw",
             Action::RemoveGitPane => "remove_git_pane",
             Action::EditMacros => "edit_macros",
         }
@@ -287,6 +289,7 @@ impl Action {
             Action::SortAgentsByUpdated => "Sort agents by most recently updated.",
             Action::SortAgentsByCreated => "Sort agents by creation date (newest first).",
             Action::SortAgentsByName => "Sort agents alphabetically by name.",
+            Action::ForceRedraw => "Force a full terminal redraw.",
             Action::RemoveGitPane => "Remove or restore the git pane.",
             Action::EditMacros => "Open the text macros editor.",
         }
@@ -338,6 +341,7 @@ impl Action {
             | Action::ToggleGitPane
             | Action::RemoveGitPane
             | Action::ToggleHelp
+            | Action::ForceRedraw
             | Action::Quit
             | Action::CloseOverlay => Some("Global"),
             Action::ResizeGrow | Action::ResizeShrink => Some("Resize mode"),
@@ -964,6 +968,20 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "help",
             description: "Open the help overlay",
+        }),
+    },
+    BindingDef {
+        action: Action::ForceRedraw,
+        default_keys: &[key!(ctrl - l)],
+        scopes: &[BindingScope::Global],
+        help: Some(HelpEntry {
+            section: "Global",
+            description: "Force a full terminal redraw",
+        }),
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "force-redraw",
+            description: "Force a full terminal redraw (clears rendering artifacts)",
         }),
     },
     BindingDef {
@@ -1981,6 +1999,7 @@ mod tests {
         assert!(actions_in_defs.contains(&Action::AddCurrentDir));
         assert!(actions_in_defs.contains(&Action::SearchFiles));
         assert!(actions_in_defs.contains(&Action::SearchNext));
+        assert!(actions_in_defs.contains(&Action::ForceRedraw));
     }
 
     #[test]


### PR DESCRIPTION
When returning from a suspended process or another fullscreen program, the terminal can retain rendering artifacts because ratatui only performs differential updates by default. This adds a `ForceRedraw` action that calls `terminal.clear()` before the next draw cycle, forcing ratatui to repaint every cell. The default keybinding is **Ctrl-L**, following the well-established terminal convention used by bash, vim, and tmux.

The action is available both as a configurable global keybinding (`force_redraw` in `config.toml`) and through the command palette (`Ctrl-P` → "force-redraw"). It appears in the `?` help overlay under the Global section. Like all keybindings in dux, users can rebind it to any key combination they prefer.

Implementation adds a `force_redraw` flag to `App` that is checked in the run loop just before `terminal.draw()`. When set, the flag is consumed and `terminal.clear()` is called to mark all back-buffer cells as dirty. Three files are touched: `keybindings.rs` (action definition, config, help, binding, palette entry), `app/mod.rs` (field, init, run-loop check, palette dispatch), and `app/input.rs` (global key handler). All existing tests pass, and the new action is covered by the `every_action_has_config_name` and `new_actions_are_in_binding_defs` test suites.