### PR TITLE
Add command palette toggle for prompt-for-name setting

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1348,6 +1348,20 @@ impl App {
                 self.set_info(format!("GitHub integration {state}."));
                 Ok(())
             }
+            "toggle-prompt-for-name" => {
+                self.config.defaults.prompt_for_name = !self.config.defaults.prompt_for_name;
+                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+                let state = if self.config.defaults.prompt_for_name {
+                    "enabled — you'll be prompted for a name"
+                } else {
+                    "disabled — random names will be generated"
+                };
+                let palette_key = self.bindings.label_for(Action::OpenPalette);
+                self.set_info(format!(
+                    "Prompt for agent name {state}. Press {palette_key} to toggle back."
+                ));
+                Ok(())
+            }
             "force-redraw" => {
                 self.force_redraw = true;
                 self.set_info("Interface redrawn. All screen contents have been repainted.");

--- a/src/config.rs
+++ b/src/config.rs
@@ -743,6 +743,12 @@ pub fn save_config(
         "commit_prompt",
         config.defaults.commit_prompt.as_deref(),
     );
+    patch_table_bool(
+        &mut doc,
+        "defaults",
+        "prompt_for_name",
+        config.defaults.prompt_for_name,
+    );
 
     // --- [logging] ---
     patch_table_str(&mut doc, "logging", "level", &config.logging.level);

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -81,6 +81,7 @@ pub enum Action {
     ToggleDiffLineNumbers,
     ResourceMonitor,
     ToggleGithubIntegration,
+    TogglePromptForName,
 }
 
 /// Where a binding's key combo is matched.
@@ -241,6 +242,7 @@ impl Action {
             Action::ToggleDiffLineNumbers => "toggle_diff_line_numbers",
             Action::ResourceMonitor => "resource_monitor",
             Action::ToggleGithubIntegration => "toggle_github_integration",
+            Action::TogglePromptForName => "toggle_prompt_for_name",
         }
     }
 
@@ -323,6 +325,7 @@ impl Action {
             Action::ToggleDiffLineNumbers => "Toggle line numbers in diff view.",
             Action::ResourceMonitor => "Show CPU and memory usage for dux and all running agents.",
             Action::ToggleGithubIntegration => "Toggle GitHub PR integration.",
+            Action::TogglePromptForName => "Toggle prompting for agent name before creation.",
         }
     }
 
@@ -395,7 +398,8 @@ impl Action {
             | Action::DebugInput
             | Action::ToggleDiffLineNumbers
             | Action::ResourceMonitor
-            | Action::ToggleGithubIntegration => None,
+            | Action::ToggleGithubIntegration
+            | Action::TogglePromptForName => None,
         }
     }
 }
@@ -1321,6 +1325,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "toggle-github-integration",
             description: "Toggle GitHub PR integration",
+        }),
+    },
+    BindingDef {
+        action: Action::TogglePromptForName,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "toggle-prompt-for-name",
+            description: "Toggle prompting for agent name before creation",
         }),
     },
 ];


### PR DESCRIPTION
The `prompt_for_name` config option controls whether users are prompted for a custom agent name or receive an auto-generated petname. Until now, changing this setting required manually editing `config.toml`. This PR adds a `toggle-prompt-for-name` entry to the command palette (Ctrl+P), following the same pattern used by `toggle-diff-line-numbers` and `toggle-github-integration`.

Toggling the setting flips `config.defaults.prompt_for_name` at runtime, persists the change to `config.toml` via `save_config()`, and shows a descriptive status message indicating the new state. This also fixes a pre-existing bug where `prompt_for_name` was **not included** in the `save_config()` patch list, meaning runtime changes to the `[defaults]` section would silently skip this field.

Changes span three files: `src/keybindings.rs` (new `TogglePromptForName` action variant and palette-only binding definition), `src/app/mod.rs` (command handler in `execute_command()`), and `src/config.rs` (`patch_table_bool` call added to the `[defaults]` section of `save_config()`).