### PR TITLE
Fix tab characters rendering as invisible in diff view

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3494,6 +3494,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex, mpsc};
 
+    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::app::{
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
@@ -3501,7 +3502,6 @@ mod tests {
         OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget, RightSection,
         RuntimeTargetId, TextInput, WorkerEvent,
     };
-    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -681,6 +681,7 @@ impl App {
             &self.theme,
             &self.syntax_cache,
             self.show_diff_line_numbers,
+            self.config.ui.diff_tab_width,
         )?;
         self.center_mode = CenterMode::Diff {
             lines: Arc::new(output.lines),
@@ -709,6 +710,7 @@ impl App {
             &self.theme,
             &self.syntax_cache,
             self.show_diff_line_numbers,
+            self.config.ui.diff_tab_width,
         )?;
         self.center_mode = CenterMode::Diff {
             lines: Arc::new(output.lines),

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,6 +192,7 @@ pub struct UiConfig {
     pub agent_scrollback_lines: usize,
     pub branch_sync_interval: u16,
     pub show_diff_line_numbers: bool,
+    pub diff_tab_width: u16,
     pub github_integration: bool,
 }
 
@@ -215,6 +216,7 @@ impl Default for Config {
                 agent_scrollback_lines: 10_000,
                 branch_sync_interval: 30,
                 show_diff_line_numbers: false,
+                diff_tab_width: 4,
                 github_integration: true,
             },
             editor: EditorConfig::default(),
@@ -336,6 +338,7 @@ impl Default for UiConfig {
             agent_scrollback_lines: 10_000,
             branch_sync_interval: 30,
             show_diff_line_numbers: false,
+            diff_tab_width: 4,
             github_integration: true,
         }
     }
@@ -599,6 +602,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             value_fn: |c| FieldValue::Bool(c.ui.show_diff_line_numbers),
         },
         ConfigEntry::Field {
+            key: "diff_tab_width",
+            comment: Some(CommentSource::Static(
+                "# Number of spaces used to render tab characters in diffs.\n# Set to 0 to leave tabs as-is (they may render as zero-width).",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.diff_tab_width),
+        },
+        ConfigEntry::Field {
             key: "github_integration",
             comment: Some(CommentSource::Static(
                 "# Enable GitHub PR tracking for agent sessions.\n# Requires the `gh` CLI installed and authenticated (`gh auth login`).\n# When enabled, a PR pill is shown in the agent pane for branches with\n# an open, merged, or closed pull request. Toggle at runtime from the\n# command palette.",
@@ -787,6 +797,7 @@ pub fn save_config(
         "show_diff_line_numbers",
         config.ui.show_diff_line_numbers,
     );
+    patch_table_u16(&mut doc, "ui", "diff_tab_width", config.ui.diff_tab_width);
     patch_table_bool(
         &mut doc,
         "ui",

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -41,6 +41,7 @@ pub fn diff_file(
     theme: &AppTheme,
     cache: &SyntaxCache,
     show_line_numbers: bool,
+    diff_tab_width: u16,
 ) -> Result<DiffOutput> {
     let old_bytes = crate::git::file_bytes_at_head(worktree_path, rel_path)?.unwrap_or_default();
     let abs_path = worktree_path.join(rel_path);
@@ -152,7 +153,7 @@ pub fn diff_file(
             };
 
             // Attempt syntax highlighting; fall back to plain coloring.
-            let content = text.trim_end_matches('\n');
+            let content = expand_tabs(text.trim_end_matches('\n'), diff_tab_width);
             let mut spans: Vec<Span<'static>> = Vec::new();
 
             // Line-number gutter.
@@ -173,7 +174,7 @@ pub fn diff_file(
                 spans.push(Span::styled("│", sep_style));
             }
 
-            match highlighter.highlight_line(content, &cache.syntax_set) {
+            match highlighter.highlight_line(&content, &cache.syntax_set) {
                 Ok(ranges) if tag == ChangeTag::Equal => {
                     // Context lines: full syntax colors, no background tint.
                     spans.push(Span::styled(
@@ -281,6 +282,30 @@ fn syntect_color(c: SynColor) -> Option<Color> {
     }
 }
 
+/// Expand tab characters to spaces, aligning to tab stops of the given width.
+/// If `tab_width` is 0, tabs are left as-is.
+fn expand_tabs(line: &str, tab_width: u16) -> String {
+    if tab_width == 0 || !line.contains('\t') {
+        return line.to_string();
+    }
+    let tw = tab_width as usize;
+    let mut out = String::with_capacity(line.len());
+    let mut col: usize = 0;
+    for ch in line.chars() {
+        if ch == '\t' {
+            let spaces = tw - (col % tw);
+            for _ in 0..spaces {
+                out.push(' ');
+            }
+            col += spaces;
+        } else {
+            out.push(ch);
+            col += 1;
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -324,8 +349,15 @@ mod tests {
         std::fs::write(&file, [0_u8, 159, 146, 151, 152]).unwrap();
 
         let cache = SyntaxCache::new();
-        let output =
-            diff_file(repo, "image.bin", &AppTheme::default_dark(), &cache, false).unwrap();
+        let output = diff_file(
+            repo,
+            "image.bin",
+            &AppTheme::default_dark(),
+            &cache,
+            false,
+            4,
+        )
+        .unwrap();
         let rendered = output
             .lines
             .iter()
@@ -397,6 +429,7 @@ mod tests {
             &AppTheme::default_dark(),
             &cache,
             true,
+            4,
         )
         .unwrap();
         let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
@@ -437,6 +470,7 @@ mod tests {
             &AppTheme::default_dark(),
             &cache,
             false,
+            4,
         )
         .unwrap();
         let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
@@ -446,6 +480,50 @@ mod tests {
         assert!(
             !has_gutter,
             "expected no gutter separator when line numbers are disabled"
+        );
+    }
+
+    #[test]
+    fn expand_tabs_column_aware() {
+        assert_eq!(expand_tabs("a\tb", 4), "a   b");
+        assert_eq!(expand_tabs("\t\t", 4), "        ");
+        assert_eq!(expand_tabs("ab\tc", 4), "ab  c");
+        assert_eq!(expand_tabs("abcd\te", 4), "abcd    e");
+        assert_eq!(expand_tabs("no tabs", 4), "no tabs");
+        assert_eq!(expand_tabs("\t", 0), "\t");
+    }
+
+    #[test]
+    fn tabs_expanded_to_spaces_in_diff() {
+        let dir = setup_text_repo(
+            "indent.rs",
+            "fn main() {\n}\n",
+            "fn main() {\n\t\tlet x = 1;\n}\n",
+        );
+        let cache = SyntaxCache::new();
+        let output = diff_file(
+            dir.path(),
+            "indent.rs",
+            &AppTheme::default_dark(),
+            &cache,
+            false,
+            4,
+        )
+        .unwrap();
+        let rendered: Vec<String> = output.lines.iter().map(|l| l.to_string()).collect();
+
+        let insert_line = rendered
+            .iter()
+            .find(|l| l.contains("let x"))
+            .expect("expected an inserted line containing 'let x'");
+        // Two tabs at width 4 = 8 leading spaces.
+        assert!(
+            insert_line.contains("        let x"),
+            "expected tabs expanded to 8 spaces, got: {insert_line}"
+        );
+        assert!(
+            !insert_line.contains('\t'),
+            "tab characters must not appear in rendered output"
         );
     }
 }


### PR DESCRIPTION
Ratatui's `Paragraph` widget renders `\t` characters as zero-width, which means any tab-based indentation in source files completely vanishes when viewing diffs. This adds a column-aware `expand_tabs()` helper in the diff pipeline that replaces tab characters with the correct number of spaces aligned to tab stops, *before* the content reaches syntect for highlighting or the fallback plain-text path.

The tab width is exposed as a new `diff_tab_width` setting in the `[ui]` section of `config.toml`, defaulting to `4`. Setting it to `0` disables expansion entirely (tabs pass through as-is). The canonical config template includes documentation for the new option, and both the `patch` save path and `Default` impls are updated.

Two new tests cover the change: a unit test for `expand_tabs` verifying column-aware alignment at tab stops, and an integration test that creates a repo with tab-indented content and asserts the rendered diff contains expanded spaces with no surviving `\t` characters.