### PR TITLE
Batch-drain crossterm events to fix inconsistent double-click detection

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4534,6 +4534,36 @@ mod tests {
     }
 
     #[test]
+    fn mouse_up_between_clicks_does_not_break_double_click() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.center_mode = CenterMode::Agent;
+        app.focus = FocusPane::Center;
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn(
+                "sh",
+                &["-c".to_string(), "printf ready; sleep 0.2".to_string()],
+                std::path::Path::new("."),
+                10,
+                10,
+                100,
+            )
+            .expect("spawn pty"),
+        );
+
+        // Down → Up → Down mirrors what the event loop sees for a real
+        // double-click.  The Up must not interfere with detection.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
+    }
+
+    #[test]
     fn mouse_wheel_left_pane_advances_selection_under_cursor() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -779,6 +779,11 @@ impl App {
                     }
                 } else {
                     // Normal UI mode: use crossterm's structured event reader.
+                    // Block up to 100ms for the first event, then drain any
+                    // remaining queued events before rendering so that
+                    // intermediate events (Up, scroll, etc.) don't each cost
+                    // a full render cycle.  This keeps double-click timestamps
+                    // close to wall-clock time.
                     let ready = match crate::io_retry::retry_on_interrupt(|| {
                         event::poll(Duration::from_millis(100))
                     }) {
@@ -792,39 +797,63 @@ impl App {
                         }
                     };
                     if ready {
-                        let event = match crate::io_retry::retry_on_interrupt(event::read) {
-                            Ok(event) => event,
-                            Err(err) => {
-                                self.report_runtime_error(
-                                    "event read failed; input handling was skipped",
-                                    &err,
-                                );
-                                continue;
-                            }
-                        };
-                        match event {
-                            Event::Key(key) => {
-                                let should_exit = match self.handle_key(key) {
-                                    Ok(should_exit) => should_exit,
-                                    Err(err) => {
-                                        self.report_runtime_error(
-                                            "key handling failed",
-                                            err.as_ref(),
-                                        );
-                                        false
-                                    }
-                                };
-                                if should_exit {
+                        let mut should_exit = false;
+                        loop {
+                            let event = match crate::io_retry::retry_on_interrupt(event::read) {
+                                Ok(event) => event,
+                                Err(err) => {
+                                    self.report_runtime_error(
+                                        "event read failed; input handling was skipped",
+                                        &err,
+                                    );
                                     break;
                                 }
-                            }
-                            Event::Mouse(mouse) => {
-                                if self.handle_mouse(mouse) {
-                                    break;
+                            };
+                            match event {
+                                Event::Key(key) => {
+                                    should_exit = match self.handle_key(key) {
+                                        Ok(exit) => exit,
+                                        Err(err) => {
+                                            self.report_runtime_error(
+                                                "key handling failed",
+                                                err.as_ref(),
+                                            );
+                                            false
+                                        }
+                                    };
                                 }
+                                Event::Mouse(mouse) => {
+                                    should_exit = self.handle_mouse(mouse);
+                                }
+                                Event::Resize(_, _) => {}
+                                _ => {}
                             }
-                            Event::Resize(_, _) => {}
-                            _ => {}
+
+                            // Stop draining if exit was requested.
+                            if should_exit {
+                                break;
+                            }
+
+                            // Stop draining if we switched to interactive
+                            // mode — remaining events must go through the
+                            // raw stdin path.
+                            if matches!(
+                                self.input_target,
+                                InputTarget::Agent | InputTarget::Terminal
+                            ) {
+                                break;
+                            }
+
+                            // Check for more queued events without blocking.
+                            match crate::io_retry::retry_on_interrupt(|| {
+                                event::poll(Duration::ZERO)
+                            }) {
+                                Ok(true) => continue,
+                                _ => break,
+                            }
+                        }
+                        if should_exit {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
The event loop previously processed **one crossterm event per iteration**, with a full `drain_events` + render cycle between each one. Between two `Down(Left)` click events there is at minimum an `Up(Left)` release, and possibly stray scroll events. Each intermediate event cost a full frame, so `Instant::now()` at event-processing time drifted from the actual wall-clock click times. On heavy frames this drift could exceed the 500ms double-click threshold even though the physical clicks were well under 200ms apart — making double-click activation of the agent pane inconsistent.

The normal UI mode input path now drains **all pending crossterm events** before rendering. After the initial `poll(100ms)` blocks for the first event, a tight `poll(Duration::ZERO)` + `read()` loop processes every queued event without rendering in between. The loop breaks on exit requests, read errors, an empty queue, or a switch to interactive mode (so remaining events correctly flow through the raw stdin path). One render then reflects the final accumulated state.

This complements the per-click threshold change from #99 — that fix handles the cross-focus pause case (clicking from another pane), while this fix handles the same-focus timing drift case (frame cost inflating the gap between clicks). A new test (`mouse_up_between_clicks_does_not_break_double_click`) verifies that a `Down → Up → Down` sequence matching real hardware events correctly triggers double-click detection.