### PR TITLE
Add input-debugging modal to diagnose keyboard and mouse events

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4534,6 +4534,36 @@ mod tests {
     }
 
     #[test]
+    fn mouse_up_between_clicks_does_not_break_double_click() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.center_mode = CenterMode::Agent;
+        app.focus = FocusPane::Center;
+        app.providers.insert(
+            "session-1".to_string(),
+            PtyClient::spawn(
+                "sh",
+                &["-c".to_string(), "printf ready; sleep 0.2".to_string()],
+                std::path::Path::new("."),
+                10,
+                10,
+                100,
+            )
+            .expect("spawn pty"),
+        );
+
+        // Down → Up → Down mirrors what the event loop sees for a real
+        // double-click.  The Up must not interfere with detection.
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 30, 5));
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 5));
+
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
+    }
+
+    #[test]
     fn mouse_wheel_left_pane_advances_selection_under_cursor() {
         let mut app = test_app(default_bindings());
         install_mouse_layout(&mut app);

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1099,6 +1099,56 @@ impl App {
     }
 
     fn handle_prompt_key(&mut self, key: KeyEvent) -> Result<bool> {
+        if let PromptState::DebugInput {
+            lines,
+            scroll_offset,
+        } = &mut self.prompt
+        {
+            // Esc always closes — hardcoded so a broken binding can't trap the user.
+            if key.code == KeyCode::Esc {
+                self.prompt = PromptState::None;
+                return Ok(false);
+            }
+
+            let kc = crokey::KeyCombination::from(key).normalized();
+            let label = crate::keybindings::display_format().to_string(kc);
+
+            // Look up what action this key resolves to in every scope.
+            let resolved: Vec<String> = BindingScope::ALL
+                .iter()
+                .filter_map(|&scope| {
+                    self.bindings
+                        .lookup(&key, scope)
+                        .map(|action| format!("{}: {}", scope.display_name(), action.config_name()))
+                })
+                .collect();
+            let action_text = if resolved.is_empty() {
+                "(none)".to_string()
+            } else {
+                resolved.join(", ")
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "Key   ",
+                    Style::default().fg(self.theme.help_section_header_fg),
+                ),
+                Span::raw(" │ "),
+                Span::styled(
+                    format!("{:<18}", label),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" │ "),
+                Span::styled(action_text, Style::default().add_modifier(Modifier::DIM)),
+            ]));
+
+            // Auto-scroll: keep the view pinned to the bottom.
+            let total = lines.len() as u16;
+            *scroll_offset = total;
+
+            return Ok(false);
+        }
+
         if matches!(self.prompt, PromptState::Command { .. }) {
             // Plain character keys always go to TextInput so j/k etc. can be
             // typed without conflicting with navigation bindings.
@@ -2620,6 +2670,49 @@ impl App {
     }
 
     fn handle_prompt_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if let PromptState::DebugInput {
+            lines,
+            scroll_offset,
+        } = &mut self.prompt
+        {
+            // Scroll wheel navigates history without logging.
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    *scroll_offset = scroll_offset.saturating_sub(3);
+                    return false;
+                }
+                MouseEventKind::ScrollDown => {
+                    *scroll_offset = (*scroll_offset + 3).min(lines.len() as u16);
+                    return false;
+                }
+                _ => {}
+            }
+
+            let kind_label = format!("{:?}", mouse.kind);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "Mouse",
+                    Style::default().fg(self.theme.help_section_header_fg),
+                ),
+                Span::raw(" │ "),
+                Span::styled(
+                    format!("{:<18}", kind_label),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(" │ "),
+                Span::styled(
+                    format!("col={} row={}", mouse.column, mouse.row),
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+            ]));
+
+            // Auto-scroll to bottom.
+            let total = lines.len() as u16;
+            *scroll_offset = total;
+
+            return false;
+        }
+
         if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
             return false;
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -779,6 +779,11 @@ impl App {
                     }
                 } else {
                     // Normal UI mode: use crossterm's structured event reader.
+                    // Block up to 100ms for the first event, then drain any
+                    // remaining queued events before rendering so that
+                    // intermediate events (Up, scroll, etc.) don't each cost
+                    // a full render cycle.  This keeps double-click timestamps
+                    // close to wall-clock time.
                     let ready = match crate::io_retry::retry_on_interrupt(|| {
                         event::poll(Duration::from_millis(100))
                     }) {
@@ -792,39 +797,63 @@ impl App {
                         }
                     };
                     if ready {
-                        let event = match crate::io_retry::retry_on_interrupt(event::read) {
-                            Ok(event) => event,
-                            Err(err) => {
-                                self.report_runtime_error(
-                                    "event read failed; input handling was skipped",
-                                    &err,
-                                );
-                                continue;
-                            }
-                        };
-                        match event {
-                            Event::Key(key) => {
-                                let should_exit = match self.handle_key(key) {
-                                    Ok(should_exit) => should_exit,
-                                    Err(err) => {
-                                        self.report_runtime_error(
-                                            "key handling failed",
-                                            err.as_ref(),
-                                        );
-                                        false
-                                    }
-                                };
-                                if should_exit {
+                        let mut should_exit = false;
+                        loop {
+                            let event = match crate::io_retry::retry_on_interrupt(event::read) {
+                                Ok(event) => event,
+                                Err(err) => {
+                                    self.report_runtime_error(
+                                        "event read failed; input handling was skipped",
+                                        &err,
+                                    );
                                     break;
                                 }
-                            }
-                            Event::Mouse(mouse) => {
-                                if self.handle_mouse(mouse) {
-                                    break;
+                            };
+                            match event {
+                                Event::Key(key) => {
+                                    should_exit = match self.handle_key(key) {
+                                        Ok(exit) => exit,
+                                        Err(err) => {
+                                            self.report_runtime_error(
+                                                "key handling failed",
+                                                err.as_ref(),
+                                            );
+                                            false
+                                        }
+                                    };
                                 }
+                                Event::Mouse(mouse) => {
+                                    should_exit = self.handle_mouse(mouse);
+                                }
+                                Event::Resize(_, _) => {}
+                                _ => {}
                             }
-                            Event::Resize(_, _) => {}
-                            _ => {}
+
+                            // Stop draining if exit was requested.
+                            if should_exit {
+                                break;
+                            }
+
+                            // Stop draining if we switched to interactive
+                            // mode — remaining events must go through the
+                            // raw stdin path.
+                            if matches!(
+                                self.input_target,
+                                InputTarget::Agent | InputTarget::Terminal
+                            ) {
+                                break;
+                            }
+
+                            // Check for more queued events without blocking.
+                            match crate::io_retry::retry_on_interrupt(|| {
+                                event::poll(Duration::ZERO)
+                            }) {
+                                Ok(true) => continue,
+                                _ => break,
+                            }
+                        }
+                        if should_exit {
+                            break;
                         }
                     }
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -368,6 +368,10 @@ pub(crate) enum PromptState {
         selected: usize,
         editing: Option<MacroEditState>,
     },
+    DebugInput {
+        lines: Vec<Line<'static>>,
+        scroll_offset: u16,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1009,6 +1013,13 @@ impl App {
             }
             "edit-macros" => {
                 self.open_edit_macros();
+                Ok(())
+            }
+            "input-debugging" => {
+                self.prompt = PromptState::DebugInput {
+                    lines: Vec::new(),
+                    scroll_offset: 0,
+                };
                 Ok(())
             }
             "force-redraw" => {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2812,6 +2812,67 @@ impl App {
                 // Full rendering implemented in Task #5.
                 self.render_edit_macros(frame);
             }
+            PromptState::DebugInput {
+                lines,
+                scroll_offset,
+            } => {
+                self.render_dim_overlay(frame);
+                let popup = centered_rect(80, 70, frame.area());
+                Clear.render(popup, frame.buffer_mut());
+
+                // Split: content area + 1-line footer hint.
+                let chunks =
+                    Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(popup);
+                let content_area = chunks[0];
+                let hint_area = chunks[1];
+
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(self.theme.overlay_border))
+                    .title(" Input Debugger ")
+                    .title_style(
+                        Style::default()
+                            .fg(self.theme.help_section_header_fg)
+                            .add_modifier(Modifier::BOLD),
+                    );
+                let inner = block.inner(content_area);
+                block.render(content_area, frame.buffer_mut());
+
+                // Compute the visible window.
+                let visible_h = inner.height as usize;
+                let total = lines.len();
+                let max_offset = total.saturating_sub(visible_h);
+                let offset = (*scroll_offset as usize).min(max_offset);
+
+                // When scroll_offset exceeds max (auto-scroll sentinel), pin to bottom.
+                let start = if *scroll_offset as usize >= total {
+                    max_offset
+                } else {
+                    offset
+                };
+
+                let visible: Vec<Line> =
+                    lines.iter().skip(start).take(visible_h).cloned().collect();
+
+                let paragraph = Paragraph::new(visible);
+                paragraph.render(inner, frame.buffer_mut());
+
+                // Footer hint.
+                let hint = Line::from(vec![
+                    Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" close  "),
+                    Span::styled("Scroll", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" navigate"),
+                ]);
+                let hint_para = Paragraph::new(hint)
+                    .alignment(ratatui::layout::Alignment::Center)
+                    .style(
+                        Style::default()
+                            .fg(self.theme.hint_desc_fg)
+                            .add_modifier(Modifier::DIM),
+                    );
+                hint_para.render(hint_area, frame.buffer_mut());
+            }
             PromptState::None => {}
         }
     }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -76,6 +76,7 @@ pub enum Action {
     SortAgentsByName,
     RemoveGitPane,
     EditMacros,
+    DebugInput,
 }
 
 /// Where a binding's key combo is matched.
@@ -96,6 +97,22 @@ pub enum BindingScope {
 }
 
 impl BindingScope {
+    /// All scope variants, for iteration in diagnostics.
+    pub const ALL: &[BindingScope] = &[
+        Self::Global,
+        Self::Left,
+        Self::Center,
+        Self::Files,
+        Self::Interactive,
+        Self::Resize,
+        Self::Palette,
+        Self::Browser,
+        Self::RuntimeKill,
+        Self::Dialog,
+        Self::CommitInput,
+        Self::Help,
+    ];
+
     /// Human-readable scope name for error messages and diagnostics.
     pub fn display_name(self) -> &'static str {
         match self {
@@ -215,6 +232,7 @@ impl Action {
             Action::ForceRedraw => "force_redraw",
             Action::RemoveGitPane => "remove_git_pane",
             Action::EditMacros => "edit_macros",
+            Action::DebugInput => "debug_input",
         }
     }
 
@@ -292,6 +310,7 @@ impl Action {
             Action::ForceRedraw => "Force a full terminal redraw.",
             Action::RemoveGitPane => "Remove or restore the git pane.",
             Action::EditMacros => "Open the text macros editor.",
+            Action::DebugInput => "Open input event debugger to inspect keyboard and mouse events.",
         }
     }
 
@@ -359,7 +378,8 @@ impl Action {
             | Action::SortAgentsByUpdated
             | Action::SortAgentsByCreated
             | Action::SortAgentsByName
-            | Action::EditMacros => None,
+            | Action::EditMacros
+            | Action::DebugInput => None,
         }
     }
 }
@@ -1227,6 +1247,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "edit-macros",
             description: "Edit text macros for interactive mode",
+        }),
+    },
+    BindingDef {
+        action: Action::DebugInput,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "input-debugging",
+            description: "Open input event debugger to inspect keyboard and mouse events",
         }),
     },
 ];


### PR DESCRIPTION
Adds a new **input-debugging** command to the command palette (Ctrl+P → type `input`) that opens a diagnostic overlay capturing every keyboard and mouse event in a live scrollable log. Each entry shows the event type (`Key` or `Mouse`), the raw event details (key combo label or mouse event kind with coordinates), and for keys, the resolved binding action across all scopes — making it easy to see exactly what crossterm delivers and how the binding system interprets it.

This was built to investigate an inconsistent double-click issue on Linux where the agent pane fails to enter fullscreen on rapid clicks despite working on macOS. The debugger lets users observe the raw event sequence their terminal produces (e.g. whether `Down(Left)` events are being swallowed or replaced by `Drag`/`Moved` events during rapid clicking). It's also useful for diagnosing any keybinding issues users might report — they can open the modal and see which action a key resolves to in each scope.

The modal is hardcoded to close on **Esc** (not the configurable `CloseOverlay` action) so a misconfigured binding can never trap the user. Scroll wheel navigates the event history, and new events auto-scroll the view to the bottom. The implementation follows existing overlay patterns: `PromptState::DebugInput` variant, key/mouse handler branches in `handle_prompt_key`/`handle_prompt_mouse`, and a dim-overlay + centered-box renderer in `render_prompt`.