### PR TITLE
Fall back to fresh session when resume args exit without output

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3335,6 +3335,7 @@ mod tests {
             sigwinch_flag: Arc::new(AtomicBool::new(false)),
             force_redraw: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
+            resume_fallback_candidates: std::collections::HashSet::new(),
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();
@@ -5723,5 +5724,96 @@ mod tests {
             .unwrap();
 
         assert_eq!(app.focus, FocusPane::Center);
+    }
+
+    #[test]
+    fn resume_fallback_retries_with_fresh_session_on_quick_exit() {
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        // Spawn a process that exits immediately without producing output.
+        let args = vec!["-c".to_string(), "exit 1".to_string()];
+        let client =
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn quick-exit");
+        app.providers.insert(session_id.clone(), client);
+        app.mark_session_status(&session_id, SessionStatus::Active);
+        app.resume_fallback_candidates.insert(session_id.clone());
+        app.selected_left = 1;
+        app.session_surface = SessionSurface::Agent;
+
+        // Wait for the process to exit.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.drain_events();
+
+        // The fallback should have spawned a fresh session, so the provider
+        // is still present and the session is active (not detached).
+        assert!(
+            app.providers.contains_key(&session_id),
+            "provider should still be present after fallback retry"
+        );
+        assert_eq!(app.sessions[0].status, SessionStatus::Active);
+        assert!(
+            !app.resume_fallback_candidates.contains(&session_id),
+            "candidate should have been removed after fallback"
+        );
+        assert!(
+            app.status.text().contains("No prior session to resume"),
+            "status should inform user about fallback: {:?}",
+            app.status.text()
+        );
+    }
+
+    #[test]
+    fn resume_fallback_skipped_when_pty_had_output() {
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        // Spawn a process that produces output before exiting.
+        let args = vec!["-c".to_string(), "echo hello".to_string()];
+        let client =
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn with output");
+        app.providers.insert(session_id.clone(), client);
+        app.mark_session_status(&session_id, SessionStatus::Active);
+        app.resume_fallback_candidates.insert(session_id.clone());
+        app.selected_left = 1;
+        app.session_surface = SessionSurface::Agent;
+
+        // Wait for the process to produce output and exit.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.drain_events();
+
+        // Since the PTY had output, the fallback should NOT have triggered.
+        // The session should be detached (normal exit behavior).
+        assert_eq!(app.sessions[0].status, SessionStatus::Detached);
+        assert!(
+            !app.resume_fallback_candidates.contains(&session_id),
+            "candidate should have been removed even when skipped"
+        );
+    }
+
+    #[test]
+    fn no_fallback_for_non_candidate_sessions() {
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        // Spawn a process that exits immediately, but do NOT add it as a candidate.
+        let args = vec!["-c".to_string(), "exit 1".to_string()];
+        let client =
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn quick-exit");
+        app.providers.insert(session_id.clone(), client);
+        app.mark_session_status(&session_id, SessionStatus::Active);
+        // Deliberately not adding to resume_fallback_candidates.
+        app.selected_left = 1;
+        app.session_surface = SessionSurface::Agent;
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.drain_events();
+
+        // Without being a candidate, the session should just go to detached.
+        assert!(
+            !app.providers.contains_key(&session_id),
+            "provider should have been removed"
+        );
+        assert_eq!(app.sessions[0].status, SessionStatus::Detached);
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -114,6 +114,9 @@ pub struct App {
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
     pub(crate) force_redraw: bool,
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
+    /// Session IDs spawned with resume_args that should fall back to regular
+    /// args if the PTY exits before producing any output.
+    pub(crate) resume_fallback_candidates: HashSet<String>,
 }
 
 /// Snapshot of session data shared with the branch-sync background worker.
@@ -709,6 +712,7 @@ impl App {
             sigwinch_flag,
             force_redraw: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
+            resume_fallback_candidates: HashSet::new(),
         };
         app.restore_sessions();
         app.rebuild_left_items();

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -158,9 +158,13 @@ impl App {
         Ok(())
     }
 
-    pub(crate) fn spawn_pty_for_session(&self, session: &AgentSession) -> Result<PtyClient> {
+    pub(crate) fn spawn_pty_for_session(
+        &self,
+        session: &AgentSession,
+        resume: bool,
+    ) -> Result<PtyClient> {
         let cfg = provider_config(&self.config, &session.provider);
-        let launch_args = cfg.interactive_args(true);
+        let launch_args = cfg.interactive_args(resume);
         let (rows, cols) = if self.last_pty_size != (0, 0) {
             self.last_pty_size
         } else {
@@ -515,9 +519,14 @@ impl App {
             ));
             return Ok(());
         }
-        match self.spawn_pty_for_session(&session) {
+        let cfg = provider_config(&self.config, &session.provider);
+        let use_resume = cfg.supports_session_resume();
+        match self.spawn_pty_for_session(&session, use_resume) {
             Ok(client) => {
                 self.providers.insert(session.id.clone(), client);
+                if use_resume {
+                    self.resume_fallback_candidates.insert(session.id.clone());
+                }
                 self.mark_session_status(&session.id, SessionStatus::Active);
                 self.show_agent_surface();
                 self.input_target = InputTarget::Agent;

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -173,14 +173,67 @@ impl App {
                 exited.push(session_id.clone());
             }
         }
+
+        // For sessions that were spawned with resume_args and exited before
+        // producing any output, retry with regular args (fresh session).
+        // This handles `claude --continue || claude` style fallback.
+        let mut retried = HashSet::new();
         for session_id in &exited {
+            if !self.resume_fallback_candidates.remove(session_id) {
+                continue;
+            }
+            let had_output = self
+                .providers
+                .get(session_id)
+                .map(|p| p.has_output())
+                .unwrap_or(false);
+            if had_output {
+                continue;
+            }
+            let Some(session) = self.sessions.iter().find(|s| s.id == *session_id).cloned() else {
+                continue;
+            };
+            self.providers.remove(session_id);
+            logger::info(&format!(
+                "resume args exited without output for agent \"{}\", retrying with regular args",
+                session.branch_name
+            ));
+            match self.spawn_pty_for_session(&session, false) {
+                Ok(client) => {
+                    self.providers.insert(session_id.clone(), client);
+                    self.mark_session_status(session_id, SessionStatus::Active);
+                    let proj_name = self.project_name_for_session(&session);
+                    self.set_info(format!(
+                        "No prior session to resume for agent \"{}\". Started a fresh {} session in project \"{}\".",
+                        session.branch_name,
+                        session.provider.as_str(),
+                        proj_name,
+                    ));
+                    retried.insert(session_id.clone());
+                }
+                Err(err) => {
+                    logger::error(&format!(
+                        "fallback PTY spawn also failed for {}: {err}",
+                        session_id
+                    ));
+                    self.mark_session_status(session_id, SessionStatus::Detached);
+                }
+            }
+        }
+
+        for session_id in &exited {
+            if retried.contains(session_id) {
+                continue;
+            }
             self.providers.remove(session_id);
             self.mark_session_status(session_id, SessionStatus::Detached);
         }
         if !exited.is_empty() {
-            // If the currently-viewed session just exited, leave interactive mode.
+            // If the currently-viewed session just exited (and was not retried),
+            // leave interactive mode.
             if let Some(current) = self.selected_session()
                 && exited.contains(&current.id)
+                && !retried.contains(&current.id)
             {
                 let key = self.bindings.label_for(Action::ReconnectAgent);
                 if self.session_surface == SessionSurface::Agent {


### PR DESCRIPTION
When reconnecting a detached agent, dux unconditionally used `resume_args` (e.g. `claude --continue`). If the worktree had no prior conversation — for example, because the user closed dux before interacting with the agent — the CLI exited immediately with an error like *"No conversation found to continue"*. The PTY exit was detected on the next tick, the overlay closed, and the session went back to detached, creating an open-close loop that made the agent appear stuck.

This adds an automatic fallback modeled after `claude --continue || claude`: when a session spawned with `resume_args` exits before producing any output, dux retries the spawn with regular `args` to start a fresh session. The status line notifies the user that no prior session was found and a new one was started. This works generically for any provider that configures `resume_args`.