### PR TITLE
Restore mouse capture after Ctrl-L force redraw

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -745,6 +745,9 @@ impl App {
                     if let Err(err) = terminal.clear() {
                         self.report_runtime_error("force redraw failed", &err);
                     }
+                    // Re-enable mouse capture — terminal.clear() resets
+                    // terminal state which drops the mouse capture mode.
+                    let _ = execute!(stdout(), EnableMouseCapture);
                 }
 
                 if let Err(err) = terminal.draw(|frame| self.render(frame)) {


### PR DESCRIPTION
When pressing `Ctrl-L` to force a full terminal redraw, `terminal.clear()` resets the terminal state — including the mouse capture mode that was enabled once at startup via `EnableMouseCapture`. After the clear, the outer terminal no longer receives mouse events, so clicking and scrolling in dux stop working until the application is restarted.

The fix re-sends the `EnableMouseCapture` escape sequence immediately after `terminal.clear()` completes, restoring mouse input for the remainder of the session. This is a one-line addition inside the existing `force_redraw` block in the main run loop.

Verified that all existing tests continue to pass (`cargo test`: 405 passed). The change is confined to `src/app/mod.rs` and has no impact on other input paths or the teardown sequence, which already sends `DisableMouseCapture` on exit.