### PR TITLE
Enable text selection and clipboard copy in interactive mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ When shelling out to git, **always ensure the command output is immune to user-s
 - The canonical config renderer produces a fully commented config on first creation. Subsequent saves preserve user edits via `toml_edit`. Users can run `dux config diff` to see what changed or `dux config regenerate` to get the latest canonical template.
 - When a setting can have a sensible default at first boot (e.g., the user's home directory, platform-specific paths), resolve and store the concrete value in `config.toml` right away — do not leave it commented out or empty. Users should see a working value they can edit, not a placeholder they have to fill in.
 - Preserve safe failure behavior around project refresh and failed agent startup.
+- **Never use byte-based `.len()` or `[..n]` slicing to truncate user-visible strings.** Terminal output, file paths, and UI text can contain multi-byte UTF-8 characters (box-drawing, block elements, CJK, emoji). Always use `.chars().count()` for length and `.chars().take(n).collect()` (or `char_indices().nth()`) for truncation. Byte-based slicing will panic if the index falls inside a multi-byte character.
 
 ## Verification
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3625,8 +3625,11 @@ impl App {
 
         let text = lines.join("\n");
         if !text.is_empty() {
-            let _ = self.clipboard.copy_text(&text, &self.worker_tx);
-            self.set_info("Terminal text copied to clipboard.");
+            let _ = self.clipboard.copy_text(
+                &text,
+                "Terminal text copied to clipboard.",
+                &self.worker_tx,
+            );
         }
     }
 }
@@ -4632,7 +4635,7 @@ mod tests {
         app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
-        assert!(app.status.text().contains("Copy path failed"));
+        assert!(app.status.text().contains("Clipboard copy failed"));
         assert!(app.status.text().contains("linux clipboard unavailable"));
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3626,7 +3626,7 @@ impl App {
         let text = lines.join("\n");
         if !text.is_empty() {
             let _ = self.clipboard.copy_text(&text, &self.worker_tx);
-            self.set_info("Copied selection to clipboard.");
+            self.set_info("Terminal text copied to clipboard.");
         }
     }
 }
