### PR TITLE
Add millisecond timestamps to input debugger entries

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,4 +1,5 @@
 use super::*;
+use chrono::Local;
 const MOUSE_WHEEL_LINES: usize = 3;
 const MIN_LEFT_WIDTH_PCT: u16 = 14;
 const MAX_LEFT_WIDTH_PCT: u16 = 38;
@@ -1149,7 +1150,10 @@ impl App {
                 resolved.join(", ")
             };
 
+            let ts = Local::now().format("%H:%M:%S%.3f").to_string();
             lines.push(Line::from(vec![
+                Span::styled(ts, Style::default().add_modifier(Modifier::DIM)),
+                Span::raw(" │ "),
                 Span::styled(
                     "Key   ",
                     Style::default().fg(self.theme.help_section_header_fg),
@@ -2710,7 +2714,10 @@ impl App {
             }
 
             let kind_label = format!("{:?}", mouse.kind);
+            let ts = Local::now().format("%H:%M:%S%.3f").to_string();
             lines.push(Line::from(vec![
+                Span::styled(ts, Style::default().add_modifier(Modifier::DIM)),
+                Span::raw(" │ "),
                 Span::styled(
                     "Mouse",
                     Style::default().fg(self.theme.help_section_header_fg),


### PR DESCRIPTION
When using the input-debugging modal to diagnose keyboard and mouse events, pressing the same key repeatedly produced visually identical lines. Without any distinguishing marker, it was impossible to tell whether new events were being captured or if the display was stale. This made the debugger less useful for diagnosing rapid input or confirming that events were actually firing.

Each entry in the debug log now starts with a **dim `HH:MM:SS.mmm` wall-clock timestamp** as the first column, separated by a `│` delimiter from the existing event type label. Both keyboard and mouse event lines include this timestamp. Millisecond precision is sufficient to distinguish even rapid key repeats (~30ms apart) while keeping the column compact and readable.

The implementation uses `chrono::Local`, which is already a project dependency. A `let ts = Local::now().format(...)` call is made inline at each of the two push sites (keyboard events and mouse events) — no new types, traits, or helpers were introduced.