### PR TITLE
fix: guard concurrent pull requests per repository

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -861,18 +861,56 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn start_pull(
+        &mut self,
+        repo_path: PathBuf,
+        target: PullTarget,
+        busy_message: impl Into<String>,
+        already_running_message: impl Into<String>,
+    ) {
+        let repo_key = repo_path.to_string_lossy().into_owned();
+        if !self.pulls_in_flight.insert(repo_key.clone()) {
+            self.set_warning(already_running_message);
+            return;
+        }
+
+        let tx = self.worker_tx.clone();
+        self.set_busy(busy_message);
+        thread::spawn(move || {
+            let result = match &target {
+                PullTarget::Project { .. } => match git::is_dirty(&repo_path) {
+                    Ok(true) => Err(
+                        "Refresh blocked because the source checkout has uncommitted changes."
+                            .to_string(),
+                    ),
+                    Ok(false) => git::pull_current_branch(&repo_path)
+                        .map(|_| git::current_branch(&repo_path).ok())
+                        .map_err(|e| e.to_string()),
+                    Err(e) => Err(e.to_string()),
+                },
+                PullTarget::Session => git::pull_current_branch(&repo_path)
+                    .map(|_| None)
+                    .map_err(|e| e.to_string()),
+            };
+            let _ = tx.send(WorkerEvent::PullCompleted {
+                repo_path: repo_key,
+                target,
+                result,
+            });
+        });
+    }
+
     fn pull_from_remote(&mut self) -> Result<()> {
         let Some(session) = self.selected_session() else {
             self.set_error("Select a session first.");
             return Ok(());
         };
-        let worktree = PathBuf::from(&session.worktree_path);
-        let tx = self.worker_tx.clone();
-        self.set_busy("Pulling latest changes from remote…");
-        thread::spawn(move || {
-            let result = git::pull_current_branch(&worktree).map_err(|e| e.to_string());
-            let _ = tx.send(WorkerEvent::PullCompleted(result));
-        });
+        self.start_pull(
+            PathBuf::from(&session.worktree_path),
+            PullTarget::Session,
+            "Pulling latest changes from remote…",
+            "Pull already in progress for this worktree. Wait for the current pull to finish.",
+        );
         Ok(())
     }
 
