### PR TITLE
Allow click-outside-to-close fullscreen overlay while scrolled back

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1089,9 +1089,11 @@ impl App {
                         } else if self.handle_mouse(mouse_ev) {
                             return Ok(true);
                         }
-                    } else if !is_scrolled_back {
+                    } else {
                         // If the click landed outside the fullscreen overlay,
                         // exit interactive mode instead of forwarding to the PTY.
+                        // This check runs regardless of scroll state so the user
+                        // can always click outside to dismiss the overlay.
                         let outside_overlay =
                             matches!(mouse_ev.kind, MouseEventKind::Down(MouseButton::Left))
                                 && !self.mouse_layout.agent_term.is_some_and(|rect| {
@@ -1114,18 +1116,20 @@ impl App {
                             return Ok(false);
                         }
 
-                        // Non-scroll events (clicks, drags, moves,
-                        // releases): only forward when the child process
-                        // has opted into mouse tracking (e.g. vim, htop).
-                        // Otherwise drop — the child would echo the raw
-                        // SGR bytes as garbage text.
-                        let child_wants_mouse = self
-                            .selected_terminal_surface_client()
-                            .is_some_and(|p| p.has_mouse_mode());
-                        if child_wants_mouse
-                            && let Some(provider) = self.selected_terminal_surface_client()
-                        {
-                            let _ = provider.write_bytes(&raw);
+                        if !is_scrolled_back {
+                            // Non-scroll events (clicks, drags, moves,
+                            // releases): only forward when the child process
+                            // has opted into mouse tracking (e.g. vim, htop).
+                            // Otherwise drop — the child would echo the raw
+                            // SGR bytes as garbage text.
+                            let child_wants_mouse = self
+                                .selected_terminal_surface_client()
+                                .is_some_and(|p| p.has_mouse_mode());
+                            if child_wants_mouse
+                                && let Some(provider) = self.selected_terminal_surface_client()
+                            {
+                                let _ = provider.write_bytes(&raw);
+                            }
                         }
                     }
                 }
@@ -6456,6 +6460,38 @@ mod tests {
             app.focus,
             FocusPane::Left,
             "focus should move to left pane when terminal_return_to_list is set"
+        );
+    }
+
+    #[test]
+    fn scrolled_back_allows_click_outside_exit() {
+        // Use the scrolled-back helper (which prints enough lines to create
+        // history) and install a mouse layout so click-outside detection works.
+        let mut app = app_with_scrolled_back_pty();
+        install_mouse_layout(&mut app);
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
+        assert!(
+            app.selected_terminal_surface_client()
+                .unwrap()
+                .scrollback_offset()
+                > 0,
+            "test setup: should be scrolled back"
+        );
+
+        // Click outside agent_term while scrolled back — overlay must close.
+        let bytes = sgr_mouse_down(2, 2);
+        let result = app.process_raw_input_bytes(&bytes).unwrap();
+        assert!(!result);
+        assert_eq!(
+            app.input_target,
+            InputTarget::None,
+            "clicking outside overlay must exit interactive mode even when scrolled back"
+        );
+        assert_eq!(
+            app.fullscreen_overlay,
+            FullscreenOverlay::None,
+            "clicking outside overlay must dismiss fullscreen even when scrolled back"
         );
     }
 }


### PR DESCRIPTION
When in fullscreen (interactive) mode, clicking outside the overlay pane exits the mode — but this stopped working as soon as the user scrolled back. The outside-overlay click detection was nested inside an `else if !is_scrolled_back` branch that was meant to suppress PTY mouse forwarding, inadvertently also suppressing the UI dismissal action.

The fix restructures the mouse-event conditional so the click-outside check runs unconditionally regardless of scroll state, while PTY mouse forwarding to the child process remains correctly gated behind the scrollback check. This is a minimal change to the branching structure with no behavior difference for the non-scrolled-back path.

Includes a new test `scrolled_back_allows_click_outside_exit` that sets up a scrolled-back PTY with a mouse layout and verifies that clicking outside the overlay still exits interactive mode and dismisses the fullscreen overlay.