### PR TITLE
Allow renaming agent sessions from the center pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -454,6 +454,7 @@ impl App {
                 Action::ExitInteractive if !in_diff => self.activate_center_agent()?,
                 Action::ShowTerminal if !in_diff => self.show_or_open_first_terminal()?,
                 Action::DeleteSession if !in_diff => self.confirm_delete_selected_session()?,
+                Action::RenameSession if !in_diff => self.open_rename_session()?,
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1177,12 +1177,15 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     BindingDef {
         action: Action::RenameSession,
         default_keys: &[key!(e)],
-        scopes: &[BindingScope::Left],
+        scopes: &[BindingScope::Left, BindingScope::Center],
         help: Some(HelpEntry {
             section: "Projects pane",
             description: "Rename the selected agent session",
         }),
-        hint_contexts: &[(HintContext::LeftSession, "Rename")],
+        hint_contexts: &[
+            (HintContext::LeftSession, "Rename"),
+            (HintContext::Center, "Rename"),
+        ],
         palette: Some(PaletteEntry {
             name: "rename-agent",
             description: "Rename the selected agent session",
@@ -1855,6 +1858,20 @@ mod tests {
             Some(Action::MoveDown)
         );
         assert_eq!(bindings.lookup(&key, BindingScope::Center), None);
+    }
+
+    #[test]
+    fn rename_session_available_in_left_and_center() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Left),
+            Some(Action::RenameSession)
+        );
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::RenameSession)
+        );
     }
 
     #[test]


### PR DESCRIPTION
The `RenameSession` action was previously scoped exclusively to the left (projects) pane, requiring users to switch focus back to the sidebar just to rename the agent they were already viewing. This change extends the binding to also work when the center (agent) pane is focused, matching the pattern already established by `DeleteSession` and `ShowTerminal`.

The implementation adds `BindingScope::Center` to the rename binding's scope list, wires up the `Action::RenameSession` arm in `handle_center_key` (gated by `!in_diff` like the other center-pane actions), and adds a `HintContext::Center` entry so the footer hint bar surfaces the keybinding when the agent pane is active.

A new unit test (`rename_session_available_in_left_and_center`) verifies that the `e` key resolves to `RenameSession` in both the Left and Center scopes.