### PR TITLE
Add resource monitor overlay for CPU and memory usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 - **Panes have interactive and non-interactive modes.** In interactive mode, all key combos (including global ones) are suppressed and input is forwarded to the PTY. In non-interactive mode, both local and global key combos are active.
 - **Key combinations are documented in the help page.** The in-app `?` overlay is the authoritative reference. External docs describe how to configure bindings, not enumerate them.
 - **Line-scroll keys are gated by context.** In interactive (PTY) mode, arrow keys and Space only scroll when already scrolled back (`scrollback_offset > 0`); otherwise they pass through to the child process. In non-interactive views (diff overlay, non-interactive agent pane, help overlay), there is no competing use for these keys, so they scroll unconditionally. Page-scroll keys (`PgUp`/`PgDn`) always initiate scrolling regardless of context.
+- **Animations and periodic refreshes use wall-clock time, not tick counts.** Tying visual updates to tick rate couples frame cadence to logic timing. Use `Instant::elapsed()` (or equivalent) so animations stay smooth and refreshes stay consistent regardless of how often ticks fire.
 
 ### Agents and Providers
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -538,6 +538,7 @@ dependencies = [
  "signal-hook 0.4.4",
  "similar",
  "syntect",
+ "sysinfo",
  "tempfile",
  "toml",
  "toml_edit",
@@ -718,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -836,7 +837,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -906,15 +907,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1147,6 +1139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,7 +1322,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1370,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "rand",
@@ -1626,7 +1637,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools 0.14.0",
+ "itertools",
  "kasuari",
  "lru",
  "strum",
@@ -1678,7 +1689,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools 0.14.0",
+ "itertools",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -2073,6 +2084,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2330,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2598,6 +2623,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,9 +2665,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2634,9 +2705,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -2644,7 +2740,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2653,7 +2758,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2671,7 +2776,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2688,6 +2793,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ syntect = { version = "5", default-features = false, features = ["default-syntax
 crokey = "1.4.0"
 indexmap = { version = "2.13.0", features = ["serde"] }
 compact_str = "0.9"
+sysinfo = "0.35"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1146,6 +1146,35 @@ impl App {
     }
 
     fn handle_prompt_key(&mut self, key: KeyEvent) -> Result<bool> {
+        if let PromptState::ResourceMonitor {
+            scroll_offset,
+            rows,
+            ..
+        } = &mut self.prompt
+        {
+            if key.code == KeyCode::Esc {
+                self.prompt = PromptState::None;
+                return Ok(false);
+            }
+            let max_offset = rows.len().saturating_sub(1) as u16;
+            match key.code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    *scroll_offset = scroll_offset.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    *scroll_offset = (*scroll_offset + 1).min(max_offset);
+                }
+                KeyCode::PageUp => {
+                    *scroll_offset = scroll_offset.saturating_sub(10);
+                }
+                KeyCode::PageDown => {
+                    *scroll_offset = (*scroll_offset + 10).min(max_offset);
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if let PromptState::DebugInput {
             lines,
             scroll_offset,
@@ -2789,6 +2818,25 @@ impl App {
     }
 
     fn handle_prompt_mouse(&mut self, mouse: MouseEvent) -> bool {
+        if let PromptState::ResourceMonitor {
+            scroll_offset,
+            rows,
+            ..
+        } = &mut self.prompt
+        {
+            let max_offset = rows.len().saturating_sub(1) as u16;
+            match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    *scroll_offset = scroll_offset.saturating_sub(3);
+                }
+                MouseEventKind::ScrollDown => {
+                    *scroll_offset = (*scroll_offset + 3).min(max_offset);
+                }
+                _ => {}
+            }
+            return false;
+        }
+
         if let PromptState::DebugInput {
             lines,
             scroll_offset,
@@ -3532,6 +3580,7 @@ mod tests {
             terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
+            resource_stats_in_flight: false,
             last_pty_size: (0, 0),
             last_pty_activity: std::collections::HashMap::new(),
             prev_scrollback_offset: 0,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1060,13 +1060,18 @@ impl App {
             if let Some(pty) = self.providers.get(&session.id) {
                 if let Some(pid) = pty.child_process_id() {
                     let title = session.title.as_deref().unwrap_or(&session.branch_name);
-                    targets.push((format!("Agent: {title}"), pid));
+                    let provider = session.provider.as_str();
+                    targets.push((format!("Agent ({provider}): {title}"), pid));
                 }
             }
         }
         for terminal in self.companion_terminals.values() {
             if let Some(pid) = terminal.client.child_process_id() {
-                targets.push((format!("Terminal: {}", terminal.label), pid));
+                let label = match &terminal.foreground_cmd {
+                    Some(cmd) => format!("Terminal ({cmd}): {}", terminal.label),
+                    None => format!("Terminal: {}", terminal.label),
+                };
+                targets.push((label, pid));
             }
         }
         targets

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -95,6 +95,7 @@ pub struct App {
     pub(crate) terminal_return_to_list: bool,
     pub(crate) terminal_counter: usize,
     pub(crate) create_agent_in_flight: bool,
+    pub(crate) resource_stats_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
     /// Tracks when each agent last received PTY data, for the streaming
     /// activity spinner in the left pane.
@@ -401,6 +402,21 @@ pub(crate) enum PromptState {
         lines: Vec<Line<'static>>,
         scroll_offset: u16,
     },
+    ResourceMonitor {
+        rows: Vec<ResourceStats>,
+        scroll_offset: u16,
+        last_refresh: Instant,
+        first_sample: bool,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResourceStats {
+    pub(crate) label: String,
+    pub(crate) pid: Option<u32>,
+    pub(crate) cpu_percent: f32,
+    pub(crate) rss_bytes: u64,
+    pub(crate) process_count: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -636,6 +652,7 @@ pub(crate) enum WorkerEvent {
         previous_title: Option<String>,
         result: Result<(), String>,
     },
+    ResourceStatsReady(Vec<ResourceStats>),
 }
 
 mod input;
@@ -726,6 +743,7 @@ impl App {
             terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
+            resource_stats_in_flight: false,
             last_pty_size: (0, 0),
             last_pty_activity: HashMap::new(),
             prev_scrollback_offset: 0,
@@ -1023,6 +1041,50 @@ impl App {
         self.set_error(format!("{context}: {err}"));
     }
 
+    pub(crate) fn open_resource_monitor(&mut self) {
+        self.prompt = PromptState::ResourceMonitor {
+            rows: Vec::new(),
+            scroll_offset: 0,
+            last_refresh: Instant::now(),
+            first_sample: true,
+        };
+        self.spawn_resource_stats_worker();
+    }
+
+    /// Gather the labeled PIDs that the resource monitor should report on.
+    /// Each entry is `(label, root_pid)` — the worker will aggregate the
+    /// full process tree under each root.
+    fn resource_monitor_targets(&self) -> Vec<(String, u32)> {
+        let mut targets = Vec::new();
+        for session in &self.sessions {
+            if let Some(pty) = self.providers.get(&session.id) {
+                if let Some(pid) = pty.child_process_id() {
+                    let title = session.title.as_deref().unwrap_or(&session.branch_name);
+                    targets.push((format!("Agent: {title}"), pid));
+                }
+            }
+        }
+        for terminal in self.companion_terminals.values() {
+            if let Some(pid) = terminal.client.child_process_id() {
+                targets.push((format!("Terminal: {}", terminal.label), pid));
+            }
+        }
+        targets
+    }
+
+    pub(crate) fn spawn_resource_stats_worker(&mut self) {
+        if self.resource_stats_in_flight {
+            return;
+        }
+        self.resource_stats_in_flight = true;
+        let targets = self.resource_monitor_targets();
+        let tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            let rows = collect_resource_stats(targets);
+            let _ = tx.send(WorkerEvent::ResourceStatsReady(rows));
+        });
+    }
+
     pub(crate) fn execute_command(&mut self, command: String) -> Result<()> {
         let command = command.trim();
         match command {
@@ -1090,6 +1152,10 @@ impl App {
                     lines: Vec::new(),
                     scroll_offset: 0,
                 };
+                Ok(())
+            }
+            "resource-monitor" => {
+                self.open_resource_monitor();
                 Ok(())
             }
             "toggle-diff-line-numbers" => {
@@ -1641,6 +1707,101 @@ pub(crate) fn load_projects(config: &Config) -> Vec<Project> {
     projects
 }
 
+// ── Resource monitor helpers ───────────────────────────────────────────────
+
+/// Collect CPU and memory stats for dux itself plus each labeled target
+/// process tree. Runs on a background thread — no `&self` needed.
+fn collect_resource_stats(targets: Vec<(String, u32)>) -> Vec<ResourceStats> {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+    let mut sys = System::new();
+    let refresh_kind = ProcessRefreshKind::nothing().with_cpu().with_memory();
+    sys.refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
+
+    let mut rows = Vec::new();
+
+    // Row: dux itself.
+    let self_pid = Pid::from_u32(std::process::id());
+    if let Some(proc_info) = sys.process(self_pid) {
+        rows.push(ResourceStats {
+            label: "dux (this process)".into(),
+            pid: Some(std::process::id()),
+            cpu_percent: proc_info.cpu_usage(),
+            rss_bytes: proc_info.memory(),
+            process_count: 1,
+        });
+    }
+
+    // Rows: each labeled target (agents and companion terminals).
+    for (label, root_pid) in &targets {
+        let (cpu, rss, count) = aggregate_tree(&sys, Pid::from_u32(*root_pid));
+        rows.push(ResourceStats {
+            label: label.clone(),
+            pid: Some(*root_pid),
+            cpu_percent: cpu,
+            rss_bytes: rss,
+            process_count: count,
+        });
+    }
+
+    // Total row.
+    let total_cpu: f32 = rows.iter().map(|r| r.cpu_percent).sum();
+    let total_rss: u64 = rows.iter().map(|r| r.rss_bytes).sum();
+    let total_procs: usize = rows.iter().map(|r| r.process_count).sum();
+    rows.push(ResourceStats {
+        label: "TOTAL".into(),
+        pid: None,
+        cpu_percent: total_cpu,
+        rss_bytes: total_rss,
+        process_count: total_procs,
+    });
+
+    rows
+}
+
+/// Check whether `pid` is a descendant (child, grandchild, ...) of `ancestor`
+/// by walking up the process tree.
+fn is_descendant_of(sys: &sysinfo::System, pid: sysinfo::Pid, ancestor: sysinfo::Pid) -> bool {
+    use sysinfo::Pid;
+
+    let mut current = pid;
+    // Depth limit prevents infinite loops if the tree has a cycle (shouldn't
+    // happen, but be defensive).
+    for _ in 0..64 {
+        if let Some(proc) = sys.process(current) {
+            if let Some(parent) = proc.parent() {
+                if parent == ancestor {
+                    return true;
+                }
+                if parent == Pid::from_u32(0) {
+                    return false;
+                }
+                current = parent;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    false
+}
+
+/// Aggregate CPU% and RSS across a root PID and all its descendants.
+fn aggregate_tree(sys: &sysinfo::System, root: sysinfo::Pid) -> (f32, u64, usize) {
+    let mut cpu = 0.0f32;
+    let mut rss = 0u64;
+    let mut count = 0usize;
+    for (pid, proc_info) in sys.processes() {
+        if *pid == root || is_descendant_of(sys, *pid, root) {
+            cpu += proc_info.cpu_usage();
+            rss += proc_info.memory();
+            count += 1;
+        }
+    }
+    (cpu, rss, count)
+}
+
 pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> ProviderCommandConfig {
     config
         .providers
@@ -1650,4 +1811,59 @@ pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> Provi
             command: provider.as_str().to_string(),
             ..Default::default()
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_process_is_descendant_of_pid_1() {
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        let self_pid = Pid::from_u32(std::process::id());
+        let init_pid = Pid::from_u32(1);
+        assert!(
+            is_descendant_of(&sys, self_pid, init_pid),
+            "current process should be a descendant of PID 1"
+        );
+    }
+
+    #[test]
+    fn aggregate_tree_includes_self_process() {
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing().with_memory(),
+        );
+        let self_pid = Pid::from_u32(std::process::id());
+        let (_cpu, rss, count) = aggregate_tree(&sys, self_pid);
+        assert!(count >= 1, "should include at least the root process");
+        assert!(rss > 0, "current process should have nonzero RSS");
+    }
+
+    #[test]
+    fn is_descendant_of_returns_false_for_unrelated_pid() {
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+        let mut sys = System::new();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        // PID 1 is not a descendant of the current process.
+        let self_pid = Pid::from_u32(std::process::id());
+        let init_pid = Pid::from_u32(1);
+        assert!(!is_descendant_of(&sys, init_pid, self_pid));
+    }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3059,6 +3059,17 @@ impl App {
                 // Full rendering implemented in Task #5.
                 self.render_edit_macros(frame);
             }
+            PromptState::ResourceMonitor {
+                rows,
+                scroll_offset,
+                first_sample,
+                ..
+            } => {
+                let rows = rows.clone();
+                let scroll_offset = *scroll_offset;
+                let first_sample = *first_sample;
+                self.render_resource_monitor(frame, &rows, scroll_offset, first_sample);
+            }
             PromptState::DebugInput {
                 lines,
                 scroll_offset,
@@ -3744,6 +3755,106 @@ impl App {
         "Agent".to_string()
     }
 
+    fn render_resource_monitor(
+        &mut self,
+        frame: &mut Frame,
+        rows: &[ResourceStats],
+        scroll_offset: u16,
+        first_sample: bool,
+    ) {
+        use ratatui::widgets::{Cell, Row, Table, TableState};
+
+        self.render_dim_overlay(frame);
+        let popup = centered_rect(85, 78, frame.area());
+        Clear.render(popup, frame.buffer_mut());
+
+        let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(popup);
+        let content_area = chunks[0];
+        let hint_area = chunks[1];
+
+        let block = self.themed_overlay_block(" Resource Monitor ");
+        let inner = block.inner(content_area);
+        block.render(content_area, frame.buffer_mut());
+
+        let header_style = Style::default()
+            .fg(self.theme.help_section_header_fg)
+            .add_modifier(Modifier::BOLD);
+
+        let header = Row::new(vec![
+            Cell::from("Name").style(header_style),
+            Cell::from("PID").style(header_style),
+            Cell::from("Procs").style(header_style),
+            Cell::from("CPU %").style(header_style),
+            Cell::from("RSS").style(header_style),
+        ])
+        .bottom_margin(1);
+
+        let table_rows: Vec<Row> = rows
+            .iter()
+            .map(|stat| {
+                let pid_str = stat.pid.map(|p| p.to_string()).unwrap_or_default();
+                let cpu_str = if first_sample {
+                    format!("~{:.1}%", stat.cpu_percent)
+                } else {
+                    format!("{:.1}%", stat.cpu_percent)
+                };
+                let rss_str = format_bytes(stat.rss_bytes);
+                let procs_str = stat.process_count.to_string();
+
+                let is_total = stat.label == "TOTAL";
+                let style = if is_total {
+                    Style::default().add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+
+                Row::new(vec![
+                    Cell::from(stat.label.clone()),
+                    Cell::from(pid_str),
+                    Cell::from(procs_str),
+                    Cell::from(cpu_str),
+                    Cell::from(rss_str),
+                ])
+                .style(style)
+            })
+            .collect();
+
+        let widths = [
+            Constraint::Min(30),
+            Constraint::Length(8),
+            Constraint::Length(6),
+            Constraint::Length(8),
+            Constraint::Length(12),
+        ];
+
+        let table = Table::new(table_rows, widths)
+            .header(header)
+            .style(Style::default().bg(self.theme.overlay_bg));
+
+        let mut table_state = TableState::default().with_offset(scroll_offset as usize);
+        StatefulWidget::render(table, inner, frame.buffer_mut(), &mut table_state);
+
+        // Footer hint.
+        let hint = Line::from(vec![
+            Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" close  "),
+            Span::styled("Scroll", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" navigate  "),
+            Span::styled(
+                "refreshes every ~2s",
+                Style::default().add_modifier(Modifier::DIM),
+            ),
+        ]);
+        let hint_para = Paragraph::new(hint)
+            .alignment(ratatui::layout::Alignment::Center)
+            .style(
+                Style::default()
+                    .fg(self.theme.hint_desc_fg)
+                    .add_modifier(Modifier::DIM),
+            );
+        hint_para.render(hint_area, frame.buffer_mut());
+    }
+
     fn render_dim_overlay(&self, frame: &mut Frame) {
         let full = frame.area();
         // Keep the statusline (bottom rows) undimmed so errors stay visible.
@@ -3781,6 +3892,21 @@ fn pty_cell_colors(fg: Color, bg: Color, is_input: bool, theme: &Theme) -> (Colo
             theme.overlay_dim_bg
         };
         (theme.overlay_dim_fg, dimmed_bg)
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = KIB * 1024;
+    const GIB: u64 = MIB * 1024;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.0} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
     }
 }
 
@@ -4122,5 +4248,32 @@ mod tests {
             pty_cell_colors(fg, Color::Reset, false, &theme),
             (theme.overlay_dim_fg, Color::Reset)
         );
+    }
+
+    #[test]
+    fn format_bytes_zero() {
+        assert_eq!(format_bytes(0), "0 B");
+    }
+
+    #[test]
+    fn format_bytes_below_kib() {
+        assert_eq!(format_bytes(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_bytes_exactly_one_kib() {
+        assert_eq!(format_bytes(1024), "1 KiB");
+    }
+
+    #[test]
+    fn format_bytes_mib_range() {
+        assert_eq!(format_bytes(1024 * 1024), "1.0 MiB");
+        assert_eq!(format_bytes(1024 * 1024 * 512), "512.0 MiB");
+    }
+
+    #[test]
+    fn format_bytes_gib_range() {
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024 * 3), "3.0 GiB");
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3786,8 +3786,7 @@ impl App {
             Cell::from("Procs").style(header_style),
             Cell::from("CPU %").style(header_style),
             Cell::from("RSS").style(header_style),
-        ])
-        .bottom_margin(1);
+        ]);
 
         let table_rows: Vec<Row> = rows
             .iter()
@@ -3827,9 +3826,7 @@ impl App {
             Constraint::Length(12),
         ];
 
-        let table = Table::new(table_rows, widths)
-            .header(header)
-            .style(Style::default().bg(self.theme.overlay_bg));
+        let table = Table::new(table_rows, widths).header(header);
 
         let mut table_state = TableState::default().with_offset(scroll_offset as usize);
         StatefulWidget::render(table, inner, frame.buffer_mut(), &mut table_state);

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -162,6 +162,20 @@ impl App {
                         *selected = 0;
                     }
                 }
+                WorkerEvent::ResourceStatsReady(stats) => {
+                    self.resource_stats_in_flight = false;
+                    if let PromptState::ResourceMonitor {
+                        rows,
+                        last_refresh,
+                        first_sample,
+                        ..
+                    } = &mut self.prompt
+                    {
+                        *rows = stats;
+                        *last_refresh = Instant::now();
+                        *first_sample = false;
+                    }
+                }
             }
         }
         // Detect PTY exits.
@@ -280,6 +294,17 @@ impl App {
         if self.tick_count.is_multiple_of(20) {
             for terminal in self.companion_terminals.values_mut() {
                 terminal.foreground_cmd = terminal.client.foreground_process_name();
+            }
+        }
+
+        // Spawn a background worker to refresh resource monitor stats when
+        // the overlay is open and enough wall-clock time has elapsed (~2s).
+        if let PromptState::ResourceMonitor {
+            ref last_refresh, ..
+        } = self.prompt
+        {
+            if last_refresh.elapsed() >= Duration::from_secs(2) {
+                self.spawn_resource_stats_worker();
             }
         }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -79,6 +79,7 @@ pub enum Action {
     EditMacros,
     DebugInput,
     ToggleDiffLineNumbers,
+    ResourceMonitor,
 }
 
 /// Where a binding's key combo is matched.
@@ -237,6 +238,7 @@ impl Action {
             Action::EditMacros => "edit_macros",
             Action::DebugInput => "debug_input",
             Action::ToggleDiffLineNumbers => "toggle_diff_line_numbers",
+            Action::ResourceMonitor => "resource_monitor",
         }
     }
 
@@ -317,6 +319,7 @@ impl Action {
             Action::EditMacros => "Open the text macros editor.",
             Action::DebugInput => "Open input event debugger to inspect keyboard and mouse events.",
             Action::ToggleDiffLineNumbers => "Toggle line numbers in diff view.",
+            Action::ResourceMonitor => "Show CPU and memory usage for dux and all running agents.",
         }
     }
 
@@ -387,7 +390,8 @@ impl Action {
             | Action::SortAgentsByName
             | Action::EditMacros
             | Action::DebugInput
-            | Action::ToggleDiffLineNumbers => None,
+            | Action::ToggleDiffLineNumbers
+            | Action::ResourceMonitor => None,
         }
     }
 }
@@ -1293,6 +1297,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             description: "Toggle line numbers in diff view",
         }),
     },
+    BindingDef {
+        action: Action::ResourceMonitor,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "resource-monitor",
+            description: "Show CPU and memory usage for dux and all running agents",
+        }),
+    },
 ];
 
 const HELP_SECTION_ORDER: &[&str] = &[
@@ -2007,6 +2022,22 @@ mod tests {
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
         assert!(names.contains(&"kill-running"));
+    }
+
+    #[test]
+    fn filtered_palette_includes_resource_monitor_command() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("resource");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"resource-monitor"));
+    }
+
+    #[test]
+    fn resource_monitor_config_name_round_trip() {
+        assert_eq!(Action::ResourceMonitor.config_name(), "resource_monitor");
     }
 
     #[test]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -329,6 +329,11 @@ impl PtyClient {
         self.child.try_wait().ok().flatten()
     }
 
