### PR TITLE
Fix merge detection for squash and rebase merge strategies

### DIFF
--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -459,8 +459,12 @@ fn check_branch_status(input: &BranchCheckInput) -> (Option<bool>, Option<bool>)
             None
         }
     };
-    // Only check merged if the branch is pushed — can't be merged if never pushed.
-    let merged = if pushed == Some(true) {
+    // Always check merged when the remote is reachable (pushed is Some).
+    // The branch may still exist on the remote (pushed=true) or may have been
+    // deleted after merge (pushed=false). In either case the diff-based merge
+    // detection in is_branch_merged handles it correctly.
+    let should_check_merged = pushed.is_some();
+    let merged = if should_check_merged {
         if let Some(ref project_path) = input.project_path {
             match git::is_branch_merged(Path::new(project_path), &worktree, &input.source_branch) {
                 Ok(v) => Some(v),

--- a/src/git.rs
+++ b/src/git.rs
@@ -93,6 +93,7 @@ pub fn is_branch_merged(
     let tip = head_commit(worktree_path)?;
 
     // Step 3: check if the tip is an ancestor of origin/<source_branch>.
+    // This detects regular merge commits where the original SHAs are preserved.
     let remote_ref = format!("origin/{source_branch}");
     let check = Command::new("git")
         .args([
@@ -106,16 +107,45 @@ pub fn is_branch_merged(
         .output()
         .with_context(|| format!("failed to run merge-base --is-ancestor for {tip}"))?;
 
-    // Exit 0 = ancestor (merged), exit 1 = not ancestor (not merged).
-    // Any other exit code is a real error.
     match check.status.code() {
-        Some(0) => Ok(true),
-        Some(1) => Ok(false),
-        _ => Err(anyhow!(
-            "git merge-base --is-ancestor failed: {}",
-            String::from_utf8_lossy(&check.stderr)
-        )),
+        Some(0) => return Ok(true),
+        Some(1) => {} // not a direct ancestor — may still be squash/rebase merged
+        _ => {
+            return Err(anyhow!(
+                "git merge-base --is-ancestor failed: {}",
+                String::from_utf8_lossy(&check.stderr)
+            ));
+        }
     }
+
+    // Step 4: squash/rebase merge detection. GitHub rewrites commit SHAs for
+    // these strategies, so merge-base --is-ancestor fails even though the
+    // changes are fully incorporated. Use `git cherry` which compares commits
+    // by patch-id — it detects equivalent changes regardless of commit SHA.
+    // Lines prefixed with `-` are already applied; `+` means not yet merged.
+    let cherry = Command::new("git")
+        .args([
+            "-C",
+            project_path.to_string_lossy().as_ref(),
+            "cherry",
+            &remote_ref,
+            &tip,
+        ])
+        .output()
+        .with_context(|| format!("failed to run git cherry for squash-merge detection on {tip}"))?;
+    if !cherry.status.success() {
+        return Err(anyhow!(
+            "git cherry failed: {}",
+            String::from_utf8_lossy(&cherry.stderr)
+        ));
+    }
+
+    // If every line starts with `-`, all commits are already in the source
+    // branch (squash/rebase merged). If any line starts with `+`, there are
+    // un-merged commits.
+    let output = String::from_utf8_lossy(&cherry.stdout);
+    let all_applied = !output.is_empty() && output.lines().all(|line| line.starts_with('-'));
+    Ok(all_applied)
 }
 
 pub fn is_git_repo(path: &Path) -> bool {
@@ -1299,6 +1329,48 @@ mod tests {
         // Simulate merge: fast-forward main on the bare origin to include the branch tip.
         run_git(repo.path(), &["checkout", "main"]);
         run_git(repo.path(), &["merge", "--ff-only", &tip]);
+        run_git(repo.path(), &["push", "origin", "main"]);
+
+        assert!(is_branch_merged(repo.path(), &wt, "main").unwrap());
+    }
+
+    #[test]
+    fn is_branch_merged_detects_squash_merge() {
+        let repo = init_test_repo();
+        let _bare = add_bare_origin(repo.path());
+        run_git(repo.path(), &["push", "-u", "origin", "main"]);
+
+        // Create the worktree in a separate temp dir (like dux does) so the
+        // worktree directory doesn't appear as a file in the repo tree.
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt = wt_dir.path().join("squash-me");
+        let out = Command::new("git")
+            .args([
+                "-C",
+                repo.path().to_string_lossy().as_ref(),
+                "worktree",
+                "add",
+                "-b",
+                "squash-me",
+                wt.to_string_lossy().as_ref(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "worktree add failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        fs::write(wt.join("squashed.txt"), "squash content\n").unwrap();
+        commit_all(&wt, "feature commit");
+        run_git(&wt, &["push", "-u", "origin", "squash-me"]);
+
+        // Simulate squash merge: create a NEW commit on main with the same
+        // changes but a different SHA (mimics GitHub's squash-and-merge).
+        run_git(repo.path(), &["checkout", "main"]);
+        fs::write(repo.path().join("squashed.txt"), "squash content\n").unwrap();
+        commit_all(repo.path(), "squash-merge: feature commit (#1)");
         run_git(repo.path(), &["push", "origin", "main"]);
 
         assert!(is_branch_merged(repo.path(), &wt, "main").unwrap());


### PR DESCRIPTION
The `merge-base --is-ancestor` check added in #106 only detects regular merge commits where the original commit SHAs are preserved in the target branch history. GitHub's squash-merge and rebase-merge strategies create new commits with different SHAs, so the ancestor check always reports "not merged" even though all changes are fully incorporated. Additionally, GitHub auto-deletes branches after merge, which caused `is_branch_pushed` to return false and skip the merge check entirely.

This adds a `git cherry` fallback when the ancestor check fails. `git cherry` compares commits by patch-id, detecting equivalent changes regardless of SHA — it correctly identifies squash-merged and rebase-merged branches across all GitHub merge strategies. The merge check now also runs when the remote branch has been deleted (pushed went from true to false), covering the auto-delete-after-merge case.

Includes an integration test that simulates a squash merge by creating a new commit on main with the same file changes but a different SHA, confirming that the detection works end-to-end.