### PR TITLE
Fix resume fallback for one-liner exits and add force-reconnect command

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -6530,12 +6530,13 @@ mod tests {
     }
 
     #[test]
-    fn resume_fallback_skipped_when_pty_had_output() {
+    fn resume_fallback_skipped_when_pty_had_substantial_output() {
         let mut app = test_app(default_bindings());
         let session_id = app.sessions[0].id.clone();
         let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
-        // Spawn a process that produces output before exiting.
-        let args = vec!["-c".to_string(), "echo hello".to_string()];
+        // Spawn a process that produces many lines of output before exiting.
+        // This simulates a real agent session that ran and then exited normally.
+        let args = vec!["-c".to_string(), "seq 1 30".to_string()];
         let client =
             PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn with output");
         app.providers.insert(session_id.clone(), client);
@@ -6548,12 +6549,50 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(200));
         app.drain_events();
 
-        // Since the PTY had output, the fallback should NOT have triggered.
-        // The session should be detached (normal exit behavior).
+        // Since the PTY had substantial output (>5 lines), the fallback
+        // should NOT have triggered. The session should be detached.
         assert_eq!(app.sessions[0].status, SessionStatus::Detached);
         assert!(
             !app.resume_fallback_candidates.contains(&session_id),
             "candidate should have been removed even when skipped"
+        );
+    }
+
+    #[test]
+    fn resume_fallback_triggers_on_one_liner_output() {
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        // Spawn a process that prints a single line (like a failed --continue)
+        // and then exits. The fallback should still trigger because the output
+        // is minimal (≤5 lines with no scrollback).
+        let args = vec![
+            "-c".to_string(),
+            "echo 'No session found to resume'".to_string(),
+        ];
+        let client =
+            PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000).expect("spawn one-liner");
+        app.providers.insert(session_id.clone(), client);
+        app.mark_session_status(&session_id, SessionStatus::Active);
+        app.resume_fallback_candidates.insert(session_id.clone());
+        app.selected_left = 1;
+        app.session_surface = SessionSurface::Agent;
+
+        // Wait for the process to produce its one line and exit.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.drain_events();
+
+        // Despite having output, the fallback should trigger because the
+        // output is minimal (one line, no scrollback).
+        assert!(
+            app.providers.contains_key(&session_id),
+            "provider should still be present after fallback retry"
+        );
+        assert_eq!(app.sessions[0].status, SessionStatus::Active);
+        assert!(
+            app.status.text().contains("No prior session to resume"),
+            "status should inform user about fallback: {:?}",
+            app.status.text()
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1252,6 +1252,7 @@ impl App {
             "rename-agent" => self.open_rename_session(),
             "kill-running" => self.open_kill_running(),
             "reconnect-agent" => self.reconnect_selected_session(),
+            "force-reconnect-agent" => self.force_reconnect_agent(),
             "show-agent" => self.activate_center_agent(),
             "show-terminal" => self.show_or_open_first_terminal(),
             "new-terminal" => self.new_companion_terminal(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -615,6 +615,54 @@ impl App {
         Ok(())
     }
 
+    /// Restart the selected agent with a fresh session, bypassing `--continue`
+    /// or equivalent resume args. Works on both active and detached agents.
+    pub(crate) fn force_reconnect_agent(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent first.");
+            return Ok(());
+        };
+        if !Path::new(&session.worktree_path).exists() {
+            self.set_error(format!(
+                "Worktree for agent \"{}\" no longer exists. Delete and re-create the agent.",
+                session.branch_name
+            ));
+            return Ok(());
+        }
+        // Kill existing PTY if the agent is still active.
+        self.providers.remove(&session.id);
+        self.last_pty_activity.remove(&session.id);
+        self.resume_fallback_candidates.remove(&session.id);
+
+        logger::info(&format!(
+            "restarting agent \"{}\" with fresh session (no resume args)",
+            session.branch_name
+        ));
+        match self.spawn_pty_for_session(&session, false) {
+            Ok(client) => {
+                self.providers.insert(session.id.clone(), client);
+                self.mark_session_status(&session.id, SessionStatus::Active);
+                self.show_agent_surface();
+                self.input_target = InputTarget::Agent;
+                self.fullscreen_overlay = FullscreenOverlay::Agent;
+                let proj_name = self.project_name_for_session(&session);
+                self.set_info(format!(
+                    "Started fresh {} session for agent \"{}\" in project \"{}\". Use /sessions inside the agent to restore a prior conversation.",
+                    session.provider.as_str(),
+                    session.branch_name,
+                    proj_name,
+                ));
+            }
+            Err(err) => {
+                self.set_error(format!(
+                    "Fresh restart failed for agent \"{}\": {err}",
+                    session.branch_name
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn reconnect_selected_session(&mut self) -> Result<()> {
         let Some(session) = self.selected_session().cloned() else {
             self.set_error("Select a stopped agent first to reconnect.");

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -283,12 +283,16 @@ impl App {
             if !self.resume_fallback_candidates.remove(session_id) {
                 continue;
             }
-            let had_output = self
+            // Check whether the exited process produced only minimal output
+            // (no scrollback and ≤5 visible lines). A failed `--continue`
+            // typically prints 1-2 lines of error; a real session produces
+            // far more output and scrollback history.
+            let is_minimal = self
                 .providers
                 .get(session_id)
-                .map(|p| p.has_output())
-                .unwrap_or(false);
-            if had_output {
+                .map(|p| p.has_minimal_output(5))
+                .unwrap_or(true);
+            if !is_minimal {
                 continue;
             }
             let Some(session) = self.sessions.iter().find(|s| s.id == *session_id).cloned() else {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -84,6 +84,7 @@ pub enum Action {
     ToggleGithubIntegration,
     TogglePromptForName,
     TogglePrBannerPosition,
+    ForceReconnectAgent,
 }
 
 /// Where a binding's key combo is matched.
@@ -247,6 +248,7 @@ impl Action {
             Action::ToggleGithubIntegration => "toggle_github_integration",
             Action::TogglePromptForName => "toggle_prompt_for_name",
             Action::TogglePrBannerPosition => "toggle_pr_banner_position",
+            Action::ForceReconnectAgent => "force_reconnect_agent",
         }
     }
 
@@ -334,6 +336,7 @@ impl Action {
             Action::TogglePrBannerPosition => {
                 "Move PR banner between top and bottom of agent pane."
             }
+            Action::ForceReconnectAgent => "Restart the agent without resuming the prior session.",
         }
     }
 
@@ -409,7 +412,8 @@ impl Action {
             | Action::ResourceMonitor
             | Action::ToggleGithubIntegration
             | Action::TogglePromptForName
-            | Action::TogglePrBannerPosition => None,
+            | Action::TogglePrBannerPosition
+            | Action::ForceReconnectAgent => None,
         }
     }
 }
@@ -1376,6 +1380,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "toggle-pr-banner-position",
             description: "Move PR banner between top and bottom of agent pane",
+        }),
+    },
+    BindingDef {
+        action: Action::ForceReconnectAgent,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "force-reconnect-agent",
+            description: "Force-reconnect the agent with a fresh session (no --continue)",
         }),
     },
 ];

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -297,6 +297,16 @@ impl PtyClient {
         self.has_output.load(Ordering::Acquire)
     }
 
+    /// Returns `true` if the terminal has only minimal output (no scrollback
+    /// and at most `threshold` visible lines). Used to detect failed resume
+    /// attempts that print a short error and exit.
+    pub fn has_minimal_output(&self, threshold: usize) -> bool {
+        self.terminal
+            .lock()
+            .map(|t| t.has_minimal_output(threshold))
+            .unwrap_or(true)
+    }
+
     /// Returns `true` if the PTY received data since the last call, then
     /// clears the flag. Used to detect streaming activity for UI indicators
     /// without interfering with the snapshot dirty flag.
@@ -441,6 +451,25 @@ impl TerminalState {
             .renderable_content()
             .display_iter
             .any(|indexed| !indexed.cell.c.is_whitespace())
+    }
+
+    /// Count the number of distinct viewport rows that contain at least one
+    /// non-whitespace character.
+    fn visible_line_count(&self) -> usize {
+        let mut seen_rows = std::collections::HashSet::new();
+        for indexed in self.term.renderable_content().display_iter {
+            if !indexed.cell.c.is_whitespace() {
+                seen_rows.insert(indexed.point.line.0);
+            }
+        }
+        seen_rows.len()
+    }
+
+    /// Returns `true` if the terminal contains only a small amount of output:
+    /// no scrollback history AND at most `threshold` visible lines with content.
+    /// Used to detect failed `--continue` exits that print a short error message.
+    fn has_minimal_output(&self, threshold: usize) -> bool {
+        self.term.grid().history_size() == 0 && self.visible_line_count() <= threshold
     }
 
     /// Whether the child process has enabled any mouse tracking mode


### PR DESCRIPTION
When an agent is reconnected with `--continue` (or equivalent resume args), the CLI sometimes prints a short error message like "No session found" and exits immediately. The existing fallback only checked whether the PTY had *any* visible output before deciding to retry without resume args. Because the error message counts as output, the fallback silently skipped and the agent appeared to crash. This change replaces the boolean `has_output()` check with a `has_minimal_output(threshold)` heuristic that considers both the number of visible lines (≤5) and the absence of scrollback history. A real agent session produces far more output and scrollback, so the threshold cleanly separates failed resumes from normal exits.

As a manual escape hatch for cases where auto-detection still falls short, a new **force-reconnect-agent** command palette entry lets users restart the agent without `--continue`. The status message reminds them they can use `/sessions` inside the agent to restore a prior conversation, so no work is lost.

Includes updated and new tests: the "substantial output" test now produces 30 lines to exceed the threshold, and a new `resume_fallback_triggers_on_one_liner_output` test verifies that a single-line exit correctly triggers the fresh-session fallback.