### PR TITLE
Fix erratic animation speed by deriving frames from wall-clock time

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -973,8 +973,7 @@ impl App {
     /// time (80ms per frame). Unlike `tick_count`, this stays constant-speed
     /// regardless of event loop frequency.
     pub(crate) fn spinner_frame_index(&self) -> usize {
-        ((self.start_time.elapsed().as_millis() / 80) as usize)
-            % crate::theme::SPINNER_FRAMES.len()
+        ((self.start_time.elapsed().as_millis() / 80) as usize) % crate::theme::SPINNER_FRAMES.len()
     }
 
     /// Poll each PTY provider for recent data and update the per-agent

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1414,7 +1414,7 @@ impl App {
 
         if let Some(overlay) = self.commit_input.overlay() {
             // Overlay (e.g. "Generating commit message…") with animated dots.
-            let dots = ".".repeat((self.tick_count as usize / 5) % 4);
+            let dots = ".".repeat((self.start_time.elapsed().as_millis() as usize / 500) % 4);
             let text = format!("{overlay}{dots}");
             Paragraph::new(text)
                 .style(Style::default().fg(self.theme.hint_desc_fg))
@@ -1893,12 +1893,8 @@ impl App {
                         .collect()
                 };
                 let items = if *loading {
-                    let spinner = match (self.tick_count / 2) % 4 {
-                        0 => "⠋",
-                        1 => "⠙",
-                        2 => "⠹",
-                        _ => "⠸",
-                    };
+                    let idx = self.spinner_frame_index();
+                    let spinner = crate::theme::SPINNER_FRAMES[idx];
                     vec![ListItem::new(Line::from(vec![
                         Span::styled(
                             format!("{spinner} "),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1413,9 +1413,10 @@ impl App {
             .set_visible_lines(text_area.height as usize);
 
         if let Some(overlay) = self.commit_input.overlay() {
-            // Overlay (e.g. "Generating commit message…") with animated dots.
-            let dots = ".".repeat((self.start_time.elapsed().as_millis() as usize / 500) % 4);
-            let text = format!("{overlay}{dots}");
+            // Overlay (e.g. "Generating commit message…") with spinner prefix.
+            let idx = self.spinner_frame_index();
+            let spinner = crate::theme::SPINNER_FRAMES[idx];
+            let text = format!("{spinner} {overlay}");
             Paragraph::new(text)
                 .style(Style::default().fg(self.theme.hint_desc_fg))
                 .render(text_area, frame.buffer_mut());


### PR DESCRIPTION
The loading spinner shown while an agent starts (and other animated indicators like commit-overlay dots and the file-dialog spinner) derived their frame index from `tick_count`, which increments once per event-loop iteration. Because the loop rate is variable — fast when events are queued, slow when blocked on the 100ms poll timeout — the animations would visibly speed up during bursts of activity and slow down when idle, producing a jerky, inconsistent effect.

This PR adds an `epoch: Instant` field set at app startup and an `animation_frame(interval_ms)` helper that computes the current frame from elapsed wall-clock time. The three animation sites in `render.rs` now call this helper with fixed intervals (100ms for the braille spinner, 200ms for the file-dialog spinner, 500ms for the commit-overlay dots), producing smooth, constant-rate animations regardless of how fast the event loop is running.

`tick_count` is preserved unchanged for its non-animation uses: worker polling cadence (`is_multiple_of(20)`) and the read-only nudge duration, which are intentionally tied to loop iterations.