### PR TITLE
Add optional line-number gutter to diff view

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3478,6 +3478,7 @@ mod tests {
             commit_input: TextInput::new()
                 .with_multiline(4)
                 .with_placeholder("Type your commit message\u{2026}"),
+            show_diff_line_numbers: false,
             left_width_pct: 20,
             right_width_pct: 23,
             terminal_pane_height_pct: 35,
@@ -4835,6 +4836,8 @@ mod tests {
                 Line::from("three"),
             ]),
             scroll: 0,
+            worktree_path: String::new(),
+            rel_path: String::new(),
         };
         app.last_diff_height = 2;
         app.last_diff_visual_lines = 10;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -97,6 +97,7 @@ pub struct App {
     pub(crate) create_agent_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
     pub(crate) prev_scrollback_offset: usize,
+    pub(crate) show_diff_line_numbers: bool,
     pub(crate) last_diff_height: u16,
     pub(crate) last_diff_visual_lines: u16,
     pub(crate) theme: Theme,
@@ -221,6 +222,9 @@ pub(crate) enum CenterMode {
     Diff {
         lines: Arc<Vec<Line<'static>>>,
         scroll: u16,
+        /// Source paths for re-generating the diff on setting changes.
+        worktree_path: String,
+        rel_path: String,
     },
 }
 
@@ -668,6 +672,7 @@ impl App {
             bindings.label_for(Action::ToggleHelp),
         );
         let mut app = Self {
+            show_diff_line_numbers: config.ui.show_diff_line_numbers,
             left_width_pct: config.ui.left_width_pct,
             right_width_pct: config.ui.right_width_pct,
             terminal_pane_height_pct: config.ui.terminal_pane_height_pct,
@@ -1049,6 +1054,20 @@ impl App {
                     lines: Vec::new(),
                     scroll_offset: 0,
                 };
+                Ok(())
+            }
+            "toggle-diff-line-numbers" => {
+                self.show_diff_line_numbers = !self.show_diff_line_numbers;
+                let _ = self.refresh_current_diff();
+                let state = if self.show_diff_line_numbers {
+                    "enabled"
+                } else {
+                    "disabled"
+                };
+                let palette_key = self.bindings.label_for(Action::OpenPalette);
+                self.set_info(format!(
+                    "Diff line numbers {state}. Press {palette_key} to open the palette and toggle back."
+                ));
                 Ok(())
             }
             "force-redraw" => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1058,6 +1058,8 @@ impl App {
             }
             "toggle-diff-line-numbers" => {
                 self.show_diff_line_numbers = !self.show_diff_line_numbers;
+                self.config.ui.show_diff_line_numbers = self.show_diff_line_numbers;
+                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
                 let _ = self.refresh_current_diff();
                 let state = if self.show_diff_line_numbers {
                     "enabled"

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -548,7 +548,7 @@ impl App {
 
     fn render_diff(&mut self, frame: &mut Frame, area: Rect, focused: bool) {
         let (lines, scroll) = match &self.center_mode {
-            CenterMode::Diff { lines, scroll } => (Arc::clone(lines), *scroll),
+            CenterMode::Diff { lines, scroll, .. } => (Arc::clone(lines), *scroll),
             _ => return,
         };
 

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -678,17 +678,49 @@ impl App {
         let Some(file) = self.selected_changed_file() else {
             return Ok(());
         };
+        let worktree_path = session.worktree_path.clone();
+        let rel_path = file.path.clone();
         let output = crate::diff::diff_file(
-            Path::new(&session.worktree_path),
-            &file.path,
+            Path::new(&worktree_path),
+            &rel_path,
             &self.theme,
             &self.syntax_cache,
+            self.show_diff_line_numbers,
         )?;
         self.center_mode = CenterMode::Diff {
             lines: Arc::new(output.lines),
             scroll: 0,
+            worktree_path,
+            rel_path,
         };
         self.focus = FocusPane::Center;
+        Ok(())
+    }
+
+    /// Re-generate the currently displayed diff (e.g. after toggling line numbers).
+    pub(crate) fn refresh_current_diff(&mut self) -> Result<()> {
+        let (worktree_path, rel_path, scroll) = match &self.center_mode {
+            CenterMode::Diff {
+                worktree_path,
+                rel_path,
+                scroll,
+                ..
+            } => (worktree_path.clone(), rel_path.clone(), *scroll),
+            _ => return Ok(()),
+        };
+        let output = crate::diff::diff_file(
+            Path::new(&worktree_path),
+            &rel_path,
+            &self.theme,
+            &self.syntax_cache,
+            self.show_diff_line_numbers,
+        )?;
+        self.center_mode = CenterMode::Diff {
+            lines: Arc::new(output.lines),
+            scroll,
+            worktree_path,
+            rel_path,
+        };
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,7 @@ pub struct UiConfig {
     pub commit_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
     pub branch_sync_interval: u16,
+    pub show_diff_line_numbers: bool,
 }
 
 impl Default for Config {
@@ -212,6 +213,7 @@ impl Default for Config {
                 commit_pane_height_pct: 40,
                 agent_scrollback_lines: 10_000,
                 branch_sync_interval: 30,
+                show_diff_line_numbers: false,
             },
             editor: EditorConfig::default(),
             keys: KeysConfig::default(),
@@ -331,6 +333,7 @@ impl Default for UiConfig {
             commit_pane_height_pct: 40,
             agent_scrollback_lines: 10_000,
             branch_sync_interval: 30,
+            show_diff_line_numbers: false,
         }
     }
 }
@@ -585,6 +588,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             )),
             value_fn: |c| FieldValue::U16(c.ui.branch_sync_interval),
         },
+        ConfigEntry::Field {
+            key: "show_diff_line_numbers",
+            comment: Some(CommentSource::Static(
+                "# Show old/new line numbers in the diff gutter.\n# Toggle at runtime from the command palette.",
+            )),
+            value_fn: |c| FieldValue::Bool(c.ui.show_diff_line_numbers),
+        },
         ConfigEntry::Blank,
         ConfigEntry::Section("editor"),
         ConfigEntry::Field {
@@ -760,6 +770,12 @@ pub fn save_config(
         "ui",
         "branch_sync_interval",
         config.ui.branch_sync_interval,
+    );
+    patch_table_bool(
+        &mut doc,
+        "ui",
+        "show_diff_line_numbers",
+        config.ui.show_diff_line_numbers,
     );
 
     // --- [editor] ---
@@ -2156,6 +2172,7 @@ staged_pane_height_pct = 50
 commit_pane_height_pct = 40
 agent_scrollback_lines = 10000
 branch_sync_interval = 30
+show_diff_line_numbers = false
 
 [logging]
 level = \"info\"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -92,8 +92,7 @@ pub fn diff_file(
                 }
             }
         }
