### PR TITLE
Dim explicit background colors in non-interactive agent pane

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3533,7 +3533,12 @@ fn pty_cell_colors(fg: Color, bg: Color, is_input: bool, theme: &Theme) -> (Colo
     if is_input {
         (fg, bg)
     } else {
-        (theme.overlay_dim_fg, bg)
+        let dimmed_bg = if bg == Color::Reset {
+            bg
+        } else {
+            theme.overlay_dim_bg
+        };
+        (theme.overlay_dim_fg, dimmed_bg)
     }
 }
 
@@ -3863,7 +3868,17 @@ mod tests {
         let bg = Color::Rgb(10, 20, 30);
         assert_eq!(
             pty_cell_colors(fg, bg, false, &theme),
-            (theme.overlay_dim_fg, bg)
+            (theme.overlay_dim_fg, theme.overlay_dim_bg)
+        );
+    }
+
+    #[test]
+    fn pty_cell_colors_preserves_default_bg_in_non_interactive_mode() {
+        let theme = Theme::default_dark();
+        let fg = Color::Rgb(200, 100, 50);
+        assert_eq!(
+            pty_cell_colors(fg, Color::Reset, false, &theme),
+            (theme.overlay_dim_fg, Color::Reset)
         );
     }
 }


### PR DESCRIPTION
When the agent pane is in non-interactive mode, all content is rendered greyed out to signal it is read-only. Previously, `pty_cell_colors()` only replaced the foreground with the theme's dim color while passing through the background unchanged. This meant cells with explicitly colored backgrounds — such as red or green from diff output or error highlights — remained visually prominent, breaking the dimmed appearance.

This change replaces explicit background colors with `overlay_dim_bg` in non-interactive mode, fully dimming them to match the rest of the pane. Cells with the default background (`Color::Reset`) are left untouched so the pane's natural background shows through without any unwanted color shift.

A new test (`pty_cell_colors_preserves_default_bg_in_non_interactive_mode`) verifies that default backgrounds are preserved, while the existing test has been updated to assert that explicit backgrounds are now dimmed.