### PR TITLE
Clean up project refresh status line and rename palette command to pull-project

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -859,9 +859,7 @@ impl App {
         let tx = self.worker_tx.clone();
         self.set_busy("Pulling latest changes from remote…");
         thread::spawn(move || {
-            let result = git::pull_current_branch(&worktree)
-                .map(|_| ())
-                .map_err(|e| e.to_string());
+            let result = git::pull_current_branch(&worktree).map_err(|e| e.to_string());
             let _ = tx.send(WorkerEvent::PullCompleted(result));
         });
         Ok(())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -891,7 +891,7 @@ impl App {
             "new-agent" => self.create_agent_for_selected_project(),
             "fork-agent" => self.fork_selected_session(),
             "provider" => self.cycle_selected_project_provider(),
-            "refresh-project" => self.refresh_selected_project(),
+            "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),
             "delete-agent" => self.confirm_delete_selected_session(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -306,7 +306,7 @@ impl App {
             self.set_error("Refresh blocked because the source checkout has uncommitted changes.");
             return Ok(());
         }
-        let output = git::pull_current_branch(path)?;
+        git::pull_current_branch(path)?;
         if let Some(existing) = self
             .projects
             .iter_mut()
@@ -316,9 +316,8 @@ impl App {
                 git::current_branch(path).unwrap_or_else(|_| existing.current_branch.clone());
         }
         self.set_info(format!(
-            "Refreshed project \"{}\": {}",
+            "Refreshed project \"{}\" — local branch is up to date with remote.",
             project.name,
-            output.trim()
         ));
         Ok(())
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -77,7 +77,7 @@ pub fn is_dirty(repo_path: &Path) -> Result<bool> {
     Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
 }
 
-pub fn pull_current_branch(repo_path: &Path) -> Result<String> {
+pub fn pull_current_branch(repo_path: &Path) -> Result<()> {
     let branch = current_branch(repo_path)?;
     let output = Command::new("git")
         .args([
@@ -95,7 +95,7 @@ pub fn pull_current_branch(repo_path: &Path) -> Result<String> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(())
 }
 
 pub fn create_worktree(

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -579,7 +579,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
         hint_contexts: &[(HintContext::LeftProject, "Pull")],
         palette: Some(PaletteEntry {
-            name: "refresh-project",
+            name: "pull-project",
             description: "Git pull the selected project checkout",
         }),
     },


### PR DESCRIPTION
The project refresh action (`git pull --ff-only`) was including raw git stdout in the status line — file change listings like `file.rs | 5 +++--` that clutter a single-line display and provide no actionable information. Per the project's own guideline to rely on exit status rather than parsing stdout for imperative git commands, `pull_current_branch()` now returns `Result<()>` and the status message is a clean, descriptive string: *Refreshed project "name" — local branch is up to date with remote.*

The command palette entry has been renamed from `refresh-project` to `pull-project` so users searching for "pull" in the palette can discover the action more easily. The corresponding dispatch match arm in `mod.rs` was updated to match, and a now-redundant `.map(|_| ())` call in `input.rs` was removed since the function no longer returns a `String`.

All 384 existing tests continue to pass with no changes required.