### PR TITLE
Add configurable PR banner position with palette toggle

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3816,6 +3816,7 @@ mod tests {
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             gh_status: crate::model::GhStatus::Unknown,
             github_integration_enabled: false,
+            pr_banner_at_bottom: true,
             pr_statuses: std::collections::HashMap::new(),
             pr_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             pr_sync_enabled: Arc::new(AtomicBool::new(false)),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -133,6 +133,7 @@ pub struct App {
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
     pub(crate) gh_status: crate::model::GhStatus,
     pub(crate) github_integration_enabled: bool,
+    pub(crate) pr_banner_at_bottom: bool,
     pub(crate) pr_statuses: HashMap<String, crate::model::PrInfo>,
     pub(crate) pr_sync_sessions: Arc<Mutex<Vec<PrSyncEntry>>>,
     pub(crate) pr_sync_enabled: Arc<AtomicBool>,
@@ -796,6 +797,7 @@ impl App {
             bindings.label_for(Action::ToggleHelp),
         );
         let gh_integration_val = config.ui.github_integration;
+        let pr_banner_at_bottom = config.ui.pr_banner_position == "bottom";
         let mut app = Self {
             show_diff_line_numbers: config.ui.show_diff_line_numbers,
             left_width_pct: config.ui.left_width_pct,
@@ -877,6 +879,7 @@ impl App {
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             gh_status: crate::model::GhStatus::Unknown,
             github_integration_enabled: gh_integration_val,
+            pr_banner_at_bottom,
             pr_statuses: HashMap::new(),
             pr_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             pr_sync_enabled: Arc::new(AtomicBool::new(false)),
@@ -1360,6 +1363,18 @@ impl App {
                 self.set_info(format!(
                     "Prompt for agent name {state}. Press {palette_key} to toggle back."
                 ));
+                Ok(())
+            }
+            "toggle-pr-banner-position" => {
+                self.pr_banner_at_bottom = !self.pr_banner_at_bottom;
+                let pos = if self.pr_banner_at_bottom {
+                    "bottom"
+                } else {
+                    "top"
+                };
+                self.config.ui.pr_banner_position = pos.to_string();
+                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+                self.set_info(format!("PR banner moved to {pos} of agent pane."));
                 Ok(())
             }
             "force-redraw" => {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -556,10 +556,19 @@ impl App {
         };
         let pr_banner_height: u16 = if pr_info.is_some() { 1 } else { 0 };
 
-        let [pr_area, pane_area] = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(pr_banner_height), Constraint::Min(1)])
-            .areas(area);
+        let (pr_area, pane_area) = if self.pr_banner_at_bottom {
+            let [pane_area, pr_area] = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(1), Constraint::Length(pr_banner_height)])
+                .areas(area);
+            (pr_area, pane_area)
+        } else {
+            let [pr_area, pane_area] = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(pr_banner_height), Constraint::Min(1)])
+                .areas(area);
+            (pr_area, pane_area)
+        };
 
         if let Some(ref pr) = pr_info {
             self.render_pr_banner(frame, pr_area, pr);

--- a/src/config.rs
+++ b/src/config.rs
@@ -194,6 +194,7 @@ pub struct UiConfig {
     pub show_diff_line_numbers: bool,
     pub diff_tab_width: u16,
     pub github_integration: bool,
+    pub pr_banner_position: String,
 }
 
 impl Default for Config {
@@ -218,6 +219,7 @@ impl Default for Config {
                 show_diff_line_numbers: false,
                 diff_tab_width: 4,
                 github_integration: true,
+                pr_banner_position: "bottom".to_string(),
             },
             editor: EditorConfig::default(),
             keys: KeysConfig::default(),
@@ -340,6 +342,7 @@ impl Default for UiConfig {
             show_diff_line_numbers: false,
             diff_tab_width: 4,
             github_integration: true,
+            pr_banner_position: "bottom".to_string(),
         }
     }
 }
@@ -615,6 +618,13 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             )),
             value_fn: |c| FieldValue::Bool(c.ui.github_integration),
         },
+        ConfigEntry::Field {
+            key: "pr_banner_position",
+            comment: Some(CommentSource::Static(
+                "# Position of the PR banner in the agent pane: \"top\" or \"bottom\".\n# Toggle at runtime from the command palette.",
+            )),
+            value_fn: |c| FieldValue::Str(c.ui.pr_banner_position.clone()),
+        },
         ConfigEntry::Blank,
         ConfigEntry::Section("editor"),
         ConfigEntry::Field {
@@ -809,6 +819,12 @@ pub fn save_config(
         "ui",
         "github_integration",
         config.ui.github_integration,
+    );
+    patch_table_str(
+        &mut doc,
+        "ui",
+        "pr_banner_position",
+        &config.ui.pr_banner_position,
     );
 
     // --- [editor] ---

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -82,6 +82,7 @@ pub enum Action {
     ResourceMonitor,
     ToggleGithubIntegration,
     TogglePromptForName,
+    TogglePrBannerPosition,
 }
 
 /// Where a binding's key combo is matched.
@@ -243,6 +244,7 @@ impl Action {
             Action::ResourceMonitor => "resource_monitor",
             Action::ToggleGithubIntegration => "toggle_github_integration",
             Action::TogglePromptForName => "toggle_prompt_for_name",
+            Action::TogglePrBannerPosition => "toggle_pr_banner_position",
         }
     }
 
@@ -326,6 +328,9 @@ impl Action {
             Action::ResourceMonitor => "Show CPU and memory usage for dux and all running agents.",
             Action::ToggleGithubIntegration => "Toggle GitHub PR integration.",
             Action::TogglePromptForName => "Toggle prompting for agent name before creation.",
+            Action::TogglePrBannerPosition => {
+                "Move PR banner between top and bottom of agent pane."
+            }
         }
     }
 
@@ -399,7 +404,8 @@ impl Action {
             | Action::ToggleDiffLineNumbers
             | Action::ResourceMonitor
             | Action::ToggleGithubIntegration
-            | Action::TogglePromptForName => None,
+            | Action::TogglePromptForName
+            | Action::TogglePrBannerPosition => None,
         }
     }
 }
@@ -1336,6 +1342,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "toggle-prompt-for-name",
             description: "Toggle prompting for agent name before creation",
+        }),
+    },
+    BindingDef {
+        action: Action::TogglePrBannerPosition,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "toggle-pr-banner-position",
+            description: "Move PR banner between top and bottom of agent pane",
         }),
     },
 ];


### PR DESCRIPTION
The PR banner (showing the `⎇ owner/repo#1234 → title` pill) previously rendered above the agent pane content with no way to change its position. This moves the default placement to **below** the agent pane and introduces a `pr_banner_position` config option in `[ui]` that accepts `"top"` or `"bottom"`.

A new **toggle-pr-banner-position** command is available in the command palette (`Ctrl-P`), letting users flip the banner between top and bottom at runtime. The choice is persisted to `config.toml` automatically, so it survives restarts.

The implementation follows the same pattern as existing palette toggles (`toggle-diff-line-numbers`, `toggle-github-integration`): a new `Action` variant, a palette-only `BindingDef`, an `execute_command` handler that flips the runtime bool and calls `save_config`, and a conditional layout split in `render_center()`.