@@ -4589,13 +4589,12 @@ mod tests {
         app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
-        assert!(app.status.text().contains(&worktree_path));
+        assert_eq!(app.status.text(), "Agent's path copied to clipboard.");
     }
 
     #[test]
     fn copy_path_copies_selected_project_path() {
         let mut app = test_app(default_bindings());
-        let project_path = app.projects[0].path.clone();
         app.selected_left = 0;
         app.clipboard = Clipboard::from_fn(clipboard_ok);
 
@@ -4604,7 +4603,7 @@ mod tests {
         app.drain_events();
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
-        assert!(app.status.text().contains(&project_path));
+        assert_eq!(app.status.text(), "Agent's path copied to clipboard.");
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -927,12 +927,14 @@ impl App {
         // Verify we have an active session/provider.
         if self.selected_session().is_none() {
             self.input_target = InputTarget::None;
+            self.terminal_selection = None;
             self.raw_input_buf.clear();
             return Ok(false);
         }
         let surface = self.session_surface;
         if self.selected_terminal_surface_client().is_none() {
             self.input_target = InputTarget::None;
+            self.terminal_selection = None;
             self.raw_input_buf.clear();
             let label = match surface {
                 SessionSurface::Agent => "Agent",
@@ -1045,6 +1047,7 @@ impl App {
                         previous_input_target: prev,
                     });
                     self.input_target = InputTarget::None;
+                    self.terminal_selection = None;
                     self.raw_input_buf.clear();
                     return Ok(false);
                 }
@@ -1055,6 +1058,7 @@ impl App {
                     self.input_target = InputTarget::None;
                     self.fullscreen_overlay = FullscreenOverlay::None;
                     self.session_surface = SessionSurface::Agent;
+                    self.terminal_selection = None;
                     self.raw_input_buf.clear();
                     if return_to_terminal_list {
                         self.left_section = LeftSection::Terminals;
@@ -1113,6 +1117,7 @@ impl App {
                             | MouseEventKind::ScrollRight
                     );
                     if is_scroll {
+                        self.terminal_selection = None;
                         // Check if the provider has forward_scroll enabled
                         // (only applies to agents, not companion terminals).
                         let forward = matches!(self.input_target, InputTarget::Agent)
@@ -1145,6 +1150,7 @@ impl App {
                             self.fullscreen_overlay = FullscreenOverlay::None;
                             self.session_surface = SessionSurface::Agent;
                             self.raw_input_buf.clear();
+                            self.terminal_selection = None;
                             if return_to_terminal_list {
                                 self.left_section = LeftSection::Terminals;
                                 self.clamp_terminal_cursor();
@@ -1154,20 +1160,21 @@ impl App {
                             return Ok(false);
                         }
 
-                        if !is_scrolled_back {
-                            // Non-scroll events (clicks, drags, moves,
-                            // releases): only forward when the child process
-                            // has opted into mouse tracking (e.g. vim, htop).
-                            // Otherwise drop — the child would echo the raw
-                            // SGR bytes as garbage text.
-                            let child_wants_mouse = self
-                                .selected_terminal_surface_client()
-                                .is_some_and(|p| p.has_mouse_mode());
-                            if child_wants_mouse
-                                && let Some(provider) = self.selected_terminal_surface_client()
-                            {
-                                let _ = provider.write_bytes(&raw);
-                            }
+                        let child_wants_mouse = self
+                            .selected_terminal_surface_client()
+                            .is_some_and(|p| p.has_mouse_mode());
+                        let shift_held = mouse_ev
+                            .modifiers
+                            .contains(crossterm::event::KeyModifiers::SHIFT);
+                        let should_select = !child_wants_mouse || shift_held;
+
+                        if should_select {
+                            self.handle_terminal_selection_mouse(mouse_ev);
+                        } else if child_wants_mouse
+                            && !is_scrolled_back
+                            && let Some(provider) = self.selected_terminal_surface_client()
+                        {
+                            let _ = provider.write_bytes(&raw);
                         }
                     }
                 }
@@ -1175,6 +1182,7 @@ impl App {
                     // Unknown intercepted action or normal forward — send to PTY,
                     // but only when not scrolled back. In scroll mode, all
                     // non-scroll input is suppressed.
+                    self.terminal_selection = None;
                     if !is_scrolled_back
                         && let Some(provider) = self.selected_terminal_surface_client()
                     {
@@ -3486,6 +3494,141 @@ impl App {
         }
         false
     }
+
+    // -- Terminal text selection helpers --
+
+    /// Map screen coordinates to terminal grid position.
+    /// Returns `None` if the point is outside the terminal area.
+    fn screen_to_grid(&self, screen_col: u16, screen_row: u16) -> Option<TermGridPos> {
+        let term_area = self.mouse_layout.agent_term?;
+        if !contains_point(term_area, screen_col, screen_row) {
+            return None;
+        }
+        Some(TermGridPos {
+            row: screen_row - term_area.y,
+            col: screen_col - term_area.x,
+        })
+    }
+
+    /// Map screen coordinates to terminal grid position, clamping to the
+    /// terminal area edges. Used during drag so the selection extends to the
+    /// nearest boundary when the mouse leaves the terminal area.
+    fn screen_to_grid_clamped(&self, screen_col: u16, screen_row: u16) -> Option<TermGridPos> {
+        let term_area = self.mouse_layout.agent_term?;
+        let col = screen_col
+            .max(term_area.x)
+            .min(term_area.x + term_area.width.saturating_sub(1))
+            - term_area.x;
+        let row = screen_row
+            .max(term_area.y)
+            .min(term_area.y + term_area.height.saturating_sub(1))
+            - term_area.y;
+        Some(TermGridPos { row, col })
+    }
+
+    /// Handle a mouse event for terminal text selection (click, drag, release).
+    fn handle_terminal_selection_mouse(&mut self, mouse_ev: MouseEvent) {
+        match mouse_ev.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(pos) = self.screen_to_grid(mouse_ev.column, mouse_ev.row) {
+                    self.terminal_selection = Some(TerminalSelection {
+                        anchor: pos,
+                        end: pos,
+                        dragging: true,
+                    });
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                let pos = self.screen_to_grid_clamped(mouse_ev.column, mouse_ev.row);
+                if let Some(sel) = &mut self.terminal_selection {
+                    if sel.dragging {
+                        if let Some(pos) = pos {
+                            sel.end = pos;
+                        }
+                    }
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(sel) = &mut self.terminal_selection {
+                    if sel.dragging {
+                        sel.dragging = false;
+                        if sel.anchor == sel.end {
+                            // Single click, no actual selection.
+                            self.terminal_selection = None;
+                        } else {
+                            self.copy_terminal_selection();
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Extract text from the terminal snapshot within the active selection
+    /// and copy it to the system clipboard.
+    fn copy_terminal_selection(&mut self) {
+        let sel = match self.terminal_selection.clone() {
+            Some(s) => s,
+            None => return,
+        };
+        let (start, end) = sel.ordered();
+
+        // Refresh snapshot to get current content.
+        self.refresh_snapshot_buf();
+
+        let mut lines: Vec<String> = Vec::new();
+        let mut current_row = start.row;
+        let mut current_line = String::new();
+
+        for cell in &self.snapshot_buf.cells {
+            if !sel.contains(cell.row, cell.col) {
+                continue;
+            }
+            if cell.row != current_row {
+                // Flush the previous line (trim trailing whitespace).
+                lines.push(current_line.trim_end().to_string());
+                // Insert empty lines for any gap rows.
+                for _ in (current_row + 1)..cell.row {
+                    lines.push(String::new());
+                }
+                current_line = String::new();
+                current_row = cell.row;
+            }
+            // Pad with spaces if columns are not contiguous (sparse cells).
+            let expected_col = if current_line.is_empty() {
+                start.col.min(cell.col)
+            } else {
+                // Approximate: one char per column.
+                let line_cols = current_line.chars().count() as u16;
+                if cell.row == start.row {
+                    start.col + line_cols
+                } else {
+                    line_cols
+                }
+            };
+            if cell.col > expected_col {
+                for _ in 0..(cell.col - expected_col) {
+                    current_line.push(' ');
+                }
+            }
+            current_line.push_str(&cell.symbol);
+        }
+        // Flush last line.
+        if !current_line.is_empty() || !lines.is_empty() {
+            lines.push(current_line.trim_end().to_string());
+            // Fill gap rows between last populated row and end.
+            for _ in (current_row + 1)..=end.row {
+                lines.push(String::new());
+            }
+        }
+
+        let text = lines.join("\n");
+        if !text.is_empty() {
+            let _ = self.clipboard.copy_text(&text, &self.worker_tx);
+            self.set_info("Copied selection to clipboard.");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -3494,6 +3637,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex, mpsc};
 
+    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::app::{
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
@@ -3501,7 +3645,6 @@ mod tests {
         OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget, RightSection,
         RuntimeTargetId, TextInput, WorkerEvent,
     };
-    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};
@@ -3681,6 +3824,7 @@ mod tests {
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
+            terminal_selection: None,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -155,6 +155,8 @@ pub struct App {
     /// ID of the provider that last populated `snapshot_buf`, used to detect
     /// agent switches and force a snapshot rebuild.
     last_snapshot_id: Option<String>,
+    /// Active text selection in the terminal viewport, if any.
+    pub(crate) terminal_selection: Option<TerminalSelection>,
 }
 
 /// Snapshot of session data shared with the branch-sync background worker.
@@ -490,6 +492,56 @@ pub(crate) enum InputTarget {
 pub(crate) enum ScrollDirection {
     Up,
     Down,
+}
+
+/// A position within the terminal grid (0-based row and column).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TermGridPos {
+    pub row: u16,
+    pub col: u16,
+}
+
+/// Active text selection in the terminal viewport.
+#[derive(Clone, Debug)]
+pub(crate) struct TerminalSelection {
+    /// Where the drag started (anchor). Fixed during drag.
+    pub anchor: TermGridPos,
+    /// Current end of selection. Moves during drag.
+    pub end: TermGridPos,
+    /// True while the mouse button is held (still dragging).
+    pub dragging: bool,
+}
+
+impl TerminalSelection {
+    /// Returns (start, end) in reading order (top-left to bottom-right).
+    pub fn ordered(&self) -> (TermGridPos, TermGridPos) {
+        if self.anchor.row < self.end.row
+            || (self.anchor.row == self.end.row && self.anchor.col <= self.end.col)
+        {
+            (self.anchor, self.end)
+        } else {
+            (self.end, self.anchor)
+        }
+    }
+
+    /// Returns true if the given (row, col) is within the selection.
+    /// Uses line-based (not rectangular) selection semantics.
+    pub fn contains(&self, row: u16, col: u16) -> bool {
+        let (start, end) = self.ordered();
+        if row < start.row || row > end.row {
+            return false;
+        }
+        if start.row == end.row {
+            return col >= start.col && col <= end.col;
+        }
+        if row == start.row {
+            return col >= start.col;
+        }
+        if row == end.row {
+            return col <= end.col;
+        }
+        true // middle rows are fully selected
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -834,6 +886,7 @@ impl App {
             syntax_cache: SyntaxCache::new(),
             snapshot_buf: TerminalSnapshot::empty(),
             last_snapshot_id: None,
+            terminal_selection: None,
         };
         app.restore_sessions();
         app.seed_pr_statuses_from_db();
@@ -1795,6 +1848,7 @@ impl App {
             if self.last_snapshot_id.as_deref() != Some(&client_id) {
                 provider.mark_dirty();
                 self.last_snapshot_id = Some(client_id);
+                self.terminal_selection = None;
             }
             provider.snapshot_into(&mut self.snapshot_buf);
             true
@@ -1990,5 +2044,95 @@ mod tests {
         let self_pid = Pid::from_u32(std::process::id());
         let init_pid = Pid::from_u32(1);
         assert!(!is_descendant_of(&sys, init_pid, self_pid));
+    }
+
+    #[test]
+    fn terminal_selection_ordered_forward() {
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 2, col: 5 },
+            end: TermGridPos { row: 4, col: 10 },
+            dragging: false,
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, TermGridPos { row: 2, col: 5 });
+        assert_eq!(end, TermGridPos { row: 4, col: 10 });
+    }
+
+    #[test]
+    fn terminal_selection_ordered_reverse() {
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 4, col: 10 },
+            end: TermGridPos { row: 2, col: 5 },
+            dragging: false,
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, TermGridPos { row: 2, col: 5 });
+        assert_eq!(end, TermGridPos { row: 4, col: 10 });
+    }
+
+    #[test]
+    fn terminal_selection_ordered_same_row() {
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 3, col: 15 },
+            end: TermGridPos { row: 3, col: 5 },
+            dragging: false,
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, TermGridPos { row: 3, col: 5 });
+        assert_eq!(end, TermGridPos { row: 3, col: 15 });
+    }
+
+    #[test]
+    fn terminal_selection_contains_single_row() {
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 3, col: 5 },
+            end: TermGridPos { row: 3, col: 10 },
+            dragging: false,
+        };
+        assert!(sel.contains(3, 5));
+        assert!(sel.contains(3, 7));
+        assert!(sel.contains(3, 10));
+        assert!(!sel.contains(3, 4));
+        assert!(!sel.contains(3, 11));
+        assert!(!sel.contains(2, 7));
+        assert!(!sel.contains(4, 7));
+    }
+
+    #[test]
+    fn terminal_selection_contains_multi_row() {
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 2, col: 10 },
+            end: TermGridPos { row: 4, col: 5 },
+            dragging: false,
+        };
+        // First row: from anchor col to end of line.
+        assert!(sel.contains(2, 10));
+        assert!(sel.contains(2, 50));
+        assert!(!sel.contains(2, 9));
+        // Middle row: fully selected.
+        assert!(sel.contains(3, 0));
+        assert!(sel.contains(3, 100));
+        // Last row: from start of line to end col.
+        assert!(sel.contains(4, 0));
+        assert!(sel.contains(4, 5));
+        assert!(!sel.contains(4, 6));
+        // Outside rows.
+        assert!(!sel.contains(1, 10));
+        assert!(!sel.contains(5, 0));
+    }
+
+    #[test]
+    fn terminal_selection_contains_reverse_anchor() {
+        // Anchor after end — should still work via ordered().
+        let sel = TerminalSelection {
+            anchor: TermGridPos { row: 4, col: 5 },
+            end: TermGridPos { row: 2, col: 10 },
+            dragging: false,
+        };
+        assert!(sel.contains(2, 10));
+        assert!(sel.contains(3, 0));
+        assert!(sel.contains(4, 5));
+        assert!(!sel.contains(2, 9));
+        assert!(!sel.contains(4, 6));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -729,7 +729,8 @@ pub(crate) enum WorkerEvent {
         entries: Vec<BrowserEntry>,
     },
     ClipboardCopyCompleted {
-        path: String,
+        /// Human-readable success message shown in the status bar.
+        label: String,
         result: Result<(), String>,
     },
     BranchSyncReady(Vec<(String, String)>),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1876,11 +1876,13 @@ impl App {
                             )];
                             let desc_avail = inner_w.saturating_sub(name_col + gap);
                             let desc = binding.palette_description.unwrap_or("");
-                            let desc_display = if desc.len() > desc_avail && desc_avail > 1 {
-                                format!("  {}\u{2026}", &desc[..desc_avail - 1])
-                            } else {
-                                format!("  {desc:desc_avail$}")
-                            };
+                            let desc_display =
+                                if desc.chars().count() > desc_avail && desc_avail > 1 {
+                                    let end: String = desc.chars().take(desc_avail - 1).collect();
+                                    format!("  {end}\u{2026}")
+                                } else {
+                                    format!("  {desc:desc_avail$}")
+                                };
                             spans.push(Span::styled(
                                 desc_display,
                                 Style::default().fg(self.theme.hint_desc_fg),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1584,14 +1584,10 @@ impl App {
             StatusTone::Error => self.theme.status_error_bg,
         };
         let prefix = format!(" {dot} ");
-        let prefix_w = prefix.len();
+        let prefix_w = prefix.chars().count();
         let max_status_chars = (status_area.width as usize) * (status_area.height as usize);
         let available = max_status_chars.saturating_sub(prefix_w);
-        let truncated = if status_text.len() > available && available > 1 {
-            format!("{}…", &status_text[..available - 1])
-        } else {
-            status_text
-        };
+        let truncated = truncate_status_text(&status_text, available);
         let status_line = Line::from(vec![
             Span::styled(prefix, Style::default().fg(dot_color).bg(status_bg)),
             Span::styled(truncated, Style::default().fg(msg_color).bg(status_bg)),
@@ -4317,6 +4313,19 @@ fn set_cell(buf: &mut ratatui::buffer::Buffer, x: u16, y: u16, symbol: &str, sty
     buf[(x, y)].set_symbol(symbol).set_style(style);
 }
 
+/// Truncate `text` to at most `available` **characters**, appending `…` when
+/// trimmed. Using char-based counting avoids panics when the text contains
+/// multi-byte UTF-8 (e.g. box-drawing or block characters).
+fn truncate_status_text(text: &str, available: usize) -> String {
+    if text.chars().count() > available && available > 1 {
+        let mut truncated: String = text.chars().take(available - 1).collect();
+        truncated.push('…');
+        truncated
+    } else {
+        text.to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4495,5 +4504,55 @@ mod tests {
     fn format_bytes_gib_range() {
         assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GiB");
         assert_eq!(format_bytes(1024 * 1024 * 1024 * 3), "3.0 GiB");
+    }
+
+    #[test]
+    fn truncate_status_text_ascii_short_enough() {
+        assert_eq!(truncate_status_text("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_status_text_ascii_exact_fit() {
+        assert_eq!(truncate_status_text("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_status_text_ascii_truncated() {
+        assert_eq!(truncate_status_text("hello world", 6), "hello…");
+    }
+
+    #[test]
+    fn truncate_status_text_multibyte_no_panic() {
+        // Box-drawing char ─ is 3 bytes but 1 char.
+        let text = "Copied: ─────end";
+        let result = truncate_status_text(text, 10);
+        assert_eq!(result.chars().count(), 10);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_status_text_block_characters() {
+        // Block characters like ██▛▘ are multi-byte; slicing by byte would panic.
+        let text = "██▛▘ Opus 4.6 (1M context) · Claude Max";
+        let result = truncate_status_text(text, 12);
+        assert_eq!(result.chars().count(), 12);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_status_text_available_zero() {
+        // Edge case: zero available should not panic.
+        assert_eq!(truncate_status_text("hello", 0), "hello");
+    }
+
+    #[test]
+    fn truncate_status_text_available_one() {
+        // With only 1 char available, no room for truncation marker.
+        assert_eq!(truncate_status_text("hello", 1), "hello");
+    }
+
+    #[test]
+    fn truncate_status_text_empty_input() {
+        assert_eq!(truncate_status_text("", 10), "");
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -984,6 +984,13 @@ impl App {
                     let ratatui_cell = &mut buf[(x, y)];
                     ratatui_cell.set_symbol(&cell.symbol);
                     ratatui_cell.set_style(style);
+
+                    // Overlay selection highlight if this cell is selected.
+                    if let Some(sel) = &self.terminal_selection {
+                        if sel.contains(cell.row, cell.col) {
+                            ratatui_cell.set_style(self.theme.selection_style());
+                        }
+                    }
                 }
 
                 // Render cursor if in input mode.

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -729,7 +729,11 @@ impl App {
         };
         match path {
             Some(p) => {
-                match self.clipboard.copy_text(&p, &self.worker_tx) {
+                match self.clipboard.copy_text(
+                    &p,
+                    "Agent's path copied to clipboard.",
+                    &self.worker_tx,
+                ) {
                     Ok(()) => self.set_busy("Copying path to clipboard…"),
                     Err(e) => self.set_error(format!("Copy path failed: {e}")),
                 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -730,7 +730,7 @@ impl App {
         match path {
             Some(p) => {
                 match self.clipboard.copy_text(&p, &self.worker_tx) {
-                    Ok(()) => self.set_busy(format!("Copying path to clipboard: \"{p}\"…")),
+                    Ok(()) => self.set_busy("Copying path to clipboard…"),
                     Err(e) => self.set_error(format!("Copy path failed: {e}")),
                 }
                 Ok(())

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -113,9 +113,9 @@ impl App {
                         },
                     }
                 }
-                WorkerEvent::ClipboardCopyCompleted { result, .. } => match result {
-                    Ok(()) => self.set_info("Agent's path copied to clipboard."),
-                    Err(e) => self.set_error(format!("Copy path failed: {e}")),
+                WorkerEvent::ClipboardCopyCompleted { label, result } => match result {
+                    Ok(()) => self.set_info(label),
+                    Err(e) => self.set_error(format!("Clipboard copy failed: {e}")),
                 },
                 WorkerEvent::BranchRenameCompleted {
                     session_id,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -113,10 +113,8 @@ impl App {
                         },
                     }
                 }
-                WorkerEvent::ClipboardCopyCompleted { path, result } => match result {
-                    Ok(()) => {
-                        self.set_info(format!("Copied path to clipboard: \"{path}\""))
-                    }
+                WorkerEvent::ClipboardCopyCompleted { result, .. } => match result {
+                    Ok(()) => self.set_info("Agent's path copied to clipboard."),
                     Err(e) => self.set_error(format!("Copy path failed: {e}")),
                 },
                 WorkerEvent::BranchRenameCompleted {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -424,8 +424,9 @@ fn diff_providers(changes: &mut Vec<String>, defaults: &Config, current: &Config
 fn truncate_display(s: &str, max: usize) -> String {
     // For multiline values just show first line.
     let first_line = s.lines().next().unwrap_or(s);
-    if first_line.len() > max {
-        format!("{}...", &first_line[..max])
+    if first_line.chars().count() > max {
+        let truncated: String = first_line.chars().take(max).collect();
+        format!("{truncated}...")
     } else if s.contains('\n') {
         format!("{first_line}...")
     } else {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -7,6 +7,7 @@ use crate::app::WorkerEvent;
 /// Request sent from the main thread to the clipboard worker.
 struct CopyRequest {
     text: String,
+    label: String,
     worker_tx: mpsc::Sender<WorkerEvent>,
 }
 
@@ -34,14 +35,19 @@ impl Clipboard {
 
     /// Send a clipboard copy request. Returns immediately — the result will
     /// arrive later as a `WorkerEvent::ClipboardCopyCompleted`.
+    ///
+    /// `label` is the human-readable success message shown in the status bar
+    /// when the copy completes.
     pub(crate) fn copy_text(
         &self,
         text: &str,
+        label: &str,
         worker_tx: &mpsc::Sender<WorkerEvent>,
     ) -> Result<()> {
         self.tx
             .send(CopyRequest {
                 text: text.to_string(),
+                label: label.to_string(),
                 worker_tx: worker_tx.clone(),
             })
             .map_err(|_| anyhow!("Clipboard worker thread is not running"))?;
@@ -58,7 +64,7 @@ impl Clipboard {
                 while let Ok(req) = rx.recv() {
                     let result = (copy_text_fn)(&req.text).map_err(|e| e.to_string());
                     let _ = req.worker_tx.send(WorkerEvent::ClipboardCopyCompleted {
-                        path: req.text,
+                        label: req.label,
                         result,
                     });
                 }
@@ -78,7 +84,7 @@ fn clipboard_worker(rx: mpsc::Receiver<CopyRequest>) {
             let msg = format!("Failed to access clipboard: {e}");
             for req in rx {
                 let _ = req.worker_tx.send(WorkerEvent::ClipboardCopyCompleted {
-                    path: req.text,
+                    label: req.label,
                     result: Err(msg.clone()),
                 });
             }
@@ -91,7 +97,7 @@ fn clipboard_worker(rx: mpsc::Receiver<CopyRequest>) {
             .set_text(&req.text)
             .map_err(|e| format!("Failed to copy to clipboard: {e}"));
         let _ = req.worker_tx.send(WorkerEvent::ClipboardCopyCompleted {
-            path: req.text,
+            label: req.label,
             result,
         });
     }
@@ -105,12 +111,12 @@ mod tests {
     fn clipboard_from_fn_sends_and_receives() {
         let (worker_tx, worker_rx) = mpsc::channel();
         let clipboard = Clipboard::from_fn(|_| Ok(()));
-        clipboard.copy_text("hello", &worker_tx).unwrap();
+        clipboard.copy_text("hello", "Copied.", &worker_tx).unwrap();
 
         let event = worker_rx.recv().unwrap();
         match event {
-            WorkerEvent::ClipboardCopyCompleted { path, result } => {
-                assert_eq!(path, "hello");
+            WorkerEvent::ClipboardCopyCompleted { label, result } => {
+                assert_eq!(label, "Copied.");
                 assert!(result.is_ok());
             }
             _ => panic!("unexpected event"),
@@ -121,12 +127,12 @@ mod tests {
     fn clipboard_from_fn_reports_errors() {
         let (worker_tx, worker_rx) = mpsc::channel();
         let clipboard = Clipboard::from_fn(|_| Err(anyhow!("test error")));
-        clipboard.copy_text("hello", &worker_tx).unwrap();
+        clipboard.copy_text("hello", "Copied.", &worker_tx).unwrap();
 
         let event = worker_rx.recv().unwrap();
         match event {
-            WorkerEvent::ClipboardCopyCompleted { path, result } => {
-                assert_eq!(path, "hello");
+            WorkerEvent::ClipboardCopyCompleted { label, result } => {
+                assert_eq!(label, "Copied.");
                 assert!(result.unwrap_err().contains("test error"));
             }
             _ => panic!("unexpected event"),

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 /// Returns `true` if the byte sequence is an SGR mouse event (`\x1b[<…M` or
 /// `\x1b[<…m`).
@@ -38,6 +38,18 @@ pub fn parse_sgr_mouse(seq: &[u8]) -> Option<MouseEvent> {
     let is_motion = cb & 32 != 0;
     let button_bits = cb & 0b11000011; // mask out motion bit (bit 5) and modifier bits (4,3)
 
+    // Extract modifier keys from SGR button byte (bits 2, 3, 4).
+    let mut modifiers = KeyModifiers::empty();
+    if cb & 4 != 0 {
+        modifiers |= KeyModifiers::SHIFT;
+    }
+    if cb & 8 != 0 {
+        modifiers |= KeyModifiers::ALT;
+    }
+    if cb & 16 != 0 {
+        modifiers |= KeyModifiers::CONTROL;
+    }
+
     let kind = if cb & 64 != 0 {
         // Scroll events.
         match button_bits & 0x03 {
@@ -65,7 +77,7 @@ pub fn parse_sgr_mouse(seq: &[u8]) -> Option<MouseEvent> {
                     kind: MouseEventKind::Moved,
                     column,
                     row,
-                    modifiers: crossterm::event::KeyModifiers::empty(),
+                    modifiers,
                 });
             }
             _ => return None,
@@ -85,7 +97,7 @@ pub fn parse_sgr_mouse(seq: &[u8]) -> Option<MouseEvent> {
         kind,
         column,
         row,
-        modifiers: crossterm::event::KeyModifiers::empty(),
+        modifiers,
     })
 }
 
@@ -532,5 +544,66 @@ mod tests {
         assert!(!is_sgr_mouse(b"\x1b[A"));
         assert!(!is_sgr_mouse(b"\x1b[5~"));
         assert!(parse_sgr_mouse(b"\x1b[A").is_none());
+    }
+
+    #[test]
+    fn parse_sgr_mouse_no_modifiers() {
+        // Left click at (50,10): ESC [ < 0 ; 50 ; 10 M
+        let seq = b"\x1b[<0;50;10M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Left));
+        assert_eq!(ev.column, 49);
+        assert_eq!(ev.row, 9);
+        assert!(ev.modifiers.is_empty());
+    }
+
+    #[test]
+    fn parse_sgr_mouse_shift_modifier() {
+        // Shift+left click: cb = 0 | 4 = 4
+        let seq = b"\x1b[<4;10;5M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Left));
+        assert!(ev.modifiers.contains(KeyModifiers::SHIFT));
+        assert!(!ev.modifiers.contains(KeyModifiers::ALT));
+        assert!(!ev.modifiers.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn parse_sgr_mouse_ctrl_modifier() {
+        // Ctrl+left click: cb = 0 | 16 = 16
+        let seq = b"\x1b[<16;10;5M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Left));
+        assert!(!ev.modifiers.contains(KeyModifiers::SHIFT));
+        assert!(ev.modifiers.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn parse_sgr_mouse_shift_alt_ctrl() {
+        // All modifiers: cb = 0 | 4 | 8 | 16 = 28
+        let seq = b"\x1b[<28;10;5M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Down(MouseButton::Left));
+        assert!(ev.modifiers.contains(KeyModifiers::SHIFT));
+        assert!(ev.modifiers.contains(KeyModifiers::ALT));
+        assert!(ev.modifiers.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn parse_sgr_mouse_shift_drag() {
+        // Shift+left drag: cb = 32 (motion) | 4 (shift) = 36
+        let seq = b"\x1b[<36;20;10M";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Drag(MouseButton::Left));
+        assert!(ev.modifiers.contains(KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn parse_sgr_mouse_shift_release() {
+        // Shift+left release: cb = 4, final byte = 'm'
+        let seq = b"\x1b[<4;10;5m";
+        let ev = parse_sgr_mouse(seq).unwrap();
+        assert_eq!(ev.kind, MouseEventKind::Up(MouseButton::Left));
+        assert!(ev.modifiers.contains(KeyModifiers::SHIFT));
     }
 }


### PR DESCRIPTION
In fullscreen (interactive) mode, non-scroll mouse events were previously either forwarded to the child PTY (when the child had mouse tracking enabled) or silently dropped. This meant users had no way to highlight and copy text from terminal output while in interactive mode. This PR adds click-drag text selection with automatic clipboard copy on mouse release, matching the behavior users expect from standard terminal emulators.

When the child process has **not** enabled mouse tracking (the common case for tools like `claude` or `codex`), left-click and drag now selects text directly. When the child **has** enabled mouse tracking (e.g. `vim`, `htop`), holding **Shift** while clicking overrides the forwarding and allows selection instead — this is the same convention used by iTerm2, Alacritty, and other terminal emulators. Selected text is rendered with the existing `selection_style()` highlight (black on cyan) and is automatically copied to the system clipboard when the mouse button is released. The selection is cleared on any keyboard input, scrolling, exiting interactive mode, or switching sessions.

To support the Shift override, SGR mouse modifier bits (Shift, Alt, Ctrl) are now properly extracted from the button byte — they were previously discarded. This is a standalone improvement that also makes the modifier data available for future mouse-related features.

Status bar text truncation previously used byte-based slicing, which panicked when the copied text contained multi-byte UTF-8 characters (box-drawing lines, block elements). The truncation logic now uses char-aware counting and is extracted into a testable `truncate_status_text()` helper. Additionally, status messages no longer embed raw copied text — terminal selections can contain arbitrary characters that break rendering. The messages now read "Terminal text copied to clipboard." and "Agent's path copied to clipboard." instead.

The PR includes 20 new unit tests covering modifier parsing, line-based selection containment, and char-safe status text truncation (including multi-byte edge cases).