### PR TITLE
Fix truncated checkbox label in rename agent overlay

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2713,7 +2713,7 @@ impl App {
                 ..
             } => {
                 self.render_dim_overlay(frame);
-                let area = centered_rect_exact(60, 11, frame.area());
+                let area = centered_rect_exact(62, 12, frame.area());
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
@@ -2725,7 +2725,7 @@ impl App {
                     .constraints([
                         Constraint::Length(1),
                         Constraint::Length(3),
-                        Constraint::Length(2),
+                        Constraint::Length(3),
                         Constraint::Min(1),
                     ])
                     .areas(inner);
@@ -2779,11 +2779,16 @@ impl App {
                         Style::default().fg(self.theme.hint_key_fg),
                     ),
                     Span::styled(
-                        " Also rename git branch (use with care if a PR is open)",
+                        " Also rename the git branch",
                         Style::default().fg(self.theme.input_label_fg),
                     ),
                 ]);
-                Paragraph::new(checkbox_line).render(checkbox_area, frame.buffer_mut());
+                let checkbox_hint = Line::from(Span::styled(
+                    "     Open PRs will still reference the old branch name",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                Paragraph::new(vec![checkbox_line, checkbox_hint])
+                    .render(checkbox_area, frame.buffer_mut());
 
                 let confirm_key = self.bindings.label_for(Action::Confirm);
                 let close_key = self.bindings.label_for(Action::CloseOverlay);


### PR DESCRIPTION
The branch-rename checkbox in the **Rename Agent** overlay previously read _"Also rename git branch (use with care if a PR is open)"_ — a single line that was too long for the 60-column overlay and got clipped. The parenthetical warning was easy to miss even when it did fit.

The label is now split across two lines: a clear action (`Also rename the git branch`) followed by a dimmed hint (`Open PRs will still reference the old branch name`). The hint uses `hint_desc_fg` styling so it reads as supplementary context rather than an alarm. The overlay width grows from 60 to 62 columns and the checkbox area from 2 to 3 rows to accommodate the second line.

This keeps the information about open PRs visible and readable without truncation, while keeping the tone informational rather than alarming — renaming a branch with an open PR is not destructive, it just means the PR will still point at the old name.