### PR TITLE
Add optional prompt for custom agent names with branch-safe validation

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -44,6 +44,7 @@ enum PromptMouseTarget {
     ConfirmDiscardCancel,
     ConfirmDiscardConfirm,
     RenameInput,
+    NameNewAgentInput,
 }
 
 fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
@@ -1695,6 +1696,74 @@ impl App {
             return Ok(false);
         }
 
+        if matches!(self.prompt, PromptState::NameNewAgent { .. }) {
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
+            let action = if is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::Dialog)
+            };
+
+            match action {
+                Some(Action::CloseOverlay) => {
+                    self.prompt = PromptState::None;
+                }
+                Some(Action::Confirm) => {
+                    // Extract the name from the input before taking ownership.
+                    let name = if let PromptState::NameNewAgent { input, .. } = &self.prompt {
+                        input.text.trim().to_string()
+                    } else {
+                        unreachable!()
+                    };
+                    if name.is_empty() {
+                        self.set_error("Agent name cannot be empty.");
+                        self.prompt = PromptState::None;
+                        return Ok(false);
+                    }
+                    if !git::is_valid_agent_name(&name) {
+                        self.set_error(
+                            "Agent name may only contain letters, digits, dashes, underscores, \
+                             or slashes. It cannot start with \"-\" or \"/\", end with \"/\", \
+                             or contain \"//\".",
+                        );
+                        return Ok(false);
+                    }
+                    // Take ownership of the prompt to extract the request.
+                    let old_prompt = std::mem::replace(&mut self.prompt, PromptState::None);
+                    let PromptState::NameNewAgent { mut request, .. } = old_prompt else {
+                        unreachable!()
+                    };
+                    let msg = match &request {
+                        CreateAgentRequest::NewProject { project, .. } => {
+                            format!(
+                                "Creating a new agent worktree \"{name}\" for project \"{}\" and launching a fresh session...",
+                                project.name
+                            )
+                        }
+                        CreateAgentRequest::ForkSession { source_label, .. } => {
+                            format!(
+                                "Forking agent \"{source_label}\" as \"{name}\" by cloning its current worktree contents into a fresh session...",
+                            )
+                        }
+                    };
+                    match &mut request {
+                        CreateAgentRequest::NewProject { custom_name, .. }
+                        | CreateAgentRequest::ForkSession { custom_name, .. } => {
+                            *custom_name = Some(name);
+                        }
+                    }
+                    self.dispatch_create_agent_request(request, msg)?;
+                }
+                _ => {
+                    if let PromptState::NameNewAgent { input, .. } = &mut self.prompt {
+                        input.handle_key(key);
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if let PromptState::RenameSession {
             session_id,
             input,
@@ -2074,6 +2143,9 @@ impl App {
             }
             OverlayMouseLayout::RenameSession { input } => {
                 contains_point(input, column, row).then_some(PromptMouseTarget::RenameInput)
+            }
+            OverlayMouseLayout::NameNewAgent { input } => {
+                contains_point(input, column, row).then_some(PromptMouseTarget::NameNewAgentInput)
             }
         }
     }
@@ -2690,6 +2762,16 @@ impl App {
         }
     }
 
+    fn set_name_new_agent_cursor_from_mouse(&mut self, column: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::NameNewAgent { input } => input,
+            _ => return,
+        };
+        if let PromptState::NameNewAgent { input, .. } = &mut self.prompt {
+            input.cursor = cursor_from_single_line_position(&input.text, input_area, 0, column);
+        }
+    }
+
     fn handle_prompt_mouse(&mut self, mouse: MouseEvent) -> bool {
         if let PromptState::DebugInput {
             lines,
@@ -2829,6 +2911,9 @@ impl App {
             }
             PromptMouseTarget::RenameInput => {
                 self.set_rename_cursor_from_mouse(mouse.column);
+            }
+            PromptMouseTarget::NameNewAgentInput => {
+                self.set_name_new_agent_cursor_from_mouse(mouse.column);
             }
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -363,6 +363,10 @@ pub(crate) enum PromptState {
         input: TextInput,
         rename_branch: bool,
     },
+    NameNewAgent {
+        request: CreateAgentRequest,
+        input: TextInput,
+    },
     PickEditor {
         session_label: String,
         worktree_path: String,
@@ -516,6 +520,9 @@ pub(crate) enum OverlayMouseLayout {
     RenameSession {
         input: Rect,
     },
+    NameNewAgent {
+        input: Rect,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -577,11 +584,13 @@ pub(crate) struct AgentReadyData {
 pub(crate) enum CreateAgentRequest {
     NewProject {
         project: Project,
+        custom_name: Option<String>,
     },
     ForkSession {
         project: Project,
         source_session: Box<AgentSession>,
         source_label: String,
+        custom_name: Option<String>,
     },
 }
 
@@ -1326,6 +1335,13 @@ impl App {
         let name = new_name.trim().to_string();
         if name.is_empty() {
             self.set_error("Name cannot be empty.");
+            return;
+        }
+        if rename_branch && !git::is_valid_agent_name(&name) {
+            self.set_error(
+                "Branch name may only contain letters, digits, dashes, underscores, or slashes. \
+                 It cannot start with \"-\" or \"/\", end with \"/\", or contain \"//\".",
+            );
             return;
         }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2878,6 +2878,81 @@ impl App {
                     );
                 hint_para.render(hint_area, frame.buffer_mut());
             }
+            PromptState::NameNewAgent { input, .. } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect_exact(60, 8, frame.area());
+                Clear.render(area, frame.buffer_mut());
+
+                let outer = self.themed_overlay_block("Name New Agent");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [label_area, input_area, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                        Constraint::Min(1),
+                    ])
+                    .areas(inner);
+
+                Paragraph::new(Line::from(Span::styled(
+                    " Enter a name for the new agent (used as branch name):",
+                    Style::default().fg(self.theme.input_label_fg),
+                )))
+                .render(label_area, frame.buffer_mut());
+
+                // Input field with cursor indicator.
+                let display = if input.cursor < input.text.len() {
+                    let (before, after) = input.text.split_at(input.cursor);
+                    let (cursor_char, rest) = after.split_at(1);
+                    Line::from(vec![
+                        Span::raw(format!(" {before}")),
+                        Span::styled(
+                            cursor_char.to_string(),
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                        Span::raw(rest.to_string()),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::raw(format!(" {}", &input.text)),
+                        Span::styled(
+                            " ",
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                    ])
+                };
+                let input_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let input_inner = input_block.inner(input_area);
+                Paragraph::new(display)
+                    .block(input_block)
+                    .render(input_area, frame.buffer_mut());
+
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let mut hints = vec![Span::raw(" ")];
+                hints.extend(self.theme.key_badge_default(&confirm_key));
+                hints.push(Span::styled(
+                    " confirm  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                hints.extend(self.theme.key_badge_default(&close_key));
+                hints.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                self.overlay_layout.active =
+                    OverlayMouseLayout::NameNewAgent { input: input_inner };
+            }
             PromptState::None => {}
         }
     }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -99,10 +99,25 @@ impl App {
             self.set_error("Select a project first.");
             return Ok(());
         };
+
+        if self.config.defaults.prompt_for_name {
+            self.input_target = InputTarget::None;
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.prompt = PromptState::NameNewAgent {
+                request: CreateAgentRequest::NewProject {
+                    project,
+                    custom_name: None,
+                },
+                input: TextInput::default(),
+            };
+            return Ok(());
+        }
+
         logger::info(&format!("creating agent for project {}", project.path));
         self.dispatch_create_agent_request(
             CreateAgentRequest::NewProject {
                 project: project.clone(),
+                custom_name: None,
             },
             format!(
                 "Creating a new agent worktree for project \"{}\" and launching a fresh session...",
@@ -121,6 +136,22 @@ impl App {
             return Ok(());
         };
         let source_label = self.session_label(&source_session);
+
+        if self.config.defaults.prompt_for_name {
+            self.input_target = InputTarget::None;
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.prompt = PromptState::NameNewAgent {
+                request: CreateAgentRequest::ForkSession {
+                    project: project.clone(),
+                    source_session: Box::new(source_session),
+                    source_label,
+                    custom_name: None,
+                },
+                input: TextInput::default(),
+            };
+            return Ok(());
+        }
+
         logger::info(&format!(
             "forking session {} from worktree {}",
             source_session.id, source_session.worktree_path
@@ -130,6 +161,7 @@ impl App {
                 project: project.clone(),
                 source_session: Box::new(source_session),
                 source_label: source_label.clone(),
+                custom_name: None,
             },
             format!(
                 "Forking agent \"{source_label}\" by cloning its current worktree contents into a fresh session...",
@@ -137,7 +169,7 @@ impl App {
         )
     }
 
-    fn dispatch_create_agent_request(
+    pub(crate) fn dispatch_create_agent_request(
         &mut self,
         request: CreateAgentRequest,
         busy_message: String,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -370,27 +370,34 @@ pub(crate) fn run_create_agent_job(
 ) {
     let (project, provider, source_branch, status_message, branch_name, worktree_path) =
         match request {
-            CreateAgentRequest::NewProject { project } => {
+            CreateAgentRequest::NewProject {
+                project,
+                custom_name,
+            } => {
                 let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
                     "Creating a new worktree for project \"{}\"...",
                     project.name
                 )));
                 let repo_path = PathBuf::from(&project.path);
-                let (branch_name, worktree_path) =
-                    match git::create_worktree(&repo_path, &paths.worktrees_root, &project.name) {
-                        Ok(result) => result,
-                        Err(err) => {
-                            logger::error(&format!(
-                                "worktree creation failed for {}: {err}",
-                                project.path
-                            ));
-                            let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
-                                "Failed to create a new worktree for project \"{}\": {err}",
-                                project.name
-                            )));
-                            return;
-                        }
-                    };
+                let (branch_name, worktree_path) = match git::create_worktree(
+                    &repo_path,
+                    &paths.worktrees_root,
+                    &project.name,
+                    custom_name.as_deref(),
+                ) {
+                    Ok(result) => result,
+                    Err(err) => {
+                        logger::error(&format!(
+                            "worktree creation failed for {}: {err}",
+                            project.path
+                        ));
+                        let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                            "Failed to create a new worktree for project \"{}\": {err}",
+                            project.name
+                        )));
+                        return;
+                    }
+                };
                 let status_message = format!(
                     "Created {} agent \"{}\" in project \"{}\". The new worktree is ready in a fresh session.",
                     project.default_provider.as_str(),
@@ -410,6 +417,7 @@ pub(crate) fn run_create_agent_job(
                 project,
                 source_session,
                 source_label,
+                custom_name,
             } => {
                 let source_worktree = PathBuf::from(&source_session.worktree_path);
                 let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
@@ -434,6 +442,7 @@ pub(crate) fn run_create_agent_job(
                     &paths.worktrees_root,
                     &project.name,
                     Some(&source_head),
+                    custom_name.as_deref(),
                 ) {
                     Ok(result) => result,
                     Err(err) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,7 @@ pub struct Defaults {
     pub provider: String,
     pub start_directory: Option<String>,
     pub commit_prompt: Option<String>,
+    pub prompt_for_name: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -250,6 +251,7 @@ impl Default for Defaults {
             provider: "claude".to_string(),
             start_directory,
             commit_prompt: Some(DEFAULT_COMMIT_PROMPT.to_string()),
+            prompt_for_name: false,
         }
     }
 }
@@ -441,6 +443,7 @@ enum FieldValue {
     OptStr(Option<String>),
     U16(u16),
     Usize(usize),
+    Bool(bool),
     MultilineStr(Option<String>),
 }
 
@@ -507,6 +510,16 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
                  # Override per-project by adding commit_prompt in a [[projects]] entry.",
             ))),
             value_fn: |c| FieldValue::MultilineStr(c.defaults.commit_prompt.clone()),
+        },
+        ConfigEntry::Blank,
+        ConfigEntry::Field {
+            key: "prompt_for_name",
+            comment: Some(CommentSource::Static(
+                "# When true, dux prompts for a custom agent name before creating or forking a session.\n\
+                 # The name becomes the git branch name for the new worktree.\n\
+                 # When false, a random two-word name is generated automatically.",
+            )),
+            value_fn: |c| FieldValue::Bool(c.defaults.prompt_for_name),
         },
         ConfigEntry::Blank,
         ConfigEntry::Providers,
@@ -635,6 +648,9 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
                     }
                     FieldValue::Usize(n) => {
                         let _ = writeln!(out, "{key} = {n}");
+                    }
+                    FieldValue::Bool(b) => {
+                        let _ = writeln!(out, "{key} = {b}");
                     }
                     FieldValue::MultilineStr(Some(s)) => {
                         let escaped = escape_toml_multiline(&s);

--- a/src/git.rs
+++ b/src/git.rs
@@ -1210,4 +1210,48 @@ mod tests {
         assert!(!is_valid_agent_name("foo..bar"));
         assert!(!is_valid_agent_name("hello world!"));
     }
+
+    #[test]
+    fn create_worktree_uses_custom_name() {
+        let repo = init_test_repo();
+        let worktrees_root = repo.path().join("agents");
+        let (branch, path) =
+            create_worktree(repo.path(), &worktrees_root, "proj", Some("my-agent")).unwrap();
+        assert_eq!(branch, "my-agent");
+        assert!(path.ends_with("proj/my-agent"));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn create_worktree_generates_name_when_none() {
+        let repo = init_test_repo();
+        let worktrees_root = repo.path().join("agents");
+        let (branch, path) = create_worktree(repo.path(), &worktrees_root, "proj", None).unwrap();
+        // Auto-generated names contain a dash (docker-style petname).
+        assert!(branch.contains('-'), "expected dash in '{branch}'");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn create_worktree_from_start_point_uses_custom_name() {
+        let repo = init_test_repo();
+        let source = add_worktree(repo.path(), "src-branch");
+        fs::write(source.join("marker.txt"), "data\n").unwrap();
+        commit_all(&source, "add marker");
+        let source_head = head_commit(&source).unwrap();
+
+        let worktrees_root = repo.path().join("forks");
+        let (branch, forked) = create_worktree_from_start_point(
+            repo.path(),
+            &worktrees_root,
+            "proj",
+            Some(&source_head),
+            Some("my-fork"),
+        )
+        .unwrap();
+
+        assert_eq!(branch, "my-fork");
+        assert!(forked.ends_with("proj/my-fork"));
+        assert_eq!(head_commit(&forked).unwrap(), source_head);
+    }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -102,8 +102,9 @@ pub fn create_worktree(
     repo_path: &Path,
     worktrees_root: &Path,
     project_name: &str,
+    custom_name: Option<&str>,
 ) -> Result<(String, PathBuf)> {
-    create_worktree_from_start_point(repo_path, worktrees_root, project_name, None)
+    create_worktree_from_start_point(repo_path, worktrees_root, project_name, None, custom_name)
 }
 
 pub fn create_worktree_from_start_point(
@@ -111,8 +112,11 @@ pub fn create_worktree_from_start_point(
     worktrees_root: &Path,
     project_name: &str,
     start_point: Option<&str>,
+    custom_name: Option<&str>,
 ) -> Result<(String, PathBuf)> {
-    let branch_name = docker_style_name();
+    let branch_name = custom_name
+        .map(|s| s.to_string())
+        .unwrap_or_else(docker_style_name);
     let project_root = worktrees_root.join(project_name);
     fs::create_dir_all(&project_root)?;
     let worktree_path = project_root.join(&branch_name);
@@ -650,6 +654,24 @@ pub fn docker_style_name() -> String {
         .expect("petname generation should not fail")
 }
 
+/// Returns `true` if `name` contains only characters safe for git branch names:
+/// ASCII alphanumeric, dash (`-`), underscore (`_`), and slash (`/`).
+/// Also rejects names that start or end with `/`, contain consecutive slashes,
+/// or start with `-`, since git forbids these patterns in ref names.
+pub fn is_valid_agent_name(name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    if name.starts_with('-') || name.starts_with('/') || name.ends_with('/') {
+        return false;
+    }
+    if name.contains("//") {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/')
+}
+
 fn sync_directory_contents(source: &Path, destination: &Path) -> Result<()> {
     let mut source_entries = Vec::new();
     for entry in fs::read_dir(source)? {
@@ -854,6 +876,7 @@ mod tests {
             &worktrees_root,
             "demo",
             Some(&source_head),
+            None,
         )
         .unwrap();
 
@@ -1162,5 +1185,29 @@ mod tests {
         assert_eq!(staged.len(), 1);
         assert_eq!(staged[0].path, "new name.txt");
         assert_eq!(staged[0].status, "R");
+    }
+
+    #[test]
+    fn valid_agent_names() {
+        assert!(is_valid_agent_name("foo"));
+        assert!(is_valid_agent_name("foo-bar"));
+        assert!(is_valid_agent_name("foo_bar"));
+        assert!(is_valid_agent_name("foo/bar"));
+        assert!(is_valid_agent_name("ABC123"));
+        assert!(is_valid_agent_name("feature/my-branch_v2"));
+    }
+
+    #[test]
+    fn invalid_agent_names() {
+        assert!(!is_valid_agent_name(""));
+        assert!(!is_valid_agent_name("foo bar"));
+        assert!(!is_valid_agent_name("foo@bar"));
+        assert!(!is_valid_agent_name("-foo"));
+        assert!(!is_valid_agent_name("foo/"));
+        assert!(!is_valid_agent_name("/foo"));
+        assert!(!is_valid_agent_name("foo//bar"));
+        assert!(!is_valid_agent_name("foo.bar"));
+        assert!(!is_valid_agent_name("foo..bar"));
+        assert!(!is_valid_agent_name("hello world!"));
     }
 }


### PR DESCRIPTION
When `prompt_for_name` is set to `true` in `[defaults]`, dux now shows a "Name New Agent" dialog before creating or forking a session. The name the user types becomes the git branch name for the new worktree. When the setting is `false` (the default), behavior is unchanged — a random two-word petname is generated automatically. The dialog supports the same text editing, mouse interaction, and keyboard shortcuts as the existing rename overlay.

Agent names are validated to contain only characters safe for git branch names: ASCII letters, digits, dashes, underscores, and slashes. Names cannot be empty, start with `-` or `/`, end with `/`, or contain `//`. This validation applies in three places: the new naming dialog on creation, the naming dialog on fork, and the existing rename flow when "also rename branch" is enabled. Invalid names produce a verbose, actionable status message explaining what characters are allowed.

The new `prompt_for_name` setting follows the existing config schema pattern with a fully materialized inline comment explaining the behavior, so the config file remains self-documenting. All 395 existing tests continue to pass, and new unit tests cover the `is_valid_agent_name` validation function for both accepted and rejected inputs.