### PR TITLE
Show agent name in fullscreen pane title instead of non-interactive pane

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3157,7 +3157,11 @@ impl App {
         let area = centered_rect(96, 94, frame.area());
         Clear.render(area, frame.buffer_mut());
         let title = match self.selected_session() {
-            Some(session) => format!(" {} agent ", capitalize(session.provider.as_str())),
+            Some(session) => {
+                let provider = capitalize(session.provider.as_str());
+                let name = session.title.as_deref().unwrap_or(&session.branch_name);
+                format!(" {provider} agent · {name} ")
+            }
             None => " Agent ".to_string(),
         };
         let saved = self.session_surface;
@@ -3345,8 +3349,7 @@ impl App {
     fn center_pane_agent_title(&self) -> String {
         if let Some(session) = self.selected_session() {
             let provider = capitalize(session.provider.as_str());
-            let name = session.title.as_deref().unwrap_or(&session.branch_name);
-            let base = format!("{provider} agent · {name}");
+            let base = format!("{provider} agent");
             let count = self.session_terminal_count(&session.id);
             if count == 1 {
                 return format!("{base} (+ 1 terminal)");


### PR DESCRIPTION
PR #109 added the agent session name (or branch name fallback) to the center pane title, but it was placed in `center_pane_agent_title()` — which controls the **non-interactive** view. The name was meant to appear in the **fullscreen** (interactive) agent overlay, where the user is actively working with the agent and the extra context is most useful.

This moves the name display into `render_fullscreen_agent()`, where the title now reads `"Claude agent · session-name"` instead of just `"Claude agent"`. The non-interactive center pane title reverts to showing only the provider name and terminal count, keeping it compact when space is limited.

Only `src/app/render.rs` is touched — the name logic is lifted out of `center_pane_agent_title()` and inlined into the fullscreen renderer. No new dependencies, no behavioral changes beyond where the name appears.