### PR TITLE
Animate left-pane dot as braille spinner when agent is streaming

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3514,6 +3514,7 @@ mod tests {
             last_diff_visual_lines: 0,
             theme: Theme::default_dark(),
             tick_count: 0,
+            start_time: std::time::Instant::now(),
             readonly_nudge_tick: None,
             watched_worktree: Arc::new(Mutex::new(None::<PathBuf>)),
             has_active_processes: Arc::new(AtomicBool::new(false)),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3508,6 +3508,7 @@ mod tests {
             terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
+            last_pty_activity: std::collections::HashMap::new(),
             prev_scrollback_offset: 0,
             last_diff_height: 0,
             last_diff_visual_lines: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -970,10 +970,10 @@ impl App {
     }
 
     /// Returns the current braille spinner frame index based on wall-clock
-    /// time (100ms per frame). Unlike `tick_count`, this stays constant-speed
+    /// time (80ms per frame). Unlike `tick_count`, this stays constant-speed
     /// regardless of event loop frequency.
     pub(crate) fn spinner_frame_index(&self) -> usize {
-        ((self.start_time.elapsed().as_millis() / 100) as usize)
+        ((self.start_time.elapsed().as_millis() / 80) as usize)
             % crate::theme::SPINNER_FRAMES.len()
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -105,6 +105,10 @@ pub struct App {
     pub(crate) last_diff_visual_lines: u16,
     pub(crate) theme: Theme,
     pub(crate) tick_count: u64,
+    /// Wall-clock reference for time-based animations (spinners). Using
+    /// elapsed time instead of `tick_count` keeps animation speed constant
+    /// regardless of how fast the event loop is running.
+    pub(crate) start_time: Instant,
     pub(crate) readonly_nudge_tick: Option<u64>,
     pub(crate) watched_worktree: Arc<Mutex<Option<PathBuf>>>,
     pub(crate) has_active_processes: Arc<AtomicBool>,
@@ -729,6 +733,7 @@ impl App {
             last_diff_visual_lines: 0,
             theme: Theme::default_dark(),
             tick_count: 0,
+            start_time: Instant::now(),
             readonly_nudge_tick: None,
             watched_worktree: Arc::clone(&watched_worktree),
             has_active_processes: Arc::new(AtomicBool::new(false)),
@@ -962,6 +967,14 @@ impl App {
             return true;
         }
         false
+    }
+
+    /// Returns the current braille spinner frame index based on wall-clock
+    /// time (100ms per frame). Unlike `tick_count`, this stays constant-speed
+    /// regardless of event loop frequency.
+    pub(crate) fn spinner_frame_index(&self) -> usize {
+        ((self.start_time.elapsed().as_millis() / 100) as usize)
+            % crate::theme::SPINNER_FRAMES.len()
     }
 
     /// Poll each PTY provider for recent data and update the per-agent

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -96,6 +96,9 @@ pub struct App {
     pub(crate) terminal_counter: usize,
     pub(crate) create_agent_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
+    /// Tracks when each agent last received PTY data, for the streaming
+    /// activity spinner in the left pane.
+    pub(crate) last_pty_activity: HashMap<String, Instant>,
     pub(crate) prev_scrollback_offset: usize,
     pub(crate) show_diff_line_numbers: bool,
     pub(crate) last_diff_height: u16,
@@ -720,6 +723,7 @@ impl App {
             terminal_counter: 0,
             create_agent_in_flight: false,
             last_pty_size: (0, 0),
+            last_pty_activity: HashMap::new(),
             prev_scrollback_offset: 0,
             last_diff_height: 0,
             last_diff_visual_lines: 0,
@@ -767,6 +771,7 @@ impl App {
         let result: Result<()> = {
             loop {
                 self.drain_events();
+                self.poll_pty_activity();
                 self.tick_count = self.tick_count.wrapping_add(1);
 
                 // Check SIGWINCH — needed when bypassing crossterm's event
@@ -957,6 +962,25 @@ impl App {
             return true;
         }
         false
+    }
+
+    /// Poll each PTY provider for recent data and update the per-agent
+    /// activity timestamp used by the left-pane streaming indicator.
+    fn poll_pty_activity(&mut self) {
+        let now = Instant::now();
+        for (session_id, provider) in &self.providers {
+            if provider.take_received_data() {
+                self.last_pty_activity.insert(session_id.clone(), now);
+            }
+        }
+    }
+
+    /// Returns `true` if the given agent received PTY data within the last
+    /// second, indicating it is actively streaming output.
+    pub(crate) fn is_agent_streaming(&self, session_id: &str) -> bool {
+        self.last_pty_activity
+            .get(session_id)
+            .is_some_and(|t| t.elapsed() < Duration::from_secs(1))
     }
 
     pub(crate) fn set_info(&mut self, message: impl Into<String>) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -437,7 +437,20 @@ impl App {
                         .title
                         .clone()
                         .unwrap_or_else(|| session.branch_name.clone());
-                    let (dot, dot_color) = self.theme.session_dot(&session.status);
+                    let (dot, dot_color) =
+                        if matches!(session.status, crate::model::SessionStatus::Active)
+                            && self.is_agent_streaming(&session.id)
+                        {
+                            let idx =
+                                (self.tick_count as usize / 2) % crate::theme::SPINNER_FRAMES.len();
+                            (
+                                crate::theme::SPINNER_FRAMES[idx].to_string(),
+                                self.theme.session_active,
+                            )
+                        } else {
+                            let (d, c) = self.theme.session_dot(&session.status);
+                            (d.to_string(), c)
+                        };
                     ListItem::new(Line::from(
                         vec![
                             Span::styled(connector, Style::default().fg(self.theme.project_icon)),
@@ -840,9 +853,8 @@ impl App {
 
             if !provider.has_output() {
                 // Show a centered loading card until the PTY produces output.
-                let spinner_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-                let idx = (self.tick_count as usize) % spinner_chars.len();
-                let spinner = spinner_chars[idx];
+                let idx = (self.tick_count as usize) % crate::theme::SPINNER_FRAMES.len();
+                let spinner = crate::theme::SPINNER_FRAMES[idx];
                 let (label_spans, label_len) = match session_provider_name.as_deref() {
                     Some(name) => {
                         let prefix = match active_surface {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -442,7 +442,7 @@ impl App {
                             && self.is_agent_streaming(&session.id)
                         {
                             let idx =
-                                (self.tick_count as usize / 2) % crate::theme::SPINNER_FRAMES.len();
+                                (self.tick_count as usize) % crate::theme::SPINNER_FRAMES.len();
                             (
                                 crate::theme::SPINNER_FRAMES[idx].to_string(),
                                 self.theme.session_active,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -441,8 +441,7 @@ impl App {
                         if matches!(session.status, crate::model::SessionStatus::Active)
                             && self.is_agent_streaming(&session.id)
                         {
-                            let idx =
-                                (self.tick_count as usize) % crate::theme::SPINNER_FRAMES.len();
+                            let idx = self.spinner_frame_index();
                             (
                                 crate::theme::SPINNER_FRAMES[idx].to_string(),
                                 self.theme.session_active,
@@ -853,7 +852,7 @@ impl App {
 
             if !provider.has_output() {
                 // Show a centered loading card until the PTY produces output.
-                let idx = (self.tick_count as usize) % crate::theme::SPINNER_FRAMES.len();
+                let idx = self.spinner_frame_index();
                 let spinner = crate::theme::SPINNER_FRAMES[idx];
                 let (label_spans, label_len) = match session_provider_name.as_deref() {
                     Some(name) => {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -482,6 +482,7 @@ impl App {
             &session.branch_name,
         )?;
         self.providers.remove(&session.id);
+        self.last_pty_activity.remove(&session.id);
         self.clear_companion_terminals_for_session(&session.id);
         self.sessions.retain(|candidate| candidate.id != session.id);
         self.session_store.delete_session(&session.id)?;
@@ -1037,6 +1038,7 @@ impl App {
             match target_id {
                 RuntimeTargetId::Agent(session_id) => {
                     if self.providers.remove(session_id).is_some() {
+                        self.last_pty_activity.remove(session_id);
                         self.mark_session_status(session_id, SessionStatus::Detached);
                         killed_agents += 1;
                         if selected_session_id.as_deref() == Some(session_id.as_str()) {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -192,6 +192,7 @@ impl App {
                 continue;
             };
             self.providers.remove(session_id);
+            self.last_pty_activity.remove(session_id);
             logger::info(&format!(
                 "resume args exited without output for agent \"{}\", retrying with regular args",
                 session.branch_name
@@ -224,6 +225,7 @@ impl App {
                 continue;
             }
             self.providers.remove(session_id);
+            self.last_pty_activity.remove(session_id);
             self.mark_session_status(session_id, SessionStatus::Detached);
         }
         if !exited.is_empty() {

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Instant;
 
 use alacritty_terminal::event::{Event, EventListener, WindowSize};
 use alacritty_terminal::grid::{Dimensions, Scroll};
@@ -77,6 +78,9 @@ pub struct PtyClient {
     /// `take_received_data` — used to detect streaming activity without
     /// interfering with the snapshot dirty flag.
     received_data: Arc<AtomicBool>,
+    /// Records the last resize so `take_received_data` can suppress the
+    /// redraw burst that follows a `SIGWINCH`.
+    last_resize_at: Mutex<Option<Instant>>,
 }
 
 impl PtyClient {
@@ -157,6 +161,7 @@ impl PtyClient {
             has_output,
             dirty,
             received_data,
+            last_resize_at: Mutex::new(None),
         })
     }
 
@@ -271,6 +276,9 @@ impl PtyClient {
             terminal.resize(rows, cols);
             self.dirty.store(true, Ordering::Release);
         }
+        if let Ok(mut ts) = self.last_resize_at.lock() {
+            *ts = Some(Instant::now());
+        }
         Ok(())
     }
 
@@ -292,8 +300,21 @@ impl PtyClient {
     /// Returns `true` if the PTY received data since the last call, then
     /// clears the flag. Used to detect streaming activity for UI indicators
     /// without interfering with the snapshot dirty flag.
+    ///
+    /// Suppresses the signal briefly after a resize to avoid counting the
+    /// child process's redraw burst as streaming activity.
     pub fn take_received_data(&self) -> bool {
-        self.received_data.swap(false, Ordering::AcqRel)
+        if !self.received_data.swap(false, Ordering::AcqRel) {
+            return false;
+        }
+        // Ignore data that arrived within 500ms of a resize — it's almost
+        // certainly the child redrawing in response to SIGWINCH.
+        if let Ok(ts) = self.last_resize_at.lock() {
+            if ts.is_some_and(|t| t.elapsed().as_millis() < 500) {
+                return false;
+            }
+        }
+        true
     }
 
     /// Whether the child process has enabled any mouse tracking mode

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -73,6 +73,10 @@ pub struct PtyClient {
     /// Set by the reader thread or scroll/resize methods when the terminal
     /// state changes. Cleared by `snapshot_into` after rebuilding the buffer.
     dirty: Arc<AtomicBool>,
+    /// Set by the reader thread when new data arrives. Cleared by
+    /// `take_received_data` — used to detect streaming activity without
+    /// interfering with the snapshot dirty flag.
+    received_data: Arc<AtomicBool>,
 }
 
 impl PtyClient {
@@ -124,12 +128,14 @@ impl PtyClient {
         let exited = Arc::new(AtomicBool::new(false));
         let has_output = Arc::new(AtomicBool::new(false));
         let dirty = Arc::new(AtomicBool::new(true));
+        let received_data = Arc::new(AtomicBool::new(false));
 
         let terminal_ref = Arc::clone(&terminal);
         let writer_ref = Arc::clone(&writer);
         let exited_ref = Arc::clone(&exited);
         let has_output_ref = Arc::clone(&has_output);
         let dirty_ref = Arc::clone(&dirty);
+        let received_data_ref = Arc::clone(&received_data);
         thread::spawn(move || {
             Self::reader_loop(
                 reader,
@@ -138,6 +144,7 @@ impl PtyClient {
                 exited_ref,
                 has_output_ref,
                 dirty_ref,
+                received_data_ref,
             );
         });
 
@@ -149,6 +156,7 @@ impl PtyClient {
             exited,
             has_output,
             dirty,
+            received_data,
         })
     }
 
@@ -159,6 +167,7 @@ impl PtyClient {
         exited: Arc<AtomicBool>,
         has_output: Arc<AtomicBool>,
         dirty: Arc<AtomicBool>,
+        received_data: Arc<AtomicBool>,
     ) {
         let mut buf = [0u8; 4096];
         loop {
@@ -172,6 +181,7 @@ impl PtyClient {
                     if let Ok(mut terminal) = terminal.lock() {
                         let replies = terminal.process(data);
                         dirty.store(true, Ordering::Release);
+                        received_data.store(true, Ordering::Release);
                         if !replies.is_empty()
                             && let Ok(mut w) = writer.lock()
                         {
@@ -277,6 +287,13 @@ impl PtyClient {
     /// Check whether the PTY has received any output from the child process.
     pub fn has_output(&self) -> bool {
         self.has_output.load(Ordering::Acquire)
+    }
+
+    /// Returns `true` if the PTY received data since the last call, then
+    /// clears the flag. Used to detect streaming activity for UI indicators
+    /// without interfering with the snapshot dirty flag.
+    pub fn take_received_data(&self) -> bool {
+        self.received_data.swap(false, Ordering::AcqRel)
     }
 
     /// Whether the child process has enabled any mouse tracking mode

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,6 +3,10 @@
 use ratatui::prelude::{Color, Modifier, Style};
 use ratatui::text::Span;
 
+/// Braille dot-pattern frames for spinner animations. Shared by the loading
+/// card, status line, and left-pane streaming indicator.
+pub const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
 pub struct Theme {
     pub header_fg: Color,
     pub header_bg: Color,


### PR DESCRIPTION
When an agent is actively producing PTY output — streaming a response, running a tool, etc. — there's currently no visual distinction from a quiet-but-alive agent in the left pane. Both show the same static green `●`. This change replaces that dot with an animated braille spinner (`⠋⠙⠹…`) for any active agent that received data within the last second, giving an at-a-glance sense of which agents are working.

The implementation adds a `received_data` atomic flag to `PtyClient`, set by the reader thread on every data chunk independently of the existing `dirty` flag (which gets cleared each frame by the snapshot). The main loop polls each provider before rendering and records per-agent last-activity timestamps in a `HashMap<String, Instant>`. The left-pane render path checks this to decide between the spinner and the static dot. The spinner runs at half the speed of the loading-card spinner for a calmer feel, and the 1-second decay window prevents flickering between output bursts.

The braille spinner character set is extracted into a shared `SPINNER_FRAMES` constant in `theme.rs`, replacing the inline array in the loading card. Cleanup of the activity map is wired into all four `providers.remove()` call sites (session deletion, kill, detach-on-exit, and resume-retry).