### PR TITLE
Filter invalid characters at input time in agent name modals

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1318,7 +1318,8 @@ impl App {
             self.fullscreen_overlay = FullscreenOverlay::None;
             self.prompt = PromptState::RenameSession {
                 session_id: session.id,
-                input: TextInput::with_text(current_name),
+                input: TextInput::with_text(current_name)
+                    .with_char_filter(crate::git::agent_name_char_filter),
                 rename_branch: false,
             };
         } else {
@@ -1338,9 +1339,9 @@ impl App {
             self.set_error("Name cannot be empty.");
             return;
         }
-        if rename_branch && !git::is_valid_agent_name(&name) {
+        if !git::is_valid_agent_name(&name) {
             self.set_error(
-                "Branch name may only contain letters, digits, dashes, underscores, or slashes. \
+                "Agent name may only contain letters, digits, dashes, underscores, or slashes. \
                  It cannot start with \"-\" or \"/\", end with \"/\", or contain \"//\".",
             );
             return;

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -108,7 +108,7 @@ impl App {
                     project,
                     custom_name: None,
                 },
-                input: TextInput::default(),
+                input: TextInput::new().with_char_filter(crate::git::agent_name_char_filter),
             };
             return Ok(());
         }
@@ -147,7 +147,7 @@ impl App {
                     source_label,
                     custom_name: None,
                 },
-                input: TextInput::default(),
+                input: TextInput::new().with_char_filter(crate::git::agent_name_char_filter),
             };
             return Ok(());
         }

--- a/src/app/text_input.rs
+++ b/src/app/text_input.rs
@@ -21,6 +21,11 @@ pub struct TextInput {
     /// are applied normally — when the overlay is dismissed the current text
     /// is shown.
     overlay: Option<String>,
+    /// Optional filter consulted before each character insertion. Receives
+    /// the current text, the cursor byte-offset where the character would be
+    /// inserted, and the candidate character. Return `true` to allow, `false`
+    /// to silently reject.
+    char_filter: Option<fn(&str, usize, char) -> bool>,
 }
 
 #[derive(Clone, Debug)]
@@ -47,6 +52,7 @@ impl TextInput {
             multiline: None,
             placeholder: None,
             overlay: None,
+            char_filter: None,
         }
     }
 
@@ -58,6 +64,7 @@ impl TextInput {
             multiline: None,
             placeholder: None,
             overlay: None,
+            char_filter: None,
         }
     }
 