-        // Minimum 4 chars per side for visual consistency.
-        (max_ln.to_string().len()).max(4)
+        max_ln.to_string().len()
     } else {
         0
     };
@@ -403,10 +402,11 @@ mod tests {
         let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
 
         // Context line "aaa" should show both old and new line numbers.
+        // Max line is 4, so ln_width is 1 — numbers are right-aligned in 1 char.
         assert!(
             rendered
                 .iter()
-                .any(|l| l.contains("   1") && l.contains("aaa")),
+                .any(|l| l.contains("1") && l.contains("aaa")),
             "expected line number 1 for context line 'aaa', got: {rendered:?}"
         );
 
@@ -416,7 +416,7 @@ mod tests {
             .find(|l| l.contains("XXX") && l.contains("+"))
             .expect("expected an inserted line containing XXX");
         assert!(
-            insert_line.contains("   3"),
+            insert_line.contains("3"),
             "expected new line number 3 for inserted line, got: {insert_line}"
         );
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -40,6 +40,7 @@ pub fn diff_file(
     rel_path: &str,
     theme: &AppTheme,
     cache: &SyntaxCache,
+    show_line_numbers: bool,
 ) -> Result<DiffOutput> {
     let old_bytes = crate::git::file_bytes_at_head(worktree_path, rel_path)?.unwrap_or_default();
     let abs_path = worktree_path.join(rel_path);
@@ -78,6 +79,28 @@ pub fn diff_file(
     let text_diff = TextDiff::from_lines(&old_text, &new_text);
     let mut lines: Vec<Line<'static>> = Vec::new();
 
+    // Compute gutter width from the maximum line number across all hunks.
+    let ln_width = if show_line_numbers {
+        let mut max_ln: usize = 1;
+        for hunk in text_diff.unified_diff().context_radius(3).iter_hunks() {
+            for change in hunk.iter_changes() {
+                if let Some(idx) = change.old_index() {
+                    max_ln = max_ln.max(idx + 1);
+                }
+                if let Some(idx) = change.new_index() {
+                    max_ln = max_ln.max(idx + 1);
+                }
+            }
+        }
+        // Minimum 4 chars per side for visual consistency.
+        (max_ln.to_string().len()).max(4)
+    } else {
+        0
+    };
+
+    let gutter_style = Style::default().fg(theme.diff_line_number_fg);
+    let sep_style = Style::default().fg(theme.diff_line_number_sep);
+
     // File header.
     lines.push(Line::from(Span::styled(
         format!("--- a/{rel_path}"),
@@ -94,10 +117,18 @@ pub fn diff_file(
 
     for hunk in text_diff.unified_diff().context_radius(3).iter_hunks() {
         // Hunk header (@@ ... @@).
-        lines.push(Line::from(Span::styled(
+        let mut hunk_spans: Vec<Span<'static>> = Vec::new();
+        if show_line_numbers {
+            // Blank gutter for hunk headers.
+            let blank = " ".repeat(ln_width);
+            hunk_spans.push(Span::styled(format!("{blank} {blank} "), gutter_style));
+            hunk_spans.push(Span::styled("│ ", sep_style));
+        }
+        hunk_spans.push(Span::styled(
             hunk.header().to_string(),
             Style::default().fg(theme.diff_hunk),
-        )));
+        ));
+        lines.push(Line::from(hunk_spans));
 
         // We maintain two separate highlighters so that removed lines are
         // highlighted in the context of the old file and added/context lines
@@ -123,41 +154,59 @@ pub fn diff_file(
 
             // Attempt syntax highlighting; fall back to plain coloring.
             let content = text.trim_end_matches('\n');
-            let spans = match highlighter.highlight_line(content, &cache.syntax_set) {
+            let mut spans: Vec<Span<'static>> = Vec::new();
+
+            // Line-number gutter.
+            if show_line_numbers {
+                let old_ln = match tag {
+                    ChangeTag::Delete | ChangeTag::Equal => {
+                        format!("{:>w$}", change.old_index().unwrap_or(0) + 1, w = ln_width)
+                    }
+                    ChangeTag::Insert => " ".repeat(ln_width),
+                };
+                let new_ln = match tag {
+                    ChangeTag::Insert | ChangeTag::Equal => {
+                        format!("{:>w$}", change.new_index().unwrap_or(0) + 1, w = ln_width)
+                    }
+                    ChangeTag::Delete => " ".repeat(ln_width),
+                };
+                spans.push(Span::styled(format!("{old_ln} {new_ln} "), gutter_style));
+                spans.push(Span::styled("│", sep_style));
+            }
+
+            match highlighter.highlight_line(content, &cache.syntax_set) {
                 Ok(ranges) if tag == ChangeTag::Equal => {
                     // Context lines: full syntax colors, no background tint.
-                    let mut out = vec![Span::styled(
+                    spans.push(Span::styled(
                         prefix.to_string(),
                         Style::default().fg(base_fg),
-                    )];
-                    out.extend(
+                    ));
+                    spans.extend(
                         ranges
                             .into_iter()
                             .map(|(s, t)| Span::styled(t.to_string(), syntect_to_ratatui(s))),
                     );
-                    out
                 }
                 Ok(ranges) => {
                     // Added/removed lines: syntax colors + tinted background.
-                    let mut out = vec![Span::styled(
+                    spans.push(Span::styled(
                         prefix.to_string(),
                         Style::default().fg(base_fg).bg(bg.unwrap_or(Color::Reset)),
-                    )];
-                    out.extend(ranges.into_iter().map(|(s, t)| {
+                    ));
+                    spans.extend(ranges.into_iter().map(|(s, t)| {
                         let mut style = syntect_to_ratatui(s);
                         if let Some(bg_color) = bg {
                             style = style.bg(bg_color);
                         }
                         Span::styled(t.to_string(), style)
                     }));
-                    out
                 }
                 Err(_) => {
                     // Fallback: no syntax highlighting.
-                    vec![Span::styled(
+                    spans.push(Span::styled(
                         format!("{prefix}{content}"),
                         Style::default().fg(base_fg).bg(bg.unwrap_or(Color::Reset)),
-                    )]
+                    ));
                 }
             };
             lines.push(Line::from(spans));
@@ -276,7 +325,8 @@ mod tests {
         std::fs::write(&file, [0_u8, 159, 146, 151, 152]).unwrap();
 
         let cache = SyntaxCache::new();
-        let output = diff_file(repo, "image.bin", &AppTheme::default_dark(), &cache).unwrap();
+        let output =
+            diff_file(repo, "image.bin", &AppTheme::default_dark(), &cache, false).unwrap();
         let rendered = output
             .lines
             .iter()
@@ -297,6 +347,105 @@ mod tests {
             rendered
                 .iter()
                 .any(|line| line.contains("New size: 5 bytes"))
+        );
+    }
+
+    /// Helper: create a git repo with a committed file and then modify it.
+    fn setup_text_repo(filename: &str, initial: &str, modified: &str) -> tempfile::TempDir {
+        let dir = tempdir().unwrap();
+        let repo = dir.path();
+
+        Command::new("git")
+            .args(["init"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        let file = repo.join(filename);
+        std::fs::write(&file, initial).unwrap();
+        Command::new("git")
+            .args(["add", filename])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "initial"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+
+        std::fs::write(&file, modified).unwrap();
+        dir
+    }
+
+    #[test]
+    fn line_numbers_appear_when_enabled() {
+        let dir = setup_text_repo("hello.txt", "aaa\nbbb\nccc\n", "aaa\nbbb\nXXX\nccc\n");
+        let cache = SyntaxCache::new();
+        let output = diff_file(
+            dir.path(),
+            "hello.txt",
+            &AppTheme::default_dark(),
+            &cache,
+            true,
+        )
+        .unwrap();
+        let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
+
+        // Context line "aaa" should show both old and new line numbers.
+        assert!(
+            rendered
+                .iter()
+                .any(|l| l.contains("   1") && l.contains("aaa")),
+            "expected line number 1 for context line 'aaa', got: {rendered:?}"
+        );
+
+        // Inserted line "XXX" should show only the new line number.
+        let insert_line = rendered
+            .iter()
+            .find(|l| l.contains("XXX") && l.contains("+"))
+            .expect("expected an inserted line containing XXX");
+        assert!(
+            insert_line.contains("   3"),
+            "expected new line number 3 for inserted line, got: {insert_line}"
+        );
+
+        // Gutter separator should be present.
+        assert!(
+            rendered.iter().any(|l| l.contains('│')),
+            "expected gutter separator │"
+        );
+    }
+
+    #[test]
+    fn line_numbers_absent_when_disabled() {
+        let dir = setup_text_repo("hello.txt", "aaa\n", "aaa\nbbb\n");
+        let cache = SyntaxCache::new();
+        let output = diff_file(
+            dir.path(),
+            "hello.txt",
+            &AppTheme::default_dark(),
+            &cache,
+            false,
+        )
+        .unwrap();
+        let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
+
+        // No gutter separator should be present in any content line.
+        let has_gutter = rendered.iter().any(|l| l.contains('│'));
+        assert!(
+            !has_gutter,
+            "expected no gutter separator when line numbers are disabled"
         );
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -78,6 +78,7 @@ pub enum Action {
     RemoveGitPane,
     EditMacros,
     DebugInput,
+    ToggleDiffLineNumbers,
 }
 
 /// Where a binding's key combo is matched.
@@ -235,6 +236,7 @@ impl Action {
             Action::RemoveGitPane => "remove_git_pane",
             Action::EditMacros => "edit_macros",
             Action::DebugInput => "debug_input",
+            Action::ToggleDiffLineNumbers => "toggle_diff_line_numbers",
         }
     }
 
@@ -314,6 +316,7 @@ impl Action {
             Action::RemoveGitPane => "Remove or restore the git pane.",
             Action::EditMacros => "Open the text macros editor.",
             Action::DebugInput => "Open input event debugger to inspect keyboard and mouse events.",
+            Action::ToggleDiffLineNumbers => "Toggle line numbers in diff view.",
         }
     }
 
@@ -383,7 +386,8 @@ impl Action {
             | Action::SortAgentsByCreated
             | Action::SortAgentsByName
             | Action::EditMacros
-            | Action::DebugInput => None,
+            | Action::DebugInput
+            | Action::ToggleDiffLineNumbers => None,
         }
     }
 }
@@ -1273,6 +1277,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "input-debugging",
             description: "Open input event debugger to inspect keyboard and mouse events",
+        }),
+    },
+    BindingDef {
+        action: Action::ToggleDiffLineNumbers,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "toggle-diff-line-numbers",
+            description: "Toggle line numbers in diff view",
         }),
     },
 ];

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -66,6 +66,8 @@ pub struct Theme {
     pub tip_pill_bg: Color,
     pub tip_text_fg: Color,
     pub tip_highlight_fg: Color,
+    pub diff_line_number_fg: Color,
+    pub diff_line_number_sep: Color,
 }
 
 impl Theme {
@@ -133,6 +135,8 @@ impl Theme {
             tip_pill_bg: Color::Rgb(70, 50, 120),
             tip_text_fg: Color::Rgb(90, 90, 90),
             tip_highlight_fg: Color::Rgb(0, 120, 120),
+            diff_line_number_fg: Color::Rgb(90, 90, 110),
+            diff_line_number_sep: Color::Rgb(60, 60, 70),
         }
     }
 


### PR DESCRIPTION
The diff view now supports an **old/new line-number gutter** prepended to each change line. Delete lines show only the old line number, insert lines show only the new one, and context lines show both. The gutter width auto-sizes to the largest line number in the diff and uses dedicated dim theme colors (`diff_line_number_fg`, `diff_line_number_sep`) so it stays visually distinct from the diff content itself.

The feature is **off by default** and can be enabled in two ways: permanently via the `show_diff_line_numbers` boolean in the `[ui]` section of `config.toml`, or on-the-fly through the **command palette** action `toggle-diff-line-numbers`. Toggling at runtime immediately regenerates the active diff while preserving the current scroll position. To support re-generation, `CenterMode::Diff` now carries the source `worktree_path` and `rel_path` alongside the rendered lines.

Two new unit tests verify that the gutter spans appear with correct line numbers when enabled and are completely absent when disabled. The existing binary-diff and scroll tests have been updated to account for the new `CenterMode::Diff` fields and the extra `show_line_numbers` parameter on `diff_file()`.