### PR TITLE
Exit fullscreen overlay when clicking outside the big pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2156,11 +2156,16 @@ impl App {
 
     fn mouse_target(&self, column: u16, row: u16) -> Option<MouseTarget> {
         if !matches!(self.fullscreen_overlay, FullscreenOverlay::None) {
-            return self
+            if self
                 .mouse_layout
                 .agent_term
-                .filter(|rect| contains_point(*rect, column, row))
-                .map(|_| MouseTarget::Center);
+                .is_some_and(|rect| contains_point(rect, column, row))
+            {
+                return Some(MouseTarget::Center);
+            }
+            // Click landed outside the fullscreen overlay — fall through to
+            // normal pane hit-testing so the existing handlers can exit
+            // fullscreen and route focus to the clicked pane.
         }
 
         if contains_point(self.mouse_layout.left_list, column, row) {


### PR DESCRIPTION
When an agent or terminal is open in fullscreen (interactive) mode, clicking on the dimmed area outside the overlay was previously a no-op — the `mouse_target()` function returned `None` for any click outside the `agent_term` rect, and the `None` arm in `handle_mouse()` did nothing. This meant the only way to leave fullscreen was via the keyboard (`Ctrl-G`).

With this change, clicks outside the fullscreen overlay fall through to the normal pane hit-testing logic instead of being discarded. Because every existing pane handler (`LeftPane`, `FilesPane`, `TerminalRow`, etc.) already resets `fullscreen_overlay` and `input_target`, no new `MouseTarget` variants or dispatch branches are needed — the single edit to the early-return guard in `mouse_target()` is sufficient.

The underlying pane layout rects remain valid during fullscreen because `render()` computes the three-pane layout every frame *before* drawing the overlay on top, so hit-testing against them is safe regardless of display state.