### PR TITLE
Force snapshot rebuild on agent switch to fix stale center pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3532,6 +3532,7 @@ mod tests {
             resume_fallback_candidates: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
+            last_snapshot_id: None,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -123,6 +123,9 @@ pub struct App {
     pub(crate) syntax_cache: SyntaxCache,
     /// Reusable snapshot buffer to avoid per-frame allocation of terminal cells.
     pub(crate) snapshot_buf: TerminalSnapshot,
+    /// ID of the provider that last populated `snapshot_buf`, used to detect
+    /// agent switches and force a snapshot rebuild.
+    last_snapshot_id: Option<String>,
 }
 
 /// Snapshot of session data shared with the branch-sync background worker.
@@ -730,6 +733,7 @@ impl App {
             resume_fallback_candidates: HashSet::new(),
             syntax_cache: SyntaxCache::new(),
             snapshot_buf: TerminalSnapshot::empty(),
+            last_snapshot_id: None,
         };
         app.restore_sessions();
         app.rebuild_left_items();
@@ -1508,23 +1512,29 @@ impl App {
     /// surface, reusing the existing cell allocation. Returns `true` if a
     /// provider was found and the snapshot was updated.
     pub(crate) fn refresh_snapshot_buf(&mut self) -> bool {
-        let client: Option<&PtyClient> = match self.session_surface {
+        let (client_id, client): (String, Option<&PtyClient>) = match self.session_surface {
             SessionSurface::Agent => {
                 let session_id = match self.selected_session() {
                     Some(s) => s.id.clone(),
                     None => return false,
                 };
-                self.providers.get(&session_id)
+                let provider = self.providers.get(&session_id);
+                (session_id, provider)
             }
             SessionSurface::Terminal => {
                 let id = match self.active_terminal_id.as_ref() {
                     Some(id) => id.clone(),
                     None => return false,
                 };
-                self.companion_terminals.get(&id).map(|t| &t.client)
+                let provider = self.companion_terminals.get(&id).map(|t| &t.client);
+                (id, provider)
             }
         };
         if let Some(provider) = client {
+            if self.last_snapshot_id.as_deref() != Some(&client_id) {
+                provider.mark_dirty();
+                self.last_snapshot_id = Some(client_id);
+            }
             provider.snapshot_into(&mut self.snapshot_buf);
             true
         } else {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -264,6 +264,11 @@ impl PtyClient {
         Ok(())
     }
 
+    /// Force the dirty flag on so the next `snapshot_into` rebuilds.
+    pub fn mark_dirty(&self) {
+        self.dirty.store(true, Ordering::Release);
+    }
+
     /// Check whether the child process has exited (reader thread detected EOF).
     pub fn is_exited(&self) -> bool {
         self.exited.load(Ordering::Acquire)


### PR DESCRIPTION
PR #122 introduced a `dirty` flag optimization on `PtyClient` so that `snapshot_into()` skips rebuilding the terminal snapshot when nothing has changed. This works well for avoiding redundant work on idle PTYs, but introduced a regression: the shared `snapshot_buf` is reused across all agents, and switching to a different agent in the left pane never marked the new provider as dirty. If the newly-selected agent's PTY was idle, the buffer kept showing the **previous** agent's content until the new one produced output.

The fix tracks which provider last populated the snapshot buffer via a `last_snapshot_id` field on `App`. When `refresh_snapshot_buf()` detects a provider switch, it calls `mark_dirty()` on the new provider before snapshotting, forcing a rebuild. This is a single-location fix inside `refresh_snapshot_buf()` — no changes needed at the many call sites that modify `selected_left`.

Changes span three files: `src/pty.rs` adds the `mark_dirty()` public method, `src/app/mod.rs` adds the tracking field and updates `refresh_snapshot_buf()`, and `src/app/input.rs` initializes the new field in the test helper. All 416 existing tests pass.