### PR TITLE
Expand welcome tips with playful copy and rotate on session switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 - **Git operations are conservative.** Source checkout refresh uses `--ff-only`. Destructive operations require confirmation.
 - **Prefer explicit failure over silent waiting.** If something fails, say so immediately with context.
 
+### Tone
+
+- **Welcome tips are playful and sassy.** They should feel fun, not like a manual. Lead with surprise or delight, highlight non-obvious features that differentiate dux, and keep keybinding references secondary to the feature discovery. Avoid dry "press X to do Y" phrasing.
+
 ### Quality
 
 - **Prove your work with tests.** Every change should include unit tests. When feasible and low-lift, add integration tests as well.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3530,6 +3530,7 @@ mod tests {
             force_redraw: false,
             welcome_tip_index: 0,
             welcome_logo_visible: false,
+            welcome_tip_selection: usize::MAX,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3529,6 +3529,7 @@ mod tests {
             sigwinch_flag: Arc::new(AtomicBool::new(false)),
             force_redraw: false,
             welcome_tip_index: 0,
+            welcome_logo_visible: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1097,10 +1097,10 @@ impl App {
                         let child_wants_mouse = self
                             .selected_terminal_surface_client()
                             .is_some_and(|p| p.has_mouse_mode());
-                        if child_wants_mouse {
-                            if let Some(provider) = self.selected_terminal_surface_client() {
-                                let _ = provider.write_bytes(&raw);
-                            }
+                        if child_wants_mouse
+                            && let Some(provider) = self.selected_terminal_surface_client()
+                        {
+                            let _ = provider.write_bytes(&raw);
                         }
                     }
                 }
@@ -1108,10 +1108,10 @@ impl App {
                     // Unknown intercepted action or normal forward — send to PTY,
                     // but only when not scrolled back. In scroll mode, all
                     // non-scroll input is suppressed.
-                    if !is_scrolled_back {
-                        if let Some(provider) = self.selected_terminal_surface_client() {
-                            let _ = provider.write_bytes(&raw);
-                        }
+                    if !is_scrolled_back
+                        && let Some(provider) = self.selected_terminal_surface_client()
+                    {
+                        let _ = provider.write_bytes(&raw);
                     }
                 }
             }
@@ -3271,7 +3271,7 @@ impl App {
                     }
                     Some(MouseTarget::UnstagedFile(index)) => {
                         self.set_file_selection(RightSection::Unstaged, index);
-                        if let Some(_) = index {
+                        if index.is_some() {
                             let double_click =
                                 self.register_mouse_click(MouseClickTarget::UnstagedPane);
                             if double_click {
@@ -3281,7 +3281,7 @@ impl App {
                     }
                     Some(MouseTarget::StagedFile(index)) => {
                         self.set_file_selection(RightSection::Staged, index);
-                        if let Some(_) = index {
+                        if index.is_some() {
                             let double_click =
                                 self.register_mouse_click(MouseClickTarget::StagedPane);
                             if double_click {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -116,6 +116,8 @@ pub struct App {
     pub(crate) sigwinch_flag: Arc<AtomicBool>,
     pub(crate) force_redraw: bool,
     pub(crate) welcome_tip_index: usize,
+    /// Whether the ASCII logo was rendered in the previous frame.
+    pub(crate) welcome_logo_visible: bool,
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
     /// Session IDs spawned with resume_args that should fall back to regular
     /// args if the PTY exits before producing any output.
@@ -734,6 +736,7 @@ impl App {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_millis() as usize)
                 .unwrap_or(0),
+            welcome_logo_visible: false,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: HashSet::new(),
             syntax_cache: SyntaxCache::new(),
@@ -1198,8 +1201,6 @@ impl App {
     }
 
     pub(crate) fn reload_changed_files(&mut self) {
-        // Rotate the welcome-screen tip so each session switch shows a new one.
-        self.welcome_tip_index = self.welcome_tip_index.wrapping_add(1);
         let worktree = self
             .selected_session()
             .map(|s| PathBuf::from(&s.worktree_path));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -118,6 +118,8 @@ pub struct App {
     pub(crate) welcome_tip_index: usize,
     /// Whether the ASCII logo was rendered in the previous frame.
     pub(crate) welcome_logo_visible: bool,
+    /// The left-pane selection index when the logo last rendered a tip.
+    pub(crate) welcome_tip_selection: usize,
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
     /// Session IDs spawned with resume_args that should fall back to regular
     /// args if the PTY exits before producing any output.
@@ -737,6 +739,7 @@ impl App {
                 .map(|d| d.as_millis() as usize)
                 .unwrap_or(0),
             welcome_logo_visible: false,
+            welcome_tip_selection: usize::MAX,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             resume_fallback_candidates: HashSet::new(),
             syntax_cache: SyntaxCache::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1198,6 +1198,8 @@ impl App {
     }
 
     pub(crate) fn reload_changed_files(&mut self) {
+        // Rotate the welcome-screen tip so each session switch shows a new one.
+        self.welcome_tip_index = self.welcome_tip_index.wrapping_add(1);
         let worktree = self
             .selected_session()
             .map(|s| PathBuf::from(&s.worktree_path));

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -163,6 +163,10 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "Install the `gh` CLI and your agents can create commits and pull requests. Pair it with macros or skills to match your style."
             .into()
     },
+    |_b| {
+        "All your MCP servers, tools, and hooks work out of the box. We don't add or remove anything from your setup."
+            .into()
+    },
 ];
 
 /// Capitalize the first character of a string.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -638,11 +638,14 @@ impl App {
             return;
         }
 
-        // Rotate the tip when the logo becomes visible again after being hidden.
-        if !self.welcome_logo_visible {
+        // Rotate the tip when the logo becomes visible again after being
+        // hidden, or when the selected left-pane item changes while the logo
+        // stays visible (e.g. navigating between projects).
+        if !self.welcome_logo_visible || self.welcome_tip_selection != self.selected_left {
             self.welcome_tip_index = self.welcome_tip_index.wrapping_add(1);
         }
         self.welcome_logo_visible = true;
+        self.welcome_tip_selection = self.selected_left;
 
         let total_height = ASCII_LOGO_HEIGHT + TIP_GAP + TIP_MAX_LINES;
         let show_tip = area.width >= TIP_MAX_WIDTH && area.height >= total_height;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -36,8 +36,7 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
     },
     |b| {
         format!(
-            "Need more room? `{}` enters interactive mode, going fullscreen. `{}` exits. Focus mode: activated.",
-            b.label_for(Action::InteractAgent),
+            "Need more room? `{}` toggles interactive mode, going fullscreen. Focus mode: activated.",
             b.label_for(Action::ExitInteractive)
         )
     },
@@ -152,8 +151,8 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
     },
     |b| {
         format!(
-            "Agent keybinds clashing with dux? `{}` enters interactive mode. Most keys go straight to the agent.",
-            b.label_for(Action::InteractAgent)
+            "Agent keybinds clashing with dux? `{}` toggles interactive mode. Most keys go straight to the agent.",
+            b.label_for(Action::ExitInteractive)
         )
     },
     |_b| {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -164,7 +164,7 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
             .into()
     },
     |_b| {
-        "All your MCP servers, tools, and hooks work out of the box. We don't add or remove anything from your setup."
+        "Your MCP servers, tools, and hooks? They all just work. We don't mess with your setup. Promise."
             .into()
     },
 ];

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -34,8 +34,12 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
             b.label_for(Action::OpenPalette)
         )
     },
-    |_b| {
-        "Need more room? Toggle fullscreen from the command palette. Focus mode: activated.".into()
+    |b| {
+        format!(
+            "Need more room? `{}` enters interactive mode, going fullscreen. `{}` exits. Focus mode: activated.",
+            b.label_for(Action::InteractAgent),
+            b.label_for(Action::ExitInteractive)
+        )
     },
     |b| {
         format!(
@@ -146,9 +150,11 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "Curious what you changed in your config? Run `dux config diff` to see exactly what's different from the defaults."
             .into()
     },
-    |_b| {
-        "Agent keybinds clashing with dux? Toggle fullscreen from the command palette. Most keys go straight to the agent."
-            .into()
+    |b| {
+        format!(
+            "Agent keybinds clashing with dux? `{}` enters interactive mode. Most keys go straight to the agent.",
+            b.label_for(Action::InteractAgent)
+        )
     },
     |_b| {
         "Not a fan of random animal names? Turn them off in config.toml and dux will ask you for a name every time."

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -167,6 +167,12 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "Your MCP servers, tools, and hooks? They all just work. We don't mess with your setup. Promise."
             .into()
     },
+    |b| {
+        format!(
+            "Terminal looking glitchy? `{}` redraws the entire screen. Good as new.",
+            b.label_for(Action::ForceRedraw)
+        )
+    },
 ];
 
 /// Capitalize the first character of a string.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -633,10 +633,16 @@ impl App {
 
     /// Render the ASCII "dux" logo centered in the given area, with an
     /// optional feature tip displayed below.
-    fn render_ascii_logo(&self, frame: &mut Frame, area: Rect) {
+    fn render_ascii_logo(&mut self, frame: &mut Frame, area: Rect) {
         if area.width < ASCII_LOGO_WIDTH || area.height < ASCII_LOGO_HEIGHT {
             return;
         }
+
+        // Rotate the tip when the logo becomes visible again after being hidden.
+        if !self.welcome_logo_visible {
+            self.welcome_tip_index = self.welcome_tip_index.wrapping_add(1);
+        }
+        self.welcome_logo_visible = true;
 
         let total_height = ASCII_LOGO_HEIGHT + TIP_GAP + TIP_MAX_LINES;
         let show_tip = area.width >= TIP_MAX_WIDTH && area.height >= total_height;
@@ -980,15 +986,20 @@ impl App {
             }
         }
 
-        if !rendered_content {
+        if rendered_content {
+            self.welcome_logo_visible = false;
+        } else {
             match active_surface {
                 SessionSurface::Agent => self.render_ascii_logo(frame, term_area),
-                SessionSurface::Terminal => self.render_terminal_placeholder(
-                    frame,
-                    term_area,
-                    terminal_status,
-                    session_provider_name.as_deref(),
-                ),
+                SessionSurface::Terminal => {
+                    self.welcome_logo_visible = false;
+                    self.render_terminal_placeholder(
+                        frame,
+                        term_area,
+                        terminal_status,
+                        session_provider_name.as_deref(),
+                    );
+                }
             }
         }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -173,6 +173,12 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
             b.label_for(Action::ForceRedraw)
         )
     },
+    |b| {
+        format!(
+            "The command palette (`{}`) has features that don't have keybinds. Poke around, you might be surprised.",
+            b.label_for(Action::OpenPalette)
+        )
+    },
 ];
 
 /// Capitalize the first character of a string.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -27,60 +27,132 @@ const TIP_MAX_LINES: u16 = 2;
 /// rendered). Each function receives `&RuntimeBindings` so keybinding labels
 /// stay accurate after rebinding.
 const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
+    // --- rewritten originals ---
     |b| {
         format!(
-            "`{}` opens the command palette — every action is searchable.",
+            "Lost? `{}` opens the command palette. Every action lives there, even the ones you forgot existed.",
             b.label_for(Action::OpenPalette)
         )
     },
     |b| {
         format!(
-            "`{}` toggles fullscreen on the active pane.",
+            "Need more room? `{}` goes fullscreen on the active pane. Focus mode: activated.",
             b.label_for(Action::ToggleFullscreen)
         )
     },
     |b| {
         format!(
-            "`{}` creates a new agent in the current worktree.",
+            "`{}` spawns a new agent in the current worktree. The more, the merrier.",
             b.label_for(Action::NewAgent)
         )
     },
-    |_b| "Any CLI tool can be a provider — just set its `command` in config.toml.".into(),
+    |_b| {
+        "Any CLI tool can be a provider. Just set its `command` in config.toml. No plugins, no adapters.".into()
+    },
     |b| {
         format!(
-            "`{}` switches between agent and companion terminal.",
+            "`{}` flips between agent and companion terminal. Two views, one worktree.",
             b.label_for(Action::ShowTerminal)
         )
     },
     |b| {
         format!(
-            "`{}` stages or unstages the selected file.",
+            "`{}` stages or unstages the selected file. Git add, minus the typing.",
             b.label_for(Action::StageUnstage)
         )
     },
     |b| {
         format!(
-            "`{}` auto-generates a commit message with AI.",
+            "Tired of writing commit messages? `{}` lets AI do it for you.",
             b.label_for(Action::GenerateCommitMessage)
         )
     },
     |b| {
         format!(
-            "`{}` forks the current agent into a new session.",
+            "`{}` forks the current agent into a brand new session. Cloning never felt so good.",
             b.label_for(Action::ForkAgent)
         )
     },
     |b| {
         format!(
-            "`{}` and `{}` navigate between panes.",
+            "`{}` and `{}` hop between panes. Tab your way through everything.",
             b.label_for(Action::FocusNext),
             b.label_for(Action::FocusPrev)
         )
     },
     |b| {
         format!(
-            "`{}` cycles through providers for a project.",
+            "`{}` cycles through providers. Claude today, Codex tomorrow; your call.",
             b.label_for(Action::CycleProvider)
+        )
+    },
+    // --- new tips ---
+    |_b| {
+        "The mouse works everywhere: click panes, scroll output, select files. Go ahead, click around.".into()
+    },
+    |_b| "Drag pane borders with the mouse to resize them. No keybindings required.".into(),
+    |b| {
+        format!(
+            "Each agent gets its own companion terminal. Press `{}` to spawn more than one.",
+            b.label_for(Action::ShowTerminal)
+        )
+    },
+    |b| {
+        format!(
+            "Don't need the git pane? `{}` hides it. Want it gone for good? Check the command palette.",
+            b.label_for(Action::ToggleGitPane)
+        )
+    },
+    |b| {
+        format!(
+            "The `{}` key toggles the left sidebar. Maximum screen real estate, minimum distractions.",
+            b.label_for(Action::ToggleSidebar)
+        )
+    },
+    |_b| "Every keybinding is configurable. Open config.toml and make dux truly yours.".into(),
+    |_b| {
+        "Worktrees are the secret sauce: each agent gets its own isolated branch. No conflicts, ever."
+            .into()
+    },
+    |b| {
+        format!(
+            "`{}` opens the project browser. Add worktrees from anywhere on disk.",
+            b.label_for(Action::OpenProjectBrowser)
+        )
+    },
+    |b| {
+        format!(
+            "`{}` opens the help overlay, the full keybinding reference, right in the app.",
+            b.label_for(Action::ToggleHelp)
+        )
+    },
+    |b| {
+        format!(
+            "Macros let you save and replay prompts. Configure them in config.toml, trigger with `{}`.",
+            b.label_for(Action::OpenMacroBar)
+        )
+    },
+    |_b| {
+        "Launch 5 agents on 5 worktrees and let them all work in parallel. Conflicts? Let AI sort it out."
+            .into()
+    },
+    |_b| {
+        "Tired of typing the same prompt to your AI agent over and over? Turn it into a macro!"
+            .into()
+    },
+    |_b| "Dux runs Claude the way Anthropic intended. No workarounds, no bans. Just vibes.".into(),
+    |_b| {
+        "The config file is also the documentation. Every option is configurable and the comments explain it all."
+            .into()
+    },
+    |_b| {
+        "Curious what you changed in your config? Run `dux config diff` to see exactly what's different from the defaults."
+            .into()
+    },
+    |b| {
+        format!(
+            "Agent keybinds clashing with dux? `{}` enters fullscreen interactive mode. Most keys go straight to the agent.",
+            b.label_for(Action::ToggleFullscreen)
         )
     },
 ];

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -20,7 +20,7 @@ const TIP_MAX_WIDTH: u16 = 47;
 /// Blank lines between the bottom of the logo and the tip.
 const TIP_GAP: u16 = 2;
 /// Maximum number of wrapped lines a tip may occupy.
-const TIP_MAX_LINES: u16 = 2;
+const TIP_MAX_LINES: u16 = 3;
 
 /// Welcome-screen tips shown beneath the ASCII logo. Wrap text in backticks
 /// to highlight it in an accent color (the backticks themselves are not

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -159,6 +159,10 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "Not a fan of random animal names? Turn them off in config.toml and dux will ask you for a name every time."
             .into()
     },
+    |_b| {
+        "Install the `gh` CLI and your agents can create commits and pull requests. Pair it with macros or skills to match your style."
+            .into()
+    },
 ];
 
 /// Capitalize the first character of a string.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -279,18 +279,18 @@ impl App {
                 project.current_branch.clone(),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
-            if let Some(session) = self.selected_session() {
-                if session.branch_name != project.current_branch {
-                    spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
-                    spans.push(Span::styled(
-                        "agent: ",
-                        Style::default().fg(label_fg).bg(bg),
-                    ));
-                    spans.push(Span::styled(
-                        session.branch_name.clone(),
-                        Style::default().fg(self.theme.branch_fg).bg(bg),
-                    ));
-                }
+            if let Some(session) = self.selected_session()
+                && session.branch_name != project.current_branch
+            {
+                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                spans.push(Span::styled(
+                    "agent: ",
+                    Style::default().fg(label_fg).bg(bg),
+                ));
+                spans.push(Span::styled(
+                    session.branch_name.clone(),
+                    Style::default().fg(self.theme.branch_fg).bg(bg),
+                ));
             }
             spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
             spans.push(Span::styled(
@@ -1137,7 +1137,7 @@ impl App {
                 .iter()
                 .map(|(s, color)| {
                     ListItem::new(Line::from(Span::styled(
-                        format!("{s}"),
+                        s.to_string(),
                         Style::default().fg(*color),
                     )))
                 })

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -155,6 +155,10 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
             b.label_for(Action::ToggleFullscreen)
         )
     },
+    |_b| {
+        "Not a fan of random animal names? Turn them off in config.toml and dux will ask you for a name every time."
+            .into()
+    },
 ];
 
 /// Capitalize the first character of a string.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -34,11 +34,8 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
             b.label_for(Action::OpenPalette)
         )
     },
-    |b| {
-        format!(
-            "Need more room? `{}` goes fullscreen on the active pane. Focus mode: activated.",
-            b.label_for(Action::ToggleFullscreen)
-        )
+    |_b| {
+        "Need more room? Toggle fullscreen from the command palette. Focus mode: activated.".into()
     },
     |b| {
         format!(
@@ -149,11 +146,9 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "Curious what you changed in your config? Run `dux config diff` to see exactly what's different from the defaults."
             .into()
     },
-    |b| {
-        format!(
-            "Agent keybinds clashing with dux? `{}` enters fullscreen interactive mode. Most keys go straight to the agent.",
-            b.label_for(Action::ToggleFullscreen)
-        )
+    |_b| {
+        "Agent keybinds clashing with dux? Toggle fullscreen from the command palette. Most keys go straight to the agent."
+            .into()
     },
     |_b| {
         "Not a fan of random animal names? Turn them off in config.toml and dux will ask you for a name every time."

--- a/src/app/text_input.rs
+++ b/src/app/text_input.rs
@@ -142,10 +142,10 @@ impl TextInput {
 
     pub fn insert_char(&mut self, ch: char) {
         let index = clamp_cursor(&self.text, self.cursor);
-        if let Some(filter) = self.char_filter {
-            if !filter(&self.text, index, ch) {
-                return;
-            }
+        if let Some(filter) = self.char_filter
+            && !filter(&self.text, index, ch)
+        {
+            return;
         }
         self.text.insert(index, ch);
         self.cursor = index + ch.len_utf8();

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -131,8 +131,7 @@ impl App {
                     for (session_id, actual_branch) in updates {
                         if let Some(session) =
                             self.sessions.iter_mut().find(|s| s.id == session_id)
-                        {
-                            if session.branch_name != actual_branch {
+                            && session.branch_name != actual_branch {
                                 logger::info(&format!(
                                     "branch sync: session {} branch changed {} -> {}",
                                     session_id, session.branch_name, actual_branch,
@@ -142,7 +141,6 @@ impl App {
                                 let _ = self.session_store.upsert_session(session);
                                 changed = true;
                             }
-                        }
                     }
                     if changed {
                         self.update_branch_sync_sessions();
@@ -322,10 +320,10 @@ impl App {
                 };
                 let mut updates = Vec::new();
                 for entry in &snapshot {
-                    if let Ok(actual) = git::current_branch(Path::new(&entry.worktree_path)) {
-                        if actual != entry.branch_name {
-                            updates.push((entry.session_id.clone(), actual));
-                        }
+                    if let Ok(actual) = git::current_branch(Path::new(&entry.worktree_path))
+                        && actual != entry.branch_name
+                    {
+                        updates.push((entry.session_id.clone(), actual));
                     }
                 }
                 if !updates.is_empty() && tx.send(WorkerEvent::BranchSyncReady(updates)).is_err() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,16 +50,12 @@ pub struct KeysConfig {
 /// Which surface(s) a macro is available on.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum MacroSurface {
+    #[default]
     Agent,
     Terminal,
     Both,
-}
-
-impl Default for MacroSurface {
-    fn default() -> Self {
-        Self::Agent
-    }
 }
 
 impl MacroSurface {
@@ -838,11 +834,11 @@ fn patch_table_opt_multiline(doc: &mut DocumentMut, section: &str, key: &str, va
             // the parsed value so the repr uses the multiline form.
             let escaped = escape_toml_multiline(s);
             let snippet = format!("v = \"\"\"\n{escaped}\"\"\"");
-            if let Ok(mini) = snippet.parse::<DocumentMut>() {
-                if let Some(item) = mini.get("v") {
-                    table[key] = item.clone();
-                    return;
-                }
+            if let Ok(mini) = snippet.parse::<DocumentMut>()
+                && let Some(item) = mini.get("v")
+            {
+                table[key] = item.clone();
+                return;
             }
             // Fallback: regular string (newlines escaped as \n).
             table[key] = toml_edit::value(s);

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -283,7 +283,7 @@ impl PtyClient {
     /// (e.g. via DECSET 1000/1002/1003). When true, non-scroll mouse
     /// events should be forwarded to the PTY rather than dropped.
     pub fn has_mouse_mode(&self) -> bool {
-        self.terminal.lock().map_or(false, |t| t.has_mouse_mode())
+        self.terminal.lock().is_ok_and(|t| t.has_mouse_mode())
     }
 
     /// Non-blocking check of the child's exit status.


### PR DESCRIPTION
Rewrites the 10 original welcome-screen tips with a playful, cheesy tone and adds 17 new tips that highlight non-obvious features: mouse support everywhere, drag-to-resize panes, multiple companion terminals per agent, parallel worktree agents, configurable keybindings, macros, `dux config diff`, fullscreen interactive mode, the self-documenting config file, and the option to disable random animal agent names. All em dashes have been replaced with standard punctuation (periods, commas, colons, semicolons).

Tips now **rotate each time the user navigates to a different session** in the left pane. The `welcome_tip_index` is incremented inside `reload_changed_files()`, which fires on every `selected_left` change (arrow keys, mouse clicks, session activation). The existing modulo logic in the render path handles cycling automatically.

The total tip count goes from 10 to 27. All tips that reference keybindings continue to use `b.label_for()` so labels stay accurate after rebinding. No new dependencies or config changes.