### PR TITLE
Default rename-branch to checked and convert spaces to dashes in agent name inputs

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3804,7 +3804,7 @@ mod tests {
         app.prompt = PromptState::RenameSession {
             session_id: "session-1".to_string(),
             input: TextInput::with_text("test".to_string()),
-            rename_branch: false,
+            rename_branch: true,
         };
 
         // Tab toggles the checkbox.
@@ -3813,7 +3813,7 @@ mod tests {
 
         match &app.prompt {
             PromptState::RenameSession { rename_branch, .. } => {
-                assert!(*rename_branch, "Tab should toggle rename_branch to true");
+                assert!(!*rename_branch, "Tab should toggle rename_branch to false");
             }
             other => panic!("expected RenameSession, got {other:?}"),
         }
@@ -3825,8 +3825,8 @@ mod tests {
         match &app.prompt {
             PromptState::RenameSession { rename_branch, .. } => {
                 assert!(
-                    !*rename_branch,
-                    "second Tab should toggle rename_branch back to false"
+                    *rename_branch,
+                    "second Tab should toggle rename_branch back to true"
                 );
             }
             other => panic!("expected RenameSession, got {other:?}"),
@@ -3834,14 +3834,14 @@ mod tests {
     }
 
     #[test]
-    fn open_rename_session_initializes_rename_branch_false() {
+    fn open_rename_session_initializes_rename_branch_true() {
         let mut app = test_app(default_bindings());
 
         app.open_rename_session().unwrap();
 
         match &app.prompt {
             PromptState::RenameSession { rename_branch, .. } => {
-                assert!(!*rename_branch, "rename_branch should default to false");
+                assert!(*rename_branch, "rename_branch should default to true");
             }
             other => panic!("expected RenameSession, got {other:?}"),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1387,8 +1387,8 @@ impl App {
             self.prompt = PromptState::RenameSession {
                 session_id: session.id,
                 input: TextInput::with_text(current_name)
-                    .with_char_filter(crate::git::agent_name_char_filter),
-                rename_branch: false,
+                    .with_char_map(crate::git::agent_name_char_map),
+                rename_branch: true,
             };
         } else {
             self.set_error("No agent session selected.");

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -108,7 +108,7 @@ impl App {
                     project,
                     custom_name: None,
                 },
-                input: TextInput::new().with_char_filter(crate::git::agent_name_char_filter),
+                input: TextInput::new().with_char_map(crate::git::agent_name_char_map),
             };
             return Ok(());
         }
@@ -147,7 +147,7 @@ impl App {
                     source_label,
                     custom_name: None,
                 },
-                input: TextInput::new().with_char_filter(crate::git::agent_name_char_filter),
+                input: TextInput::new().with_char_map(crate::git::agent_name_char_map),
             };
             return Ok(());
         }

--- a/src/app/text_input.rs
+++ b/src/app/text_input.rs
@@ -21,11 +21,11 @@ pub struct TextInput {
     /// are applied normally — when the overlay is dismissed the current text
     /// is shown.
     overlay: Option<String>,
-    /// Optional filter consulted before each character insertion. Receives
+    /// Optional mapper consulted before each character insertion. Receives
     /// the current text, the cursor byte-offset where the character would be
-    /// inserted, and the candidate character. Return `true` to allow, `false`
-    /// to silently reject.
-    char_filter: Option<fn(&str, usize, char) -> bool>,
+    /// inserted, and the candidate character. Return `Some(c)` to insert `c`
+    /// (which may differ from the input), or `None` to silently reject.
+    char_map: Option<fn(&str, usize, char) -> Option<char>>,
 }
 
 #[derive(Clone, Debug)]
@@ -52,7 +52,7 @@ impl TextInput {
             multiline: None,
             placeholder: None,
             overlay: None,
-            char_filter: None,
+            char_map: None,
         }
     }
 
@@ -64,7 +64,7 @@ impl TextInput {
             multiline: None,
             placeholder: None,
             overlay: None,
-            char_filter: None,
+            char_map: None,
         }
     }
 
@@ -96,11 +96,12 @@ impl TextInput {
         self.overlay.as_deref()
     }
 
-    /// Set a character filter that is consulted before each insertion.
-    /// The filter receives the current text, cursor byte-offset, and candidate
-    /// character. Return `true` to allow, `false` to silently reject.
-    pub fn with_char_filter(mut self, filter: fn(&str, usize, char) -> bool) -> Self {
-        self.char_filter = Some(filter);
+    /// Set a character mapper that is consulted before each insertion.
+    /// The mapper receives the current text, cursor byte-offset, and candidate
+    /// character. Return `Some(c)` to insert `c` (which may differ from the
+    /// input for transparent substitution), or `None` to silently reject.
+    pub fn with_char_map(mut self, map: fn(&str, usize, char) -> Option<char>) -> Self {
+        self.char_map = Some(map);
         self
     }
 
@@ -142,11 +143,14 @@ impl TextInput {
 
     pub fn insert_char(&mut self, ch: char) {
         let index = clamp_cursor(&self.text, self.cursor);
-        if let Some(filter) = self.char_filter
-            && !filter(&self.text, index, ch)
-        {
-            return;
-        }
+        let ch = if let Some(map) = self.char_map {
+            match map(&self.text, index, ch) {
+                Some(c) => c,
+                None => return,
+            }
+        } else {
+            ch
+        };
         self.text.insert(index, ch);
         self.cursor = index + ch.len_utf8();
     }
@@ -1734,16 +1738,16 @@ mod tests {
         }
     }
 
-    // ── char_filter tests ─────────────────────────────────────────
+    // ── char_map tests ─────────────────────────────────────────────
 
-    /// A filter that rejects the character 'x'.
-    fn reject_x(_text: &str, _cursor: usize, ch: char) -> bool {
-        ch != 'x'
+    /// A mapper that rejects the character 'x'.
+    fn reject_x(_text: &str, _cursor: usize, ch: char) -> Option<char> {
+        if ch == 'x' { None } else { Some(ch) }
     }
 
     #[test]
-    fn filter_rejects_char() {
-        let mut input = TextInput::new().with_char_filter(reject_x);
+    fn map_rejects_char() {
+        let mut input = TextInput::new().with_char_map(reject_x);
         input.handle_key(key(KeyCode::Char('a')));
         input.handle_key(key(KeyCode::Char('x')));
         input.handle_key(key(KeyCode::Char('b')));
@@ -1751,7 +1755,7 @@ mod tests {
     }
 
     #[test]
-    fn no_filter_allows_all() {
+    fn no_map_allows_all() {
         let mut input = TextInput::new();
         input.handle_key(key(KeyCode::Char('a')));
         input.handle_key(key(KeyCode::Char('x')));
@@ -1759,14 +1763,14 @@ mod tests {
         assert_eq!(input.text, "axb");
     }
 
-    /// A filter that enforces a max length of 3 characters.
-    fn max_three(text: &str, _cursor: usize, _ch: char) -> bool {
-        text.len() < 3
+    /// A mapper that enforces a max length of 3 characters.
+    fn max_three(text: &str, _cursor: usize, ch: char) -> Option<char> {
+        if text.len() < 3 { Some(ch) } else { None }
     }
 
     #[test]
-    fn filter_receives_current_text() {
-        let mut input = TextInput::new().with_char_filter(max_three);
+    fn map_receives_current_text() {
+        let mut input = TextInput::new().with_char_map(max_three);
         for ch in "abcde".chars() {
             input.handle_key(key(KeyCode::Char(ch)));
         }
@@ -1774,10 +1778,24 @@ mod tests {
     }
 
     #[test]
-    fn filter_applies_to_insert_char_directly() {
-        let mut input = TextInput::new().with_char_filter(reject_x);
+    fn map_applies_to_insert_char_directly() {
+        let mut input = TextInput::new().with_char_map(reject_x);
         input.insert_char('x');
         input.insert_char('y');
         assert_eq!(input.text, "y");
+    }
+
+    /// A mapper that converts 'a' to 'A'.
+    fn upcase_a(_text: &str, _cursor: usize, ch: char) -> Option<char> {
+        if ch == 'a' { Some('A') } else { Some(ch) }
+    }
+
+    #[test]
+    fn map_transforms_char() {
+        let mut input = TextInput::new().with_char_map(upcase_a);
+        input.handle_key(key(KeyCode::Char('a')));
+        input.handle_key(key(KeyCode::Char('b')));
+        input.handle_key(key(KeyCode::Char('a')));
+        assert_eq!(input.text, "AbA");
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -672,28 +672,31 @@ pub fn is_valid_agent_name(name: &str) -> bool {
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '/')
 }
 
-/// Input filter for agent name text fields. Rejects characters that would
-/// make the name invalid per [`is_valid_agent_name`] rules. Designed for use
-/// with [`TextInput::with_char_filter`].
-pub fn agent_name_char_filter(text: &str, cursor: usize, ch: char) -> bool {
+/// Input mapper for agent name text fields. Maps characters for insertion,
+/// rejecting those that would make the name invalid per [`is_valid_agent_name`]
+/// rules. Spaces are transparently converted to dashes. Designed for use with
+/// [`TextInput::with_char_map`].
+pub fn agent_name_char_map(text: &str, cursor: usize, ch: char) -> Option<char> {
+    // Transparently convert spaces to dashes.
+    let ch = if ch == ' ' { '-' } else { ch };
     // Only allow ASCII alphanumeric, '-', '_', '/'
     if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '/') {
-        return false;
+        return None;
     }
     // First position must be alphanumeric (reject '-', '_', '/')
     if cursor == 0 && !ch.is_ascii_alphanumeric() {
-        return false;
+        return None;
     }
     // Prevent '//' by checking the character before and after the cursor
     if ch == '/' {
         if cursor > 0 && text.as_bytes().get(cursor - 1) == Some(&b'/') {
-            return false;
+            return None;
         }
         if text.as_bytes().get(cursor) == Some(&b'/') {
-            return false;
+            return None;
         }
     }
-    true
+    Some(ch)
 }
 
 fn sync_directory_contents(source: &Path, destination: &Path) -> Result<()> {
@@ -1279,46 +1282,56 @@ mod tests {
         assert_eq!(head_commit(&forked).unwrap(), source_head);
     }
 
-    // ── agent_name_char_filter tests ──────────────────────────────
+    // ── agent_name_char_map tests ───────────────────────────────
 
     #[test]
-    fn agent_filter_allows_valid_chars() {
-        assert!(agent_name_char_filter("a", 1, 'b'));
-        assert!(agent_name_char_filter("a", 1, '0'));
-        assert!(agent_name_char_filter("a", 1, '-'));
-        assert!(agent_name_char_filter("a", 1, '_'));
-        assert!(agent_name_char_filter("a", 1, '/'));
+    fn agent_map_allows_valid_chars() {
+        assert_eq!(agent_name_char_map("a", 1, 'b'), Some('b'));
+        assert_eq!(agent_name_char_map("a", 1, '0'), Some('0'));
+        assert_eq!(agent_name_char_map("a", 1, '-'), Some('-'));
+        assert_eq!(agent_name_char_map("a", 1, '_'), Some('_'));
+        assert_eq!(agent_name_char_map("a", 1, '/'), Some('/'));
     }
 
     #[test]
-    fn agent_filter_rejects_invalid_chars() {
-        assert!(!agent_name_char_filter("a", 1, ' '));
-        assert!(!agent_name_char_filter("a", 1, '@'));
-        assert!(!agent_name_char_filter("a", 1, '.'));
-        assert!(!agent_name_char_filter("a", 1, '!'));
-        assert!(!agent_name_char_filter("a", 1, '#'));
+    fn agent_map_rejects_invalid_chars() {
+        assert_eq!(agent_name_char_map("a", 1, '@'), None);
+        assert_eq!(agent_name_char_map("a", 1, '.'), None);
+        assert_eq!(agent_name_char_map("a", 1, '!'), None);
+        assert_eq!(agent_name_char_map("a", 1, '#'), None);
     }
 
     #[test]
-    fn agent_filter_first_char_must_be_alphanumeric() {
+    fn agent_map_converts_space_to_dash() {
+        assert_eq!(agent_name_char_map("a", 1, ' '), Some('-'));
+    }
+
+    #[test]
+    fn agent_map_rejects_space_at_position_zero() {
+        // Space maps to dash, but dash is rejected at position 0.
+        assert_eq!(agent_name_char_map("", 0, ' '), None);
+    }
+
+    #[test]
+    fn agent_map_first_char_must_be_alphanumeric() {
         // Rejected at position 0
-        assert!(!agent_name_char_filter("", 0, '-'));
-        assert!(!agent_name_char_filter("", 0, '_'));
-        assert!(!agent_name_char_filter("", 0, '/'));
+        assert_eq!(agent_name_char_map("", 0, '-'), None);
+        assert_eq!(agent_name_char_map("", 0, '_'), None);
+        assert_eq!(agent_name_char_map("", 0, '/'), None);
         // Accepted at position 0
-        assert!(agent_name_char_filter("", 0, 'a'));
-        assert!(agent_name_char_filter("", 0, '1'));
+        assert_eq!(agent_name_char_map("", 0, 'a'), Some('a'));
+        assert_eq!(agent_name_char_map("", 0, '1'), Some('1'));
         // Also rejected when inserting at position 0 in non-empty text
-        assert!(!agent_name_char_filter("abc", 0, '-'));
+        assert_eq!(agent_name_char_map("abc", 0, '-'), None);
     }
 
     #[test]
-    fn agent_filter_prevents_double_slash() {
+    fn agent_map_prevents_double_slash() {
         // Inserting '/' right after an existing '/'
-        assert!(!agent_name_char_filter("a/", 2, '/'));
+        assert_eq!(agent_name_char_map("a/", 2, '/'), None);
         // Inserting '/' right before an existing '/'
-        assert!(!agent_name_char_filter("a/b", 1, '/'));
+        assert_eq!(agent_name_char_map("a/b", 1, '/'), None);
         // Inserting '/' where no adjacent slash exists
-        assert!(agent_name_char_filter("ab", 1, '/'));
+        assert_eq!(agent_name_char_map("ab", 1, '/'), Some('/'));
     }
 }


### PR DESCRIPTION
The rename-branch checkbox in the agent rename dialog now defaults to **checked** instead of unchecked. This matches the more common intent when renaming an agent — you usually want the branch to follow.

`TextInput`'s `char_filter` (`fn -> bool`) has been generalized into `char_map` (`fn -> Option<char>`), which can both reject characters (`None`) and transparently substitute them (`Some(replacement)`). The agent name mapper uses this to **convert spaces into dashes** automatically in both the rename and new-agent name dialogs, so typing `my cool feature` produces `my-cool-feature` instead of silently swallowing the spaces.

All existing `char_filter` tests have been migrated to the new `char_map` API and new tests cover the space-to-dash conversion, the transformation path in `TextInput`, and the updated default for `rename_branch`.