### PR TITLE
Add Home/End keys for scroll-to-top and scroll-to-bottom

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -142,6 +142,8 @@ impl App {
                         let page = self.last_help_height.max(1);
                         *scroll = scroll.saturating_sub(page);
                     }
+                    Action::ScrollToBottom => *scroll = max_help,
+                    Action::ScrollToTop => *scroll = 0,
                     _ => {}
                 }
             } else if key.code == KeyCode::Char(' ') {
@@ -516,6 +518,13 @@ impl App {
                         self.reset_pty_scrollback();
                     }
                 }
+                Action::ScrollToTop => {
+                    if let CenterMode::Diff { ref mut scroll, .. } = self.center_mode {
+                        *scroll = 0;
+                    } else {
+                        self.set_pty_scrollback_max();
+                    }
+                }
                 _ => {}
             }
         } else if !in_diff && self.input_target == InputTarget::None {
@@ -542,6 +551,12 @@ impl App {
     fn reset_pty_scrollback(&self) {
         if let Some(provider) = self.selected_terminal_surface_client() {
             provider.set_scrollback(0);
+        }
+    }
+
+    fn set_pty_scrollback_max(&self) {
+        if let Some(provider) = self.selected_terminal_surface_client() {
+            provider.set_scrollback(usize::MAX);
         }
     }
 
@@ -1104,6 +1119,16 @@ impl App {
                         let _ = provider.write_bytes(&raw);
                     }
                 }
+                SeqAction::Intercept(Action::ScrollToTop, conditional, raw) => {
+                    let has_scrollback = self
+                        .selected_terminal_surface_client()
+                        .is_some_and(|p| p.scrollback_offset() > 0);
+                    if conditional && has_scrollback {
+                        self.set_pty_scrollback_max();
+                    } else if let Some(provider) = self.selected_terminal_surface_client() {
+                        let _ = provider.write_bytes(&raw);
+                    }
+                }
                 SeqAction::Mouse(mouse_ev, raw) => {
                     let is_scroll = matches!(
                         mouse_ev.kind,
@@ -1211,6 +1236,12 @@ impl App {
                 }
                 KeyCode::PageDown => {
                     *scroll_offset = (*scroll_offset + 10).min(max_offset);
+                }
+                KeyCode::Home => {
+                    *scroll_offset = 0;
+                }
+                KeyCode::End => {
+                    *scroll_offset = max_offset;
                 }
                 _ => {}
             }
@@ -3494,6 +3525,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex, mpsc};
 
+    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::app::{
         App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
@@ -3501,7 +3533,6 @@ mod tests {
         OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget, RightSection,
         RuntimeTargetId, TextInput, WorkerEvent,
     };
-    use super::DOUBLE_CLICK_THRESHOLD;
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
     use crate::editor::{DetectedEditor, EditorKind};
@@ -4510,6 +4541,46 @@ mod tests {
         assert_eq!(
             bindings.lookup(&key, BindingScope::Interactive),
             Some(Action::ScrollPageDown),
+        );
+    }
+
+    #[test]
+    fn scroll_to_top_resolves_home_in_interactive_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Home, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Interactive),
+            Some(Action::ScrollToTop),
+        );
+    }
+
+    #[test]
+    fn scroll_to_top_resolves_home_in_center_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Home, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::ScrollToTop),
+        );
+    }
+
+    #[test]
+    fn scroll_to_bottom_resolves_end_in_interactive_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::End, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Interactive),
+            Some(Action::ScrollToBottom),
+        );
+    }
+
+    #[test]
+    fn scroll_to_bottom_resolves_end_in_center_scope() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::End, KeyModifiers::NONE);
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::ScrollToBottom),
         );
     }
 
