### PR TITLE
Set dirty flag on PTY write to avoid input echo delay

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -193,10 +193,15 @@ impl PtyClient {
     }
 
     /// Write raw bytes to the PTY (forwards keystrokes to the child process).
+    /// Also marks the terminal dirty so the next render frame rebuilds the
+    /// snapshot — the child process will echo or react to this input, and
+    /// pre-marking dirty avoids a one-frame delay waiting for the reader
+    /// thread to process the echo.
     pub fn write_bytes(&self, bytes: &[u8]) -> Result<()> {
         let mut writer = self.writer.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
         writer.write_all(bytes).context("failed to write to PTY")?;
         writer.flush().context("failed to flush PTY writer")?;
+        self.dirty.store(true, Ordering::Release);
         Ok(())
     }
 


### PR DESCRIPTION
The dirty flag optimization added in #119 skips the snapshot rebuild when no terminal state change has occurred. However, `write_bytes()` — which forwards keystrokes to the PTY — did not mark the terminal dirty. If the render frame fires between the write and the reader thread processing the child's echo, `snapshot_into()` sees `dirty=false` and returns the stale buffer, delaying the visible echo by one 100ms frame.

This adds `dirty.store(true, Release)` at the end of `write_bytes()`. Since any PTY write will produce a response that changes the terminal state (echo, cursor movement, output), pre-marking dirty is semantically correct and ensures the very next frame rebuilds the snapshot.

All 407 tests pass. No new tests needed — the fix is a single atomic store on an existing flag in an existing code path.