### PR TITLE
Improve agent pane: delete from center, name in title, fix dim background

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -452,6 +452,7 @@ impl App {
                 Action::FocusAgent if !in_diff => self.activate_center_agent()?,
                 Action::ExitInteractive if !in_diff => self.activate_center_agent()?,
                 Action::ShowTerminal if !in_diff => self.show_companion_terminal()?,
+                Action::DeleteSession if !in_diff => self.confirm_delete_selected_session()?,
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3363,7 +3363,8 @@ impl App {
     fn center_pane_agent_title(&self) -> String {
         if let Some(session) = self.selected_session() {
             let provider = capitalize(session.provider.as_str());
-            let mut base = format!("{provider} agent");
+            let name = session.title.as_deref().unwrap_or(&session.branch_name);
+            let mut base = format!("{provider} agent · {name}");
             let count = self.session_terminal_count(&session.id);
             if count == 1 {
                 base = format!("{base} (+ 1 terminal)");
@@ -3413,7 +3414,7 @@ fn pty_cell_colors(fg: Color, bg: Color, is_input: bool, theme: &Theme) -> (Colo
     if is_input {
         (fg, bg)
     } else {
-        (theme.overlay_dim_fg, theme.overlay_dim_bg)
+        (theme.overlay_dim_fg, bg)
     }
 }
 
@@ -3743,7 +3744,7 @@ mod tests {
         let bg = Color::Rgb(10, 20, 30);
         assert_eq!(
             pty_cell_colors(fg, bg, false, &theme),
-            (theme.overlay_dim_fg, theme.overlay_dim_bg)
+            (theme.overlay_dim_fg, bg)
         );
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -617,12 +617,15 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::DeleteSession,
         default_keys: &[key!(ctrl - d)],
-        scopes: &[BindingScope::Left],
+        scopes: &[BindingScope::Left, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Projects pane",
             description: "Delete selected session/worktree",
         }),
-        hint_contexts: &[(HintContext::LeftSession, "Delete")],
+        hint_contexts: &[
+            (HintContext::LeftSession, "Delete"),
+            (HintContext::Center, "Delete"),
+        ],
         palette: Some(PaletteEntry {
             name: "delete-agent",
             description: "Delete the selected agent session",


### PR DESCRIPTION
The `Ctrl+D` keybinding for deleting an agent session was previously only available in the left (projects) pane. This extends it to also work from the center (agent) pane, gated behind `!in_diff` to prevent accidental deletion while reviewing diffs. The hint bar and binding scopes are updated accordingly.

The center pane title bar now includes the agent's name alongside the provider label, formatted as **`{Provider} agent · {name}`** (using a Unicode middle dot separator). The name is taken from the session title when set, falling back to the branch name. This makes it easier to identify which agent is active when working with multiple sessions.

In non-interactive mode, the PTY cell rendering previously replaced *both* foreground and background colors with dim overlay values, resulting in a near-black background that obscured most content. The background color is now passed through unchanged so only the text is dimmed, preserving the terminal's original color scheme while still signaling that the pane is read-only.