### PR TITLE
Color-code agents by PR state in the projects pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3494,6 +3494,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex, mpsc};
 
+    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::app::{
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
@@ -3501,7 +3502,6 @@ mod tests {
         OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget, RightSection,
         RuntimeTargetId, TextInput, WorkerEvent,
     };
-    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -453,7 +453,8 @@ impl App {
                     let label_color = match self.pr_statuses.get(&session.id).map(|pr| &pr.state) {
                         Some(crate::model::PrState::Merged) => self.theme.pr_merged_label,
                         Some(crate::model::PrState::Closed) => self.theme.pr_closed_label,
-                        _ => dot_color,
+                        Some(crate::model::PrState::Open) => self.theme.pr_open_label,
+                        None => dot_color,
                     };
                     ListItem::new(Line::from(
                         vec![

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -78,6 +78,7 @@ pub struct Theme {
     pub pr_banner_fg: Color,
     pub pr_merged_label: Color,
     pub pr_closed_label: Color,
+    pub pr_open_label: Color,
 }
 
 impl Theme {
@@ -94,7 +95,7 @@ impl Theme {
             selection_fg: Color::Black,
             selection_bg: Color::Cyan,
             project_icon: Color::Rgb(100, 149, 237),
-            session_active: Color::Green,
+            session_active: Color::Rgb(66, 135, 245),
             session_detached: Color::Yellow,
             session_exited: Color::Rgb(100, 100, 100),
             status_info_fg: Color::Rgb(100, 100, 100),
@@ -153,6 +154,7 @@ impl Theme {
             pr_merged_label: Color::Rgb(170, 100, 220),
             pr_banner_fg: Color::White,
             pr_closed_label: Color::Rgb(140, 80, 80),
+            pr_open_label: Color::Green,
         }
     }
 


### PR DESCRIPTION
Active agents in the projects pane were always green regardless of whether they had an associated pull request. This made it impossible to distinguish at a glance which agents had open PRs without selecting each one individually and checking for the PR banner.

The active agent color is now **blue** (`Rgb(66, 135, 245)`) when no PR has been detected, and **green** when an open PR exists. This complements the existing purple (merged) and dark red (closed) PR label colors, giving each PR lifecycle state a distinct visual signal in the left pane. Detached (yellow) and exited (gray) states remain unchanged.

The implementation adds a `pr_open_label` field to the `Theme` struct and updates the label color match in the render logic to explicitly handle `PrState::Open` instead of falling through to the default dot color. This keeps the color scheme centralized in `theme.rs` and consistent with how merged and closed states were already handled.