@@ -3441,7 +3479,8 @@ mod tests {
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
         KillableRuntime, KillableRuntimeKind, LeftSection, MouseLayoutState, OverlayMouseLayout,
-        OverlayMouseLayoutState, PromptState, RightSection, RuntimeTargetId, TextInput,
+        OverlayMouseLayoutState, PromptState, PullTarget, RightSection, RuntimeTargetId, TextInput,
+        WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -3580,6 +3619,7 @@ mod tests {
             terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
+            pulls_in_flight: std::collections::HashSet::new(),
             resource_stats_in_flight: false,
             last_pty_size: (0, 0),
             last_pty_activity: std::collections::HashMap::new(),
@@ -3776,6 +3816,61 @@ mod tests {
             .expect("git commit");
 
         std::fs::write(&file_path, updated).expect("write updated");
+    }
+
+    #[test]
+    fn refresh_selected_project_blocks_repeat_presses_while_pull_is_running() {
+        let mut app = test_app(default_bindings());
+        app.selected_left = 0;
+
+        app.refresh_selected_project()
+            .expect("start project refresh");
+        app.refresh_selected_project()
+            .expect("repeat refresh should not error");
+
+        let repo_path = app.projects[0].path.clone();
+        assert!(app.pulls_in_flight.contains(&repo_path));
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Warning);
+        assert!(app.status.text().contains("already in progress"));
+    }
+
+    #[test]
+    fn project_pull_completion_clears_in_flight_guard() {
+        let mut app = test_app(default_bindings());
+        let repo_path = app.projects[0].path.clone();
+        app.pulls_in_flight.insert(repo_path.clone());
+
+        app.worker_tx
+            .send(WorkerEvent::PullCompleted {
+                repo_path,
+                target: PullTarget::Project {
+                    project_id: app.projects[0].id.clone(),
+                    project_name: app.projects[0].name.clone(),
+                },
+                result: Ok(Some("feature/demo".to_string())),
+            })
+            .expect("queue worker event");
+
+        app.drain_events();
+
+        assert!(app.pulls_in_flight.is_empty());
+        assert_eq!(app.projects[0].current_branch, "feature/demo");
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+    }
+
+    #[test]
+    fn pull_from_remote_blocks_repeat_presses_while_pull_is_running() {
+        let mut app = test_app(default_bindings());
+        app.selected_left = 1;
+
+        app.pull_from_remote().expect("start session pull");
+        app.pull_from_remote()
+            .expect("repeat pull should not error");
+
+        let repo_path = app.sessions[0].worktree_path.clone();
+        assert!(app.pulls_in_flight.contains(&repo_path));
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Warning);
+        assert!(app.status.text().contains("already in progress"));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -95,6 +95,7 @@ pub struct App {
     pub(crate) terminal_return_to_list: bool,
     pub(crate) terminal_counter: usize,
     pub(crate) create_agent_in_flight: bool,
+    pub(crate) pulls_in_flight: HashSet<String>,
     pub(crate) resource_stats_in_flight: bool,
     pub(crate) last_pty_size: (u16, u16),
     /// Tracks when each agent last received PTY data, for the streaming
@@ -636,7 +637,11 @@ pub(crate) enum WorkerEvent {
     CommitMessageGenerated(String),
     CommitMessageFailed(String),
     PushCompleted(Result<(), String>),
-    PullCompleted(Result<(), String>),
+    PullCompleted {
+        repo_path: String,
+        target: PullTarget,
+        result: Result<Option<String>, String>,
+    },
     BrowserEntriesReady {
         dir: PathBuf,
         entries: Vec<BrowserEntry>,
@@ -653,6 +658,15 @@ pub(crate) enum WorkerEvent {
         result: Result<(), String>,
     },
     ResourceStatsReady(Vec<ResourceStats>),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum PullTarget {
+    Project {
+        project_id: String,
+        project_name: String,
+    },
+    Session,
 }
 
 mod input;
@@ -743,6 +757,7 @@ impl App {
             terminal_return_to_list: false,
             terminal_counter: 0,
             create_agent_in_flight: false,
+            pulls_in_flight: HashSet::new(),
             resource_stats_in_flight: false,
             last_pty_size: (0, 0),
             last_pty_activity: HashMap::new(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -426,24 +426,18 @@ impl App {
             return Ok(());
         };
         logger::info(&format!("refreshing project {}", project.path));
-        let path = Path::new(&project.path);
-        if git::is_dirty(path)? {
-            self.set_error("Refresh blocked because the source checkout has uncommitted changes.");
-            return Ok(());
-        }
-        git::pull_current_branch(path)?;
-        if let Some(existing) = self
-            .projects
-            .iter_mut()
-            .find(|candidate| candidate.id == project.id)
-        {
-            existing.current_branch =
-                git::current_branch(path).unwrap_or_else(|_| existing.current_branch.clone());
-        }
-        self.set_info(format!(
-            "Refreshed project \"{}\" — local branch is up to date with remote.",
-            project.name,
-        ));
+        self.start_pull(
+            PathBuf::from(&project.path),
+            PullTarget::Project {
+                project_id: project.id,
+                project_name: project.name.clone(),
+            },
+            format!("Refreshing project \"{}\" from remote…", project.name),
+            format!(
+                "Project refresh already in progress for \"{}\". Wait for the current pull to finish.",
+                project.name,
+            ),
+        );
         Ok(())
     }
 

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -74,15 +74,45 @@ impl App {
                     ),
                     Err(e) => self.set_error(format!("Push to remote failed: {e}")),
                 },
-                WorkerEvent::PullCompleted(result) => match result {
-                    Ok(()) => {
-                        self.set_info(
-                            "Pulled latest changes from remote successfully. Local branch is up to date.",
-                        );
-                        self.reload_changed_files();
+                WorkerEvent::PullCompleted {
+                    repo_path,
+                    target,
+                    result,
+                } => {
+                    self.pulls_in_flight.remove(&repo_path);
+                    match target {
+                        PullTarget::Project {
+                            project_id,
+                            project_name,
+                        } => match result {
+                            Ok(branch_name) => {
+                                if let Some(existing) = self
+                                    .projects
+                                    .iter_mut()
+                                    .find(|candidate| candidate.id == project_id)
+                                    && let Some(branch_name) = branch_name
+                                {
+                                    existing.current_branch = branch_name;
+                                }
+                                self.set_info(format!(
+                                    "Refreshed project \"{}\". Local branch is up to date with remote.",
+                                    project_name,
+                                ));
+                            }
+                            Err(e) => self
+                                .set_error(format!("Project refresh failed for \"{}\": {e}", project_name)),
+                        },
+                        PullTarget::Session => match result {
+                            Ok(_) => {
+                                self.set_info(
+                                    "Pulled latest changes from remote successfully. Local branch is up to date.",
+                                );
+                                self.reload_changed_files();
+                            }
+                            Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
+                        },
                     }
-                    Err(e) => self.set_error(format!("Pull from remote failed: {e}")),
-                },
+                }
                 WorkerEvent::ClipboardCopyCompleted { path, result } => match result {
                     Ok(()) => {
                         self.set_info(format!("Copied path to clipboard: \"{path}\""))


### PR DESCRIPTION
- route project refreshes and session pulls through one async pull path
- block repeated pull triggers while the same repository is already syncing
- update project branch state when refresh jobs finish in the background
- add tests for duplicate pull protection and in-flight cleanup