+    /// Returns the PID of the shell process spawned in this PTY.
+    pub fn child_process_id(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
     /// Returns the name of the foreground process running in this PTY, or
     /// `None` if the shell itself is in the foreground (idle).
     ///


### PR DESCRIPTION
Introduces a **resource-monitor** command accessible via the command palette (`Ctrl-P`) that opens a modal overlay displaying real-time CPU%, RSS memory, and subprocess count for dux itself, every running agent session (aggregated across its full process tree), and companion terminals. A **TOTAL** row summarizes the combined resource footprint. The overlay uses an 85×78% centered layout modeled after the existing input debugger, with a `Table` widget for structured columns and keyboard/mouse scroll support.

Stats collection runs on a **background worker thread** using the `sysinfo` crate, avoiding any UI-thread blocking. The worker is gated by an in-flight flag to prevent duplicate spawns, and results arrive through the existing `WorkerEvent` channel. Refresh is driven by wall-clock time (~2 seconds) rather than tick count, and the first sample displays CPU values with a `~` prefix to signal that sysinfo needs two readings to compute a meaningful delta.

This change also adds a new design tenet to `CLAUDE.md` requiring that all animations and periodic refreshes use `Instant::elapsed()` instead of tick counts, ensuring visual updates remain smooth and consistent regardless of tick cadence. Includes 10 new unit tests covering byte formatting, process tree traversal, and palette registration.