### PR TITLE
Add profiling build profile and reduce per-frame render allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+flamegraph.svg
+perf.data
+perf.data.old

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,10 @@ opt-level = "z"   # Optimize for size.
 lto = true        # Enable link time optimization.
 codegen-units = 1 # Reduce parallel code generation units.
 debug = 0         # No debug information
+
+[profile.profiling]
+inherits = "release"
+opt-level = 2     # Full speed optimizations (not size-optimized).
+debug = 2         # Full debug info for symbols in flamegraphs.
+strip = false     # Keep symbols intact for profilers.
+lto = false       # Disable LTO so builds are faster during profiling.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run fmt fmt-check lint lint-fix
+.PHONY: run fmt fmt-check lint lint-fix profiling
 
 run:
 	cargo run
@@ -14,3 +14,7 @@ lint:
 
 lint-fix:
 	cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+
+profiling:
+	@command -v flamegraph >/dev/null 2>&1 || { echo "Error: 'flamegraph' not found. Install it with: cargo install flamegraph"; exit 1; }
+	cargo flamegraph --profile profiling --bin dux -o flamegraph.svg

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3354,6 +3354,7 @@ mod tests {
             force_redraw: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: std::collections::HashSet::new(),
+            syntax_cache: crate::diff::SyntaxCache::new(),
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();
@@ -4686,7 +4687,11 @@ mod tests {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);
         app.center_mode = CenterMode::Diff {
-            lines: vec![Line::from("one"), Line::from("two"), Line::from("three")],
+            lines: Arc::new(vec![
+                Line::from("one"),
+                Line::from("two"),
+                Line::from("three"),
+            ]),
             scroll: 0,
         };
         app.last_diff_height = 2;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,7 @@ use crate::config::{
     Config, DuxPaths, MacroSurface, ProjectConfig, ProviderCommandConfig, check_provider_available,
     ensure_config, save_config, validate_keys,
 };
+use crate::diff::SyntaxCache;
 use crate::editor::DetectedEditor;
 use crate::git;
 use crate::keybindings::{
@@ -117,6 +118,8 @@ pub struct App {
     /// Session IDs spawned with resume_args that should fall back to regular
     /// args if the PTY exits before producing any output.
     pub(crate) resume_fallback_candidates: HashSet<String>,
+    /// Cached syntax highlighting resources shared across diff computations.
+    pub(crate) syntax_cache: SyntaxCache,
 }
 
 /// Snapshot of session data shared with the branch-sync background worker.
@@ -205,7 +208,7 @@ pub(crate) enum FullscreenOverlay {
 pub(crate) enum CenterMode {
     Agent,
     Diff {
-        lines: Vec<Line<'static>>,
+        lines: Arc<Vec<Line<'static>>>,
         scroll: u16,
     },
 }
@@ -713,6 +716,7 @@ impl App {
             force_redraw: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: HashSet::new(),
+            syntax_cache: SyntaxCache::new(),
         };
         app.restore_sessions();
         app.rebuild_left_items();

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -382,7 +382,7 @@ impl App {
 
     fn render_diff(&mut self, frame: &mut Frame, area: Rect, focused: bool) {
         let (lines, scroll) = match &self.center_mode {
-            CenterMode::Diff { lines, scroll } => (lines.clone(), *scroll),
+            CenterMode::Diff { lines, scroll } => (Arc::clone(lines), *scroll),
             _ => return,
         };
 
@@ -419,7 +419,7 @@ impl App {
             .saturating_sub(content_area.height);
         let scroll = scroll.min(max_scroll);
 
-        Paragraph::new(lines.clone())
+        Paragraph::new((*lines).clone())
             .wrap(Wrap { trim: false })
             .scroll((scroll, 0))
             .render(content_area, frame.buffer_mut());

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -557,10 +557,14 @@ impl App {
         let Some(file) = self.selected_changed_file() else {
             return Ok(());
         };
-        let output =
-            crate::diff::diff_file(Path::new(&session.worktree_path), &file.path, &self.theme)?;
+        let output = crate::diff::diff_file(
+            Path::new(&session.worktree_path),
+            &file.path,
+            &self.theme,
+            &self.syntax_cache,
+        )?;
         self.center_mode = CenterMode::Diff {
-            lines: output.lines,
+            lines: Arc::new(output.lines),
             scroll: 0,
         };
         self.focus = FocusPane::Center;

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -11,6 +11,21 @@ use syntect::parsing::SyntaxSet;
 
 use crate::theme::Theme as AppTheme;
 
+/// Cached syntax highlighting resources to avoid reloading on every diff.
+pub struct SyntaxCache {
+    pub syntax_set: SyntaxSet,
+    pub theme_set: ThemeSet,
+}
+
+impl SyntaxCache {
+    pub fn new() -> Self {
+        Self {
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+            theme_set: ThemeSet::load_defaults(),
+        }
+    }
+}
+
 /// Pre-rendered diff ready for display.
 pub struct DiffOutput {
     pub lines: Vec<Line<'static>>,
@@ -20,7 +35,12 @@ pub struct DiffOutput {
 ///
 /// `worktree_path` is the root of the git worktree and `rel_path` is the
 /// file path relative to it (as reported by `git status --porcelain`).
-pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Result<DiffOutput> {
+pub fn diff_file(
+    worktree_path: &Path,
+    rel_path: &str,
+    theme: &AppTheme,
+    cache: &SyntaxCache,
+) -> Result<DiffOutput> {
     let old_bytes = crate::git::file_bytes_at_head(worktree_path, rel_path)?.unwrap_or_default();
     let abs_path = worktree_path.join(rel_path);
     let new_bytes = std::fs::read(&abs_path).unwrap_or_default();
@@ -43,18 +63,17 @@ pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Resu
     let old_text = String::from_utf8(old_bytes).unwrap_or_default();
     let new_text = String::from_utf8(new_bytes).unwrap_or_default();
 
-    let syntax_set = SyntaxSet::load_defaults_newlines();
-    let theme_set = ThemeSet::load_defaults();
-    let syn_theme = &theme_set.themes["base16-ocean.dark"];
+    let syn_theme = &cache.theme_set.themes["base16-ocean.dark"];
 
-    let syntax = syntax_set
+    let syntax = cache
+        .syntax_set
         .find_syntax_by_extension(
             Path::new(rel_path)
                 .extension()
                 .and_then(|e| e.to_str())
                 .unwrap_or(""),
         )
-        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+        .unwrap_or_else(|| cache.syntax_set.find_syntax_plain_text());
 
     let text_diff = TextDiff::from_lines(&old_text, &new_text);
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -104,7 +123,7 @@ pub fn diff_file(worktree_path: &Path, rel_path: &str, theme: &AppTheme) -> Resu
 
             // Attempt syntax highlighting; fall back to plain coloring.
             let content = text.trim_end_matches('\n');
-            let spans = match highlighter.highlight_line(content, &syntax_set) {
+            let spans = match highlighter.highlight_line(content, &cache.syntax_set) {
                 Ok(ranges) if tag == ChangeTag::Equal => {
                     // Context lines: full syntax colors, no background tint.
                     let mut out = vec![Span::styled(
@@ -256,7 +275,8 @@ mod tests {
 
         std::fs::write(&file, [0_u8, 159, 146, 151, 152]).unwrap();
 
-        let output = diff_file(repo, "image.bin", &AppTheme::default_dark()).unwrap();
+        let cache = SyntaxCache::new();
+        let output = diff_file(repo, "image.bin", &AppTheme::default_dark(), &cache).unwrap();
         let rendered = output
             .lines
             .iter()


### PR DESCRIPTION
Adds a `[profile.profiling]` Cargo profile that inherits from release but keeps full debug symbols (`debug = 2`, `strip = false`) and disables LTO for faster builds. This makes it straightforward to generate flamegraphs and use macOS Instruments without touching the release profile. A `make profiling` target wraps `cargo flamegraph` with a prerequisite check for the `flamegraph` crate, and `.gitignore` now excludes the generated artifacts.

On the render optimization side, `CenterMode::Diff` now stores its pre-rendered lines behind an `Arc<Vec<Line>>` instead of a plain `Vec`. Previously, `render_diff` cloned the entire diff line buffer **twice** per frame — once to extract it from the enum and once to pass it to `Paragraph::new`. With `Arc`, the extraction is a pointer bump; only the `Paragraph` copy remains (a ratatui API constraint). Additionally, `SyntaxSet::load_defaults_newlines()` and `ThemeSet::load_defaults()` were being called every time a diff was opened. These are now loaded once at startup into a `SyntaxCache` struct on `App` and passed by reference to `diff_file`.

All 393 existing tests pass. No user-facing behavior changes.