### PR TITLE
Add expandable subprocess details to resource monitor

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1225,6 +1225,8 @@ impl App {
     fn handle_prompt_key(&mut self, key: KeyEvent) -> Result<bool> {
         if let PromptState::ResourceMonitor {
             scroll_offset,
+            selected_row,
+            expanded,
             rows,
             ..
         } = &mut self.prompt
@@ -1233,28 +1235,43 @@ impl App {
                 self.prompt = PromptState::None;
                 return Ok(false);
             }
-            let max_offset = rows.len().saturating_sub(1) as u16;
+            let visual = build_visual_rows(rows, expanded);
+            let max_row = visual.len().saturating_sub(1);
             match key.code {
                 KeyCode::Up | KeyCode::Char('k') => {
-                    *scroll_offset = scroll_offset.saturating_sub(1);
+                    *selected_row = selected_row.saturating_sub(1);
                 }
                 KeyCode::Down | KeyCode::Char('j') => {
-                    *scroll_offset = (*scroll_offset + 1).min(max_offset);
+                    *selected_row = (*selected_row + 1).min(max_row);
                 }
                 KeyCode::PageUp => {
-                    *scroll_offset = scroll_offset.saturating_sub(10);
+                    *selected_row = selected_row.saturating_sub(10);
                 }
                 KeyCode::PageDown => {
-                    *scroll_offset = (*scroll_offset + 10).min(max_offset);
+                    *selected_row = (*selected_row + 10).min(max_row);
                 }
                 KeyCode::Home => {
-                    *scroll_offset = 0;
+                    *selected_row = 0;
                 }
                 KeyCode::End => {
-                    *scroll_offset = max_offset;
+                    *selected_row = max_row;
+                }
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    if let Some(VisualRow::Parent(idx)) = visual.get(*selected_row) {
+                        let stat = &rows[*idx];
+                        if let Some(pid) = stat.pid {
+                            if !stat.children.is_empty() {
+                                if !expanded.remove(&pid) {
+                                    expanded.insert(pid);
+                                }
+                            }
+                        }
+                    }
                 }
                 _ => {}
             }
+            // Keep scroll_offset tracking the cursor.
+            *scroll_offset = (*selected_row).saturating_sub(5) as u16;
             return Ok(false);
         }
 