@@ -6512,6 +6583,61 @@ mod tests {
                 .scrollback_offset(),
             0,
             "'q' should scroll to bottom when scrolled back"
+        );
+    }
+
+    #[test]
+    fn scrolled_back_allows_scroll_to_top_via_home() {
+        let mut app = app_with_scrolled_back_pty();
+        // Ensure we're scrolled back.
+        assert!(
+            app.selected_terminal_surface_client()
+                .unwrap()
+                .scrollback_offset()
+                > 0
+        );
+
+        // Remember current offset, then reset to a small offset.
+        app.selected_terminal_surface_client()
+            .unwrap()
+            .set_scrollback(2);
+        let before = app
+            .selected_terminal_surface_client()
+            .unwrap()
+            .scrollback_offset();
+
+        // Feed Home key escape sequence — ScrollToTop should maximize scrollback.
+        let result = app.process_raw_input_bytes(b"\x1b[H").unwrap();
+        assert!(!result);
+        let after = app
+            .selected_terminal_surface_client()
+            .unwrap()
+            .scrollback_offset();
+        assert!(
+            after >= before,
+            "Home should scroll to top of buffer, got offset {after} (was {before})"
+        );
+    }
+
+    #[test]
+    fn scrolled_back_allows_scroll_to_bottom_via_end() {
+        let mut app = app_with_scrolled_back_pty();
+        assert!(
+            app.selected_terminal_surface_client()
+                .unwrap()
+                .scrollback_offset()
+                > 0
+        );
+
+        // Feed End key escape sequence — ScrollToBottom should reset scrollback.
+        let result = app.process_raw_input_bytes(b"\x1b[F").unwrap();
+        assert!(!result);
+        assert_eq!(
+            app.selected_terminal_surface_client()
+                .unwrap()
+                .scrollback_offset(),
+            0,
+            "End should scroll to bottom when scrolled back"
         );
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -31,6 +31,7 @@ pub enum Action {
     ScrollLineUp,
     ScrollLineDown,
     ScrollToBottom,
+    ScrollToTop,
     // Files pane (git staging)
     OpenDiff,
     StageUnstage,
@@ -197,6 +198,7 @@ impl Action {
             Action::ScrollLineUp => "scroll_line_up",
             Action::ScrollLineDown => "scroll_line_down",
             Action::ScrollToBottom => "scroll_to_bottom",
+            Action::ScrollToTop => "scroll_to_top",
             Action::OpenDiff => "open_diff",
             Action::StageUnstage => "stage_unstage",
             Action::CommitChanges => "commit_changes",
@@ -278,6 +280,7 @@ impl Action {
             Action::ScrollLineUp => "Scroll up one line in any scrollable view.",
             Action::ScrollLineDown => "Scroll down one line in any scrollable view.",
             Action::ScrollToBottom => "Exit scroll mode and jump to the latest output.",
+            Action::ScrollToTop => "Jump to the top of the scrollback buffer.",
             Action::OpenDiff => "Open the selected file's diff.",
             Action::StageUnstage => "Stage or unstage the selected file.",
             Action::CommitChanges => "Commit staged changes.",
@@ -350,9 +353,10 @@ impl Action {
             | Action::ScrollPageUp
             | Action::ScrollPageDown
             | Action::ShowTerminal => Some("Agent pane"),
-            Action::ScrollLineUp | Action::ScrollLineDown | Action::ScrollToBottom => {
-                Some("Scrolling")
-            }
+            Action::ScrollLineUp
+            | Action::ScrollLineDown
+            | Action::ScrollToBottom
+            | Action::ScrollToTop => Some("Scrolling"),
             Action::OpenDiff
             | Action::StageUnstage
             | Action::CommitChanges
@@ -767,11 +771,30 @@ pub const BINDING_DEFS: &[BindingDef] = &[
     },
     BindingDef {
         action: Action::ScrollToBottom,
-        default_keys: &[key!(q)],
-        scopes: &[BindingScope::Interactive, BindingScope::Center],
+        default_keys: &[key!(q), key!(end)],
+        scopes: &[
+            BindingScope::Interactive,
+            BindingScope::Center,
+            BindingScope::Help,
+        ],
         help: Some(HelpEntry {
             section: "Scrolling",
             description: "Exit scroll mode and jump to latest output",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ScrollToTop,
+        default_keys: &[key!(home)],
+        scopes: &[
+            BindingScope::Interactive,
+            BindingScope::Center,
+            BindingScope::Help,
+        ],
+        help: Some(HelpEntry {
+            section: "Scrolling",
+            description: "Jump to top of scrollback",
         }),
         hint_contexts: &[],
         palette: None,
@@ -1761,6 +1784,7 @@ impl RuntimeBindings {
             Action::ScrollLineUp,
             Action::ScrollLineDown,
             Action::ScrollToBottom,
+            Action::ScrollToTop,
         ];
         let mut bindings = Vec::new();
         for rb in &self.bindings {


### PR DESCRIPTION
Adds `Home` and `End` key support everywhere `PgUp`/`PgDn` already works. `Home` jumps to the very top of the scrollback buffer via a new `ScrollToTop` action, while `End` is added as an additional key for the existing `ScrollToBottom` action (alongside `q`). Both keys are fully configurable through the `[keys]` config section like all other bindings.

The new bindings work in the agent pane (center), diff view, help overlay, resource monitor, and interactive mode. In interactive mode they follow the same conditional-on-scrollback semantics as `ScrollLineUp`/`ScrollLineDown` and `ScrollToBottom` — when not scrolled back, the raw escape sequence is forwarded to the PTY so the child process can handle it normally.

Includes 6 new tests: binding resolution for `Home`→`ScrollToTop` and `End`→`ScrollToBottom` in both `Interactive` and `Center` scopes, plus interactive-mode integration tests verifying scroll-to-top via `Home` and scroll-to-bottom via `End` escape sequences.