@@ -87,6 +94,14 @@ impl TextInput {
     /// Returns the overlay message if one is active.
     pub fn overlay(&self) -> Option<&str> {
         self.overlay.as_deref()
+    }
+
+    /// Set a character filter that is consulted before each insertion.
+    /// The filter receives the current text, cursor byte-offset, and candidate
+    /// character. Return `true` to allow, `false` to silently reject.
+    pub fn with_char_filter(mut self, filter: fn(&str, usize, char) -> bool) -> Self {
+        self.char_filter = Some(filter);
+        self
     }
 
     /// Enable multiline editing with a visible line limit for rendering.
@@ -127,6 +142,11 @@ impl TextInput {
 
     pub fn insert_char(&mut self, ch: char) {
         let index = clamp_cursor(&self.text, self.cursor);
+        if let Some(filter) = self.char_filter {
+            if !filter(&self.text, index, ch) {
+                return;
+            }
+        }
         self.text.insert(index, ch);
         self.cursor = index + ch.len_utf8();
     }
@@ -1712,5 +1732,52 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ── char_filter tests ─────────────────────────────────────────
+
+    /// A filter that rejects the character 'x'.
+    fn reject_x(_text: &str, _cursor: usize, ch: char) -> bool {
+        ch != 'x'
+    }
+
+    #[test]
+    fn filter_rejects_char() {
+        let mut input = TextInput::new().with_char_filter(reject_x);
+        input.handle_key(key(KeyCode::Char('a')));
+        input.handle_key(key(KeyCode::Char('x')));
+        input.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(input.text, "ab");
+    }
+
+    #[test]
+    fn no_filter_allows_all() {
+        let mut input = TextInput::new();
+        input.handle_key(key(KeyCode::Char('a')));
+        input.handle_key(key(KeyCode::Char('x')));
+        input.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(input.text, "axb");
+    }
+
+    /// A filter that enforces a max length of 3 characters.
+    fn max_three(text: &str, _cursor: usize, _ch: char) -> bool {
+        text.len() < 3
+    }
+
+    #[test]
+    fn filter_receives_current_text() {
+        let mut input = TextInput::new().with_char_filter(max_three);
+        for ch in "abcde".chars() {
+            input.handle_key(key(KeyCode::Char(ch)));
+        }
+        assert_eq!(input.text, "abc");
+    }
+
+    #[test]
+    fn filter_applies_to_insert_char_directly() {
+        let mut input = TextInput::new().with_char_filter(reject_x);
+        input.insert_char('x');
+        input.insert_char('y');
+        assert_eq!(input.text, "y");
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -672,6 +672,30 @@ pub fn is_valid_agent_name(name: &str) -> bool {
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/')
 }
 
+/// Input filter for agent name text fields. Rejects characters that would
+/// make the name invalid per [`is_valid_agent_name`] rules. Designed for use
+/// with [`TextInput::with_char_filter`].
+pub fn agent_name_char_filter(text: &str, cursor: usize, ch: char) -> bool {
+    // Only allow ASCII alphanumeric, '-', '_', '/'
+    if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '/') {
+        return false;
+    }
+    // First position must be alphanumeric (reject '-', '_', '/')
+    if cursor == 0 && !ch.is_ascii_alphanumeric() {
+        return false;
+    }
+    // Prevent '//' by checking the character before and after the cursor
+    if ch == '/' {
+        if cursor > 0 && text.as_bytes().get(cursor - 1) == Some(&b'/') {
+            return false;
+        }
+        if text.as_bytes().get(cursor) == Some(&b'/') {
+            return false;
+        }
+    }
+    true
+}
+
 fn sync_directory_contents(source: &Path, destination: &Path) -> Result<()> {
     let mut source_entries = Vec::new();
     for entry in fs::read_dir(source)? {
@@ -1253,5 +1277,48 @@ mod tests {
         assert_eq!(branch, "my-fork");
         assert!(forked.ends_with("proj/my-fork"));
         assert_eq!(head_commit(&forked).unwrap(), source_head);
+    }
+
+    // ── agent_name_char_filter tests ──────────────────────────────
+
+    #[test]
+    fn agent_filter_allows_valid_chars() {
+        assert!(agent_name_char_filter("a", 1, 'b'));
+        assert!(agent_name_char_filter("a", 1, '0'));
+        assert!(agent_name_char_filter("a", 1, '-'));
+        assert!(agent_name_char_filter("a", 1, '_'));
+        assert!(agent_name_char_filter("a", 1, '/'));
+    }
+
+    #[test]
+    fn agent_filter_rejects_invalid_chars() {
+        assert!(!agent_name_char_filter("a", 1, ' '));
+        assert!(!agent_name_char_filter("a", 1, '@'));
+        assert!(!agent_name_char_filter("a", 1, '.'));
+        assert!(!agent_name_char_filter("a", 1, '!'));
+        assert!(!agent_name_char_filter("a", 1, '#'));
+    }
+
+    #[test]
+    fn agent_filter_first_char_must_be_alphanumeric() {
+        // Rejected at position 0
+        assert!(!agent_name_char_filter("", 0, '-'));
+        assert!(!agent_name_char_filter("", 0, '_'));
+        assert!(!agent_name_char_filter("", 0, '/'));
+        // Accepted at position 0
+        assert!(agent_name_char_filter("", 0, 'a'));
+        assert!(agent_name_char_filter("", 0, '1'));
+        // Also rejected when inserting at position 0 in non-empty text
+        assert!(!agent_name_char_filter("abc", 0, '-'));
+    }
+
+    #[test]
+    fn agent_filter_prevents_double_slash() {
+        // Inserting '/' right after an existing '/'
+        assert!(!agent_name_char_filter("a/", 2, '/'));
+        // Inserting '/' right before an existing '/'
+        assert!(!agent_name_char_filter("a/b", 1, '/'));
+        // Inserting '/' where no adjacent slash exists
+        assert!(agent_name_char_filter("ab", 1, '/'));
     }
 }


### PR DESCRIPTION
Previously, the new-agent and fork-agent name modals accepted any keystroke and only validated the name when the user pressed Enter. This meant characters like spaces, `@`, `.`, and other invalid inputs would appear in the text field only to be rejected on submit with a generic error message — a frustrating experience when you just want to type a valid branch name.

This PR adds a generic `char_filter` mechanism to `TextInput`: an optional `fn(&str, usize, char) -> bool` function pointer that is consulted in `insert_char()` before any character is committed to the buffer. When the filter returns `false`, the keystroke is silently dropped. The filter receives the current text and cursor position, so it can enforce context-sensitive rules like "first character must be alphanumeric" and "no consecutive slashes." Because `fn` pointers implement `Clone` and `Debug`, the existing derives on `TextInput` are unaffected and no other callers change behavior — inputs without a filter continue to accept everything.

An `agent_name_char_filter` function is defined alongside the existing `is_valid_agent_name` in `git.rs`, mirroring the same ruleset (ASCII alphanumeric, `-`, `_`, `/`; no leading `-`/`_`/`/`; no `//`). Both the new-agent and fork-agent modals now wire this filter into their `TextInput`. The submit-time `is_valid_agent_name` check is intentionally kept as a safety net for edge cases the per-keystroke filter cannot prevent, such as a trailing `/` left behind after backspacing. Eight new unit tests cover the generic filter mechanism and the agent-name-specific rules.