@@ -2981,20 +2998,24 @@ impl App {
     fn handle_prompt_mouse(&mut self, mouse: MouseEvent) -> bool {
         if let PromptState::ResourceMonitor {
             scroll_offset,
+            selected_row,
+            expanded,
             rows,
             ..
         } = &mut self.prompt
         {
-            let max_offset = rows.len().saturating_sub(1) as u16;
+            let visual = build_visual_rows(rows, expanded);
+            let max_row = visual.len().saturating_sub(1);
             match mouse.kind {
                 MouseEventKind::ScrollUp => {
-                    *scroll_offset = scroll_offset.saturating_sub(3);
+                    *selected_row = selected_row.saturating_sub(3);
                 }
                 MouseEventKind::ScrollDown => {
-                    *scroll_offset = (*scroll_offset + 3).min(max_offset);
+                    *selected_row = (*selected_row + 3).min(max_row);
                 }
                 _ => {}
             }
+            *scroll_offset = (*selected_row).saturating_sub(5) as u16;
             return false;
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -447,6 +447,8 @@ pub(crate) enum PromptState {
     ResourceMonitor {
         rows: Vec<ResourceStats>,
         scroll_offset: u16,
+        selected_row: usize,
+        expanded: HashSet<u32>,
         last_refresh: Instant,
         first_sample: bool,
     },
@@ -461,12 +463,44 @@ pub(crate) enum BranchWarningKind {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct ProcessInfo {
+    pub(crate) name: String,
+    pub(crate) pid: u32,
+    pub(crate) cpu_percent: f32,
+    pub(crate) rss_bytes: u64,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ResourceStats {
     pub(crate) label: String,
     pub(crate) pid: Option<u32>,
     pub(crate) cpu_percent: f32,
     pub(crate) rss_bytes: u64,
     pub(crate) process_count: usize,
+    pub(crate) children: Vec<ProcessInfo>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum VisualRow {
+    /// Index into the `ResourceStats` rows vec.
+    Parent(usize),
+    /// (parent row index, child index within that parent's `children`).
+    Child(usize, usize),
+}
+
+pub(crate) fn build_visual_rows(rows: &[ResourceStats], expanded: &HashSet<u32>) -> Vec<VisualRow> {
+    let mut visual = Vec::new();
+    for (i, row) in rows.iter().enumerate() {
+        visual.push(VisualRow::Parent(i));
+        if let Some(pid) = row.pid {
+            if expanded.contains(&pid) {
+                for (j, _) in row.children.iter().enumerate() {
+                    visual.push(VisualRow::Child(i, j));
+                }
+            }
+        }
+    }
+    visual
 }
 
 #[derive(Clone, Debug)]
@@ -1215,6 +1249,8 @@ impl App {
         self.prompt = PromptState::ResourceMonitor {
             rows: Vec::new(),
             scroll_offset: 0,
+            selected_row: 0,
+            expanded: HashSet::new(),
             last_refresh: Instant::now(),
             first_sample: true,
         };
@@ -1964,18 +2000,20 @@ fn collect_resource_stats(targets: Vec<(String, u32)>) -> Vec<ResourceStats> {
             cpu_percent: proc_info.cpu_usage(),
             rss_bytes: proc_info.memory(),
             process_count: 1,
+            children: Vec::new(),
         });
     }
 
     // Rows: each labeled target (agents and companion terminals).
     for (label, root_pid) in &targets {
-        let (cpu, rss, count) = aggregate_tree(&sys, Pid::from_u32(*root_pid));
+        let (cpu, rss, count, children) = aggregate_tree(&sys, Pid::from_u32(*root_pid));
         rows.push(ResourceStats {
             label: label.clone(),
             pid: Some(*root_pid),
             cpu_percent: cpu,
             rss_bytes: rss,
             process_count: count,
+            children,
         });
     }
 
@@ -1989,6 +2027,7 @@ fn collect_resource_stats(targets: Vec<(String, u32)>) -> Vec<ResourceStats> {
         cpu_percent: total_cpu,
         rss_bytes: total_rss,
         process_count: total_procs,
+        children: Vec::new(),
     });
 
     rows
@@ -2023,18 +2062,32 @@ fn is_descendant_of(sys: &sysinfo::System, pid: sysinfo::Pid, ancestor: sysinfo:
 }
 
 /// Aggregate CPU% and RSS across a root PID and all its descendants.
-fn aggregate_tree(sys: &sysinfo::System, root: sysinfo::Pid) -> (f32, u64, usize) {
+/// Returns `(total_cpu, total_rss, process_count, top_children)` where
+/// `top_children` contains the top 10 individual processes by RSS.
+fn aggregate_tree(
+    sys: &sysinfo::System,
+    root: sysinfo::Pid,
+) -> (f32, u64, usize, Vec<ProcessInfo>) {
     let mut cpu = 0.0f32;
     let mut rss = 0u64;
     let mut count = 0usize;
+    let mut children = Vec::new();
     for (pid, proc_info) in sys.processes() {
         if *pid == root || is_descendant_of(sys, *pid, root) {
             cpu += proc_info.cpu_usage();
             rss += proc_info.memory();
             count += 1;
+            children.push(ProcessInfo {
+                name: proc_info.name().to_string_lossy().into_owned(),
+                pid: pid.as_u32(),
+                cpu_percent: proc_info.cpu_usage(),
+                rss_bytes: proc_info.memory(),
+            });
         }
     }
-    (cpu, rss, count)
+    children.sort_by(|a, b| b.rss_bytes.cmp(&a.rss_bytes));
+    children.truncate(10);
+    (cpu, rss, count, children)
 }
 
 pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> ProviderCommandConfig {
@@ -2081,7 +2134,7 @@ mod tests {
             ProcessRefreshKind::nothing().with_memory(),
         );
         let self_pid = Pid::from_u32(std::process::id());
-        let (_cpu, rss, count) = aggregate_tree(&sys, self_pid);
+        let (_cpu, rss, count, _children) = aggregate_tree(&sys, self_pid);
         assert!(count >= 1, "should include at least the root process");
         assert!(rss > 0, "current process should have nonzero RSS");
     }
@@ -2100,6 +2153,70 @@ mod tests {
         let self_pid = Pid::from_u32(std::process::id());
         let init_pid = Pid::from_u32(1);
         assert!(!is_descendant_of(&sys, init_pid, self_pid));
+    }
+
+    #[test]
+    fn build_visual_rows_respects_expansion() {
+        let rows = vec![
+            ResourceStats {
+                label: "dux".into(),
+                pid: Some(1),
+                cpu_percent: 0.0,
+                rss_bytes: 0,
+                process_count: 1,
+                children: Vec::new(),
+            },
+            ResourceStats {
+                label: "Agent".into(),
+                pid: Some(100),
+                cpu_percent: 5.0,
+                rss_bytes: 1024,
+                process_count: 3,
+                children: vec![
+                    ProcessInfo {
+                        name: "node".into(),
+                        pid: 101,
+                        cpu_percent: 3.0,
+                        rss_bytes: 512,
+                    },
+                    ProcessInfo {
+                        name: "claude".into(),
+                        pid: 102,
+                        cpu_percent: 2.0,
+                        rss_bytes: 256,
+                    },
+                ],
+            },
+            ResourceStats {
+                label: "TOTAL".into(),
+                pid: None,
+                cpu_percent: 5.0,
+                rss_bytes: 1024,
+                process_count: 4,
+                children: Vec::new(),
+            },
+        ];
+
+        // Nothing expanded: 3 visual rows (one per parent).
+        let visual = build_visual_rows(&rows, &HashSet::new());
+        assert_eq!(visual.len(), 3);
+
+        // Expand PID 100: 3 parents + 2 children = 5 visual rows.
+        let mut expanded = HashSet::new();
+        expanded.insert(100);
+        let visual = build_visual_rows(&rows, &expanded);
+        assert_eq!(visual.len(), 5);
+        assert!(matches!(visual[0], VisualRow::Parent(0)));
+        assert!(matches!(visual[1], VisualRow::Parent(1)));
+        assert!(matches!(visual[2], VisualRow::Child(1, 0)));
+        assert!(matches!(visual[3], VisualRow::Child(1, 1)));
+        assert!(matches!(visual[4], VisualRow::Parent(2)));
+
+        // Expanding a PID that doesn't match any row: no effect.
+        let mut expanded = HashSet::new();
+        expanded.insert(999);
+        let visual = build_visual_rows(&rows, &expanded);
+        assert_eq!(visual.len(), 3);
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3359,13 +3359,24 @@ impl App {
             PromptState::ResourceMonitor {
                 rows,
                 scroll_offset,
+                selected_row,
+                expanded,
                 first_sample,
                 ..
             } => {
                 let rows = rows.clone();
                 let scroll_offset = *scroll_offset;
+                let selected_row = *selected_row;
+                let expanded = expanded.clone();
                 let first_sample = *first_sample;
-                self.render_resource_monitor(frame, &rows, scroll_offset, first_sample);
+                self.render_resource_monitor(
+                    frame,
+                    &rows,
+                    scroll_offset,
+                    selected_row,
+                    &expanded,
+                    first_sample,
+                );
             }
             PromptState::DebugInput {
                 lines,
@@ -4062,6 +4073,8 @@ impl App {
         frame: &mut Frame,
         rows: &[ResourceStats],
         scroll_offset: u16,
+        selected_row: usize,
+        expanded: &HashSet<u32>,
         first_sample: bool,
     ) {
         use ratatui::widgets::{Cell, Row, Table, TableState};
@@ -4090,33 +4103,76 @@ impl App {
             Cell::from("RSS").style(header_style),
         ]);
 
-        let table_rows: Vec<Row> = rows
+        let visual = build_visual_rows(rows, expanded);
+        let dim_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+
+        let table_rows: Vec<Row> = visual
             .iter()
-            .map(|stat| {
-                let pid_str = stat.pid.map(|p| p.to_string()).unwrap_or_default();
-                let cpu_str = if first_sample {
-                    format!("~{:.1}%", stat.cpu_percent)
-                } else {
-                    format!("{:.1}%", stat.cpu_percent)
-                };
-                let rss_str = format_bytes(stat.rss_bytes);
-                let procs_str = stat.process_count.to_string();
+            .map(|vr| match vr {
+                VisualRow::Parent(idx) => {
+                    let stat = &rows[*idx];
+                    let pid_str = stat.pid.map(|p| p.to_string()).unwrap_or_default();
+                    let cpu_str = if first_sample {
+                        format!("~{:.1}%", stat.cpu_percent)
+                    } else {
+                        format!("{:.1}%", stat.cpu_percent)
+                    };
+                    let rss_str = format_bytes(stat.rss_bytes);
+                    let procs_str = stat.process_count.to_string();
 
-                let is_total = stat.label == "TOTAL";
-                let style = if is_total {
-                    Style::default().add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
+                    let is_total = stat.label == "TOTAL";
+                    let style = if is_total {
+                        Style::default().add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    };
 
-                Row::new(vec![
-                    Cell::from(stat.label.clone()),
-                    Cell::from(pid_str),
-                    Cell::from(procs_str),
-                    Cell::from(cpu_str),
-                    Cell::from(rss_str),
-                ])
-                .style(style)
+                    // Expand indicator: ▶/▼ for expandable rows, space for others.
+                    let indicator = if !stat.children.is_empty() {
+                        if let Some(pid) = stat.pid {
+                            if expanded.contains(&pid) {
+                                "▼ "
+                            } else {
+                                "▶ "
+                            }
+                        } else {
+                            "  "
+                        }
+                    } else {
+                        "  "
+                    };
+                    let label = format!("{indicator}{}", stat.label);
+
+                    Row::new(vec![
+                        Cell::from(label),
+                        Cell::from(pid_str),
+                        Cell::from(procs_str),
+                        Cell::from(cpu_str),
+                        Cell::from(rss_str),
+                    ])
+                    .style(style)
+                }
+                VisualRow::Child(parent_idx, child_idx) => {
+                    let child = &rows[*parent_idx].children[*child_idx];
+                    let is_last = *child_idx == rows[*parent_idx].children.len().saturating_sub(1);
+                    let connector = if is_last { "└" } else { "├" };
+                    let label = format!("    {connector} {}", child.name);
+                    let cpu_str = if first_sample {
+                        format!("~{:.1}%", child.cpu_percent)
+                    } else {
+                        format!("{:.1}%", child.cpu_percent)
+                    };
+                    let rss_str = format_bytes(child.rss_bytes);
+
+                    Row::new(vec![
+                        Cell::from(label),
+                        Cell::from(child.pid.to_string()),
+                        Cell::from(""),
+                        Cell::from(cpu_str),
+                        Cell::from(rss_str),
+                    ])
+                    .style(dim_style)
+                }
             })
             .collect();
 
@@ -4128,9 +4184,14 @@ impl App {
             Constraint::Length(12),
         ];
 
-        let table = Table::new(table_rows, widths).header(header);
+        let highlight_style = self.theme.selection_style();
+        let table = Table::new(table_rows, widths)
+            .header(header)
+            .row_highlight_style(highlight_style);
 
-        let mut table_state = TableState::default().with_offset(scroll_offset as usize);
+        let mut table_state = TableState::default()
+            .with_offset(scroll_offset as usize)
+            .with_selected(Some(selected_row));
         StatefulWidget::render(table, inner, frame.buffer_mut(), &mut table_state);
 
         // Footer hint.
@@ -4139,6 +4200,8 @@ impl App {
         let mut spans = vec![Span::raw(" ")];
         spans.extend(self.theme.key_badge_default(&close_key));
         spans.push(Span::styled(" close  ", desc_style));
+        spans.extend(self.theme.key_badge_default("Enter"));
+        spans.push(Span::styled(" expand/collapse  ", desc_style));
         spans.extend(self.theme.key_badge_default("Scroll"));
         spans.push(Span::styled(" navigate  ", desc_style));
         spans.push(Span::styled(

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -255,6 +255,8 @@ impl App {
                     self.resource_stats_in_flight = false;
                     if let PromptState::ResourceMonitor {
                         rows,
+                        selected_row,
+                        expanded,
                         last_refresh,
                         first_sample,
                         ..
@@ -263,6 +265,12 @@ impl App {
                         *rows = stats;
                         *last_refresh = Instant::now();
                         *first_sample = false;
+                        // Clamp cursor to the (possibly changed) visual row count.
+                        let visual = build_visual_rows(rows, expanded);
+                        let max_row = visual.len().saturating_sub(1);
+                        if *selected_row > max_row {
+                            *selected_row = max_row;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The resource monitor modal now lets users drill into each agent or terminal row to see the individual subprocesses consuming resources. Pressing **Enter** or **Space** on a row expands it to reveal the **top 10 child processes sorted by RSS**, each showing its name, PID, CPU%, and memory usage. Rows display `▶`/`▼` indicators and children render with tree connectors (`├`/`└`) in a dimmed style to visually distinguish them from parent aggregates.

Expansion state is keyed by root PID rather than row index, so it naturally survives the 2-second auto-refresh cycle — expanded rows stay expanded as stats update. A new `VisualRow` enum maps the hierarchical parent/child data into a flat scrollable list, with the cursor, keyboard navigation, and mouse scroll all operating on visual row coordinates. The scroll offset automatically follows the cursor position.

The changes span four files: `mod.rs` (data model, `ProcessInfo` struct, `VisualRow` helper, updated `aggregate_tree`), `render.rs` (visual row iteration, expand indicators, child row styling, footer hint), `input.rs` (cursor-based navigation replacing pure scroll offset, Enter/Space toggle), and `workers.rs` (cursor clamping on refresh). Includes a unit test for `build_visual_rows` covering expanded, collapsed, and non-matching PID scenarios.