### PR TITLE
Add welcome screen feature tips below ASCII logo

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3528,6 +3528,7 @@ mod tests {
             macro_bar: None,
             sigwinch_flag: Arc::new(AtomicBool::new(false)),
             force_redraw: false,
+            welcome_tip_index: 0,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -115,6 +115,7 @@ pub struct App {
     pub(crate) macro_bar: Option<MacroBarState>,
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
     pub(crate) force_redraw: bool,
+    pub(crate) welcome_tip_index: usize,
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
     /// Session IDs spawned with resume_args that should fall back to regular
     /// args if the PTY exits before producing any output.
@@ -729,6 +730,10 @@ impl App {
             macro_bar: None,
             sigwinch_flag,
             force_redraw: false,
+            welcome_tip_index: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as usize)
+                .unwrap_or(0),
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: HashSet::new(),
             syntax_cache: SyntaxCache::new(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -22,95 +22,67 @@ const TIP_GAP: u16 = 2;
 /// Maximum number of wrapped lines a tip may occupy.
 const TIP_MAX_LINES: u16 = 2;
 
-#[derive(Clone, Copy)]
-enum TipCategory {
-    Tip,
-    Shortcut,
-    DidYouKnow,
-}
-
-impl TipCategory {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Tip => " Tip ",
-            Self::Shortcut => " Shortcut ",
-            Self::DidYouKnow => " Did you know ",
-        }
-    }
-
-    fn bg(self, theme: &Theme) -> Color {
-        match self {
-            Self::Tip => theme.tip_pill_tip_bg,
-            Self::Shortcut => theme.tip_pill_shortcut_bg,
-            Self::DidYouKnow => theme.tip_pill_trivia_bg,
-        }
-    }
-}
-
-/// Welcome-screen tips shown beneath the ASCII logo. Each entry pairs a pill
-/// category with a function that produces the tip text. Wrap text in backticks
+/// Welcome-screen tips shown beneath the ASCII logo. Wrap text in backticks
 /// to highlight it in an accent color (the backticks themselves are not
-/// rendered). The function receives `&RuntimeBindings` so keybinding labels
+/// rendered). Each function receives `&RuntimeBindings` so keybinding labels
 /// stay accurate after rebinding.
-const WELCOME_TIPS: &[(TipCategory, fn(&RuntimeBindings) -> String)] = &[
-    (TipCategory::Shortcut, |b| {
+const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
+    |b| {
         format!(
             "`{}` opens the command palette — every action is searchable.",
             b.label_for(Action::OpenPalette)
         )
-    }),
-    (TipCategory::Tip, |b| {
+    },
+    |b| {
         format!(
             "`{}` toggles fullscreen on the active pane.",
             b.label_for(Action::ToggleFullscreen)
         )
-    }),
-    (TipCategory::Shortcut, |b| {
+    },
+    |b| {
         format!(
             "`{}` creates a new agent in the current worktree.",
             b.label_for(Action::NewAgent)
         )
-    }),
-    (TipCategory::DidYouKnow, |_b| {
-        "Any CLI tool can be a provider — just set its `command` in config.toml.".into()
-    }),
-    (TipCategory::Tip, |b| {
+    },
+    |_b| "Any CLI tool can be a provider — just set its `command` in config.toml.".into(),
+    |b| {
         format!(
             "`{}` switches between agent and companion terminal.",
             b.label_for(Action::ShowTerminal)
         )
-    }),
-    (TipCategory::Shortcut, |b| {
+    },
+    |b| {
         format!(
             "`{}` stages or unstages the selected file.",
             b.label_for(Action::StageUnstage)
         )
-    }),
-    (TipCategory::DidYouKnow, |b| {
+    },
+    |b| {
         format!(
             "`{}` auto-generates a commit message with AI.",
             b.label_for(Action::GenerateCommitMessage)
         )
-    }),
-    (TipCategory::Tip, |b| {
+    },
+    |b| {
         format!(
             "`{}` forks the current agent into a new session.",
             b.label_for(Action::ForkAgent)
         )
-    }),
-    (TipCategory::Shortcut, |b| {
+    },
+    |b| {
         format!(
             "`{}` and `{}` navigate between panes.",
             b.label_for(Action::FocusNext),
             b.label_for(Action::FocusPrev)
         )
-    }),
-    (TipCategory::DidYouKnow, |b| {
+    },
+    |b| {
         format!(
             "`{}` cycles through providers for a project.",
             b.label_for(Action::CycleProvider)
         )
-    }),
+    },
 ];
 
 /// Capitalize the first character of a string.
@@ -591,14 +563,14 @@ impl App {
 
         // --- tip pill ---
         if show_tip {
-            let (category, text_fn) = &WELCOME_TIPS[self.welcome_tip_index % WELCOME_TIPS.len()];
+            let text_fn = &WELCOME_TIPS[self.welcome_tip_index % WELCOME_TIPS.len()];
             let tip_text = text_fn(&self.bindings);
 
             let pill_span = Span::styled(
-                category.label(),
+                " Tip ",
                 Style::default()
                     .fg(self.theme.tip_pill_fg)
-                    .bg(category.bg(&self.theme))
+                    .bg(self.theme.tip_pill_bg)
                     .add_modifier(Modifier::BOLD),
             );
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,6 +15,102 @@ const ASCII_LOGO_WIDTH: u16 = 33;
 /// Number of lines in `ASCII_LOGO`.
 const ASCII_LOGO_HEIGHT: u16 = 7;
 
+/// Maximum display width for a tip line (logo width + padding on each side).
+const TIP_MAX_WIDTH: u16 = 47;
+/// Blank lines between the bottom of the logo and the tip.
+const TIP_GAP: u16 = 2;
+/// Maximum number of wrapped lines a tip may occupy.
+const TIP_MAX_LINES: u16 = 2;
+
+#[derive(Clone, Copy)]
+enum TipCategory {
+    Tip,
+    Shortcut,
+    DidYouKnow,
+}
+
+impl TipCategory {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Tip => " Tip ",
+            Self::Shortcut => " Shortcut ",
+            Self::DidYouKnow => " Did you know ",
+        }
+    }
+
+    fn bg(self, theme: &Theme) -> Color {
+        match self {
+            Self::Tip => theme.tip_pill_tip_bg,
+            Self::Shortcut => theme.tip_pill_shortcut_bg,
+            Self::DidYouKnow => theme.tip_pill_trivia_bg,
+        }
+    }
+}
+
+/// Welcome-screen tips shown beneath the ASCII logo. Each entry pairs a pill
+/// category with a function that produces the tip text (receiving the runtime
+/// keybindings so labels stay accurate after rebinding).
+const WELCOME_TIPS: &[(TipCategory, fn(&RuntimeBindings) -> String)] = &[
+    (TipCategory::Shortcut, |b| {
+        format!(
+            "{} opens the command palette — every action is searchable.",
+            b.label_for(Action::OpenPalette)
+        )
+    }),
+    (TipCategory::Tip, |b| {
+        format!(
+            "{} toggles fullscreen on the active pane.",
+            b.label_for(Action::ToggleFullscreen)
+        )
+    }),
+    (TipCategory::Shortcut, |b| {
+        format!(
+            "{} creates a new agent in the current worktree.",
+            b.label_for(Action::NewAgent)
+        )
+    }),
+    (TipCategory::DidYouKnow, |_b| {
+        "Any CLI tool can be a provider — just set its command in config.toml.".into()
+    }),
+    (TipCategory::Tip, |b| {
+        format!(
+            "{} switches between agent and companion terminal.",
+            b.label_for(Action::ShowTerminal)
+        )
+    }),
+    (TipCategory::Shortcut, |b| {
+        format!(
+            "{} stages or unstages the selected file.",
+            b.label_for(Action::StageUnstage)
+        )
+    }),
+    (TipCategory::DidYouKnow, |b| {
+        format!(
+            "{} auto-generates a commit message with AI.",
+            b.label_for(Action::GenerateCommitMessage)
+        )
+    }),
+    (TipCategory::Tip, |b| {
+        format!(
+            "{} forks the current agent into a new session.",
+            b.label_for(Action::ForkAgent)
+        )
+    }),
+    (TipCategory::Shortcut, |b| {
+        format!(
+            "{} and {} navigate between panes.",
+            b.label_for(Action::FocusNext),
+            b.label_for(Action::FocusPrev)
+        )
+    }),
+    (TipCategory::DidYouKnow, |b| {
+        format!(
+            "{} cycles through providers for a project.",
+            b.label_for(Action::CycleProvider)
+        )
+    }),
+];
+
 /// Capitalize the first character of a string.
 fn capitalize(s: &str) -> String {
     let mut c = s.chars();
@@ -465,21 +561,59 @@ impl App {
         }
     }
 
-    /// Render the ASCII "dux" logo centered in the given area.
+    /// Render the ASCII "dux" logo centered in the given area, with an
+    /// optional feature tip displayed below.
     fn render_ascii_logo(&self, frame: &mut Frame, area: Rect) {
         if area.width < ASCII_LOGO_WIDTH || area.height < ASCII_LOGO_HEIGHT {
             return;
         }
 
-        let x = area.x + (area.width - ASCII_LOGO_WIDTH) / 2;
-        let y = area.y + (area.height - ASCII_LOGO_HEIGHT) / 2;
-        let style = Style::default().fg(self.theme.border_normal);
+        let total_height = ASCII_LOGO_HEIGHT + TIP_GAP + TIP_MAX_LINES;
+        let show_tip = area.width >= TIP_MAX_WIDTH && area.height >= total_height;
 
+        let block_height = if show_tip {
+            total_height
+        } else {
+            ASCII_LOGO_HEIGHT
+        };
+        let x = area.x + (area.width - ASCII_LOGO_WIDTH) / 2;
+        let y = area.y + (area.height - block_height) / 2;
+
+        // --- logo ---
+        let style = Style::default().fg(self.theme.border_normal);
         let lines: Vec<Line> = ASCII_LOGO.iter().map(|l| Line::styled(*l, style)).collect();
         Paragraph::new(lines).render(
             Rect::new(x, y, ASCII_LOGO_WIDTH, ASCII_LOGO_HEIGHT),
             frame.buffer_mut(),
         );
+
+        // --- tip pill ---
+        if show_tip {
+            let (category, text_fn) = &WELCOME_TIPS[self.welcome_tip_index % WELCOME_TIPS.len()];
+            let tip_text = text_fn(&self.bindings);
+
+            let pill_span = Span::styled(
+                category.label(),
+                Style::default()
+                    .fg(self.theme.tip_pill_fg)
+                    .bg(category.bg(&self.theme))
+                    .add_modifier(Modifier::BOLD),
+            );
+            let gap_span = Span::raw(" ");
+            let text_span = Span::styled(tip_text, Style::default().fg(self.theme.tip_text_fg));
+
+            let tip_line = Line::from(vec![pill_span, gap_span, text_span]);
+            let tip_width = TIP_MAX_WIDTH.min(area.width.saturating_sub(2));
+            let tip_x = area.x + (area.width - tip_width) / 2;
+            let tip_y = y + ASCII_LOGO_HEIGHT + TIP_GAP;
+
+            Paragraph::new(vec![tip_line])
+                .wrap(Wrap { trim: true })
+                .render(
+                    Rect::new(tip_x, tip_y, tip_width, TIP_MAX_LINES),
+                    frame.buffer_mut(),
+                );
+        }
     }
 
     fn render_terminal_placeholder(

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -609,6 +609,7 @@ impl App {
 
             Paragraph::new(vec![tip_line])
                 .wrap(Wrap { trim: true })
+                .alignment(ratatui::layout::Alignment::Center)
                 .render(
                     Rect::new(tip_x, tip_y, tip_width, TIP_MAX_LINES),
                     frame.buffer_mut(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -48,64 +48,66 @@ impl TipCategory {
 }
 
 /// Welcome-screen tips shown beneath the ASCII logo. Each entry pairs a pill
-/// category with a function that produces the tip text (receiving the runtime
-/// keybindings so labels stay accurate after rebinding).
+/// category with a function that produces the tip text. Wrap text in backticks
+/// to highlight it in an accent color (the backticks themselves are not
+/// rendered). The function receives `&RuntimeBindings` so keybinding labels
+/// stay accurate after rebinding.
 const WELCOME_TIPS: &[(TipCategory, fn(&RuntimeBindings) -> String)] = &[
     (TipCategory::Shortcut, |b| {
         format!(
-            "{} opens the command palette — every action is searchable.",
+            "`{}` opens the command palette — every action is searchable.",
             b.label_for(Action::OpenPalette)
         )
     }),
     (TipCategory::Tip, |b| {
         format!(
-            "{} toggles fullscreen on the active pane.",
+            "`{}` toggles fullscreen on the active pane.",
             b.label_for(Action::ToggleFullscreen)
         )
     }),
     (TipCategory::Shortcut, |b| {
         format!(
-            "{} creates a new agent in the current worktree.",
+            "`{}` creates a new agent in the current worktree.",
             b.label_for(Action::NewAgent)
         )
     }),
     (TipCategory::DidYouKnow, |_b| {
-        "Any CLI tool can be a provider — just set its command in config.toml.".into()
+        "Any CLI tool can be a provider — just set its `command` in config.toml.".into()
     }),
     (TipCategory::Tip, |b| {
         format!(
-            "{} switches between agent and companion terminal.",
+            "`{}` switches between agent and companion terminal.",
             b.label_for(Action::ShowTerminal)
         )
     }),
     (TipCategory::Shortcut, |b| {
         format!(
-            "{} stages or unstages the selected file.",
+            "`{}` stages or unstages the selected file.",
             b.label_for(Action::StageUnstage)
         )
     }),
     (TipCategory::DidYouKnow, |b| {
         format!(
-            "{} auto-generates a commit message with AI.",
+            "`{}` auto-generates a commit message with AI.",
             b.label_for(Action::GenerateCommitMessage)
         )
     }),
     (TipCategory::Tip, |b| {
         format!(
-            "{} forks the current agent into a new session.",
+            "`{}` forks the current agent into a new session.",
             b.label_for(Action::ForkAgent)
         )
     }),
     (TipCategory::Shortcut, |b| {
         format!(
-            "{} and {} navigate between panes.",
+            "`{}` and `{}` navigate between panes.",
             b.label_for(Action::FocusNext),
             b.label_for(Action::FocusPrev)
         )
     }),
     (TipCategory::DidYouKnow, |b| {
         format!(
-            "{} cycles through providers for a project.",
+            "`{}` cycles through providers for a project.",
             b.label_for(Action::CycleProvider)
         )
     }),
@@ -599,10 +601,25 @@ impl App {
                     .bg(category.bg(&self.theme))
                     .add_modifier(Modifier::BOLD),
             );
-            let gap_span = Span::raw(" ");
-            let text_span = Span::styled(tip_text, Style::default().fg(self.theme.tip_text_fg));
 
-            let tip_line = Line::from(vec![pill_span, gap_span, text_span]);
+            let normal = Style::default().fg(self.theme.tip_text_fg);
+            let highlight = Style::default()
+                .fg(self.theme.tip_highlight_fg)
+                .add_modifier(Modifier::BOLD);
+
+            let mut spans: Vec<Span> = vec![pill_span, Span::raw(" ")];
+            let mut inside_backtick = false;
+            for segment in tip_text.split('`') {
+                if !segment.is_empty() {
+                    spans.push(Span::styled(
+                        segment.to_owned(),
+                        if inside_backtick { highlight } else { normal },
+                    ));
+                }
+                inside_backtick = !inside_backtick;
+            }
+
+            let tip_line = Line::from(spans);
             let tip_width = TIP_MAX_WIDTH.min(area.width.saturating_sub(2));
             let tip_x = area.x + (area.width - tip_width) / 2;
             let tip_y = y + ASCII_LOGO_HEIGHT + TIP_GAP;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -608,7 +608,7 @@ impl App {
             let tip_y = y + ASCII_LOGO_HEIGHT + TIP_GAP;
 
             Paragraph::new(vec![tip_line])
-                .wrap(Wrap { trim: true })
+                .wrap(Wrap { trim: false })
                 .alignment(ratatui::layout::Alignment::Center)
                 .render(
                     Rect::new(tip_x, tip_y, tip_width, TIP_MAX_LINES),

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -62,6 +62,11 @@ pub struct Theme {
     pub diff_stat_remove_fg: Color,
     pub runtime_context_value_fg: Color,
     pub nudge_border: Color,
+    pub tip_pill_fg: Color,
+    pub tip_pill_shortcut_bg: Color,
+    pub tip_pill_tip_bg: Color,
+    pub tip_pill_trivia_bg: Color,
+    pub tip_text_fg: Color,
 }
 
 impl Theme {
@@ -125,6 +130,11 @@ impl Theme {
             diff_stat_remove_fg: Color::Red,
             runtime_context_value_fg: Color::Rgb(125, 150, 160),
             nudge_border: Color::Rgb(180, 150, 50),
+            tip_pill_fg: Color::White,
+            tip_pill_shortcut_bg: Color::Rgb(120, 80, 200),
+            tip_pill_tip_bg: Color::Rgb(0, 150, 150),
+            tip_pill_trivia_bg: Color::Rgb(180, 140, 30),
+            tip_text_fg: Color::Rgb(120, 120, 120),
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -63,9 +63,7 @@ pub struct Theme {
     pub runtime_context_value_fg: Color,
     pub nudge_border: Color,
     pub tip_pill_fg: Color,
-    pub tip_pill_shortcut_bg: Color,
-    pub tip_pill_tip_bg: Color,
-    pub tip_pill_trivia_bg: Color,
+    pub tip_pill_bg: Color,
     pub tip_text_fg: Color,
     pub tip_highlight_fg: Color,
 }
@@ -132,9 +130,7 @@ impl Theme {
             runtime_context_value_fg: Color::Rgb(125, 150, 160),
             nudge_border: Color::Rgb(180, 150, 50),
             tip_pill_fg: Color::White,
-            tip_pill_shortcut_bg: Color::Rgb(120, 80, 200),
-            tip_pill_tip_bg: Color::Rgb(0, 150, 150),
-            tip_pill_trivia_bg: Color::Rgb(180, 140, 30),
+            tip_pill_bg: Color::Rgb(120, 80, 200),
             tip_text_fg: Color::Rgb(120, 120, 120),
             tip_highlight_fg: Color::Rgb(0, 190, 190),
         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -67,6 +67,7 @@ pub struct Theme {
     pub tip_pill_tip_bg: Color,
     pub tip_pill_trivia_bg: Color,
     pub tip_text_fg: Color,
+    pub tip_highlight_fg: Color,
 }
 
 impl Theme {
@@ -135,6 +136,7 @@ impl Theme {
             tip_pill_tip_bg: Color::Rgb(0, 150, 150),
             tip_pill_trivia_bg: Color::Rgb(180, 140, 30),
             tip_text_fg: Color::Rgb(120, 120, 120),
+            tip_highlight_fg: Color::Rgb(0, 190, 190),
         }
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -129,10 +129,10 @@ impl Theme {
             diff_stat_remove_fg: Color::Red,
             runtime_context_value_fg: Color::Rgb(125, 150, 160),
             nudge_border: Color::Rgb(180, 150, 50),
-            tip_pill_fg: Color::White,
-            tip_pill_bg: Color::Rgb(120, 80, 200),
-            tip_text_fg: Color::Rgb(120, 120, 120),
-            tip_highlight_fg: Color::Rgb(0, 190, 190),
+            tip_pill_fg: Color::Rgb(180, 180, 180),
+            tip_pill_bg: Color::Rgb(70, 50, 120),
+            tip_text_fg: Color::Rgb(90, 90, 90),
+            tip_highlight_fg: Color::Rgb(0, 120, 120),
         }
     }
 


### PR DESCRIPTION
When no agent is running, the center pane shows the dux ASCII logo on an otherwise empty screen. This change adds a **random feature tip** below the logo each time the app launches, rendered as a colored pill label (`Tip`, `Shortcut`, or `Did you know`) followed by a short description. The pill categories use distinct background colors — teal, violet, and amber — defined as semantic theme constants so they stay consistent with the rest of the UI.

Tips resolve keybinding labels at render time through `RuntimeBindings::label_for()`, so they always reflect the user's current bindings rather than hardcoded defaults. Adding a new tip is a one-liner: append a `(TipCategory, fn(&RuntimeBindings) -> String)` tuple to the `WELCOME_TIPS` array. The initial set includes 10 tips covering the command palette, fullscreen toggle, agent creation, file staging, commit message generation, pane navigation, provider cycling, and more.

The tip area gracefully degrades — if the terminal is too narrow or short to fit both the logo and a tip, only the logo renders. Word wrapping via `Paragraph::wrap` keeps longer tips readable within a `47`-column centered region, and the entire block (logo + gap + tip) is vertically centered as a unit.