### PR TITLE
Warn when adding a project whose branch is not the remote default

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -43,6 +43,8 @@ enum PromptMouseTarget {
     ConfirmQuitConfirm,
     ConfirmDiscardCancel,
     ConfirmDiscardConfirm,
+    ConfirmNonDefaultBranchCancel,
+    ConfirmNonDefaultBranchAdd,
     RenameInput,
     NameNewAgentInput,
 }
@@ -1845,6 +1847,28 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ConfirmNonDefaultBranch {
+            confirm_selected, ..
+        } = &mut self.prompt
+        {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
+                    *confirm_selected = !*confirm_selected;
+                }
+                Some(Action::Confirm) => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_non_default_branch(confirm));
+                }
+                _ if key.code == KeyCode::Char(' ') => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_non_default_branch(confirm));
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if matches!(self.prompt, PromptState::EditMacros { .. }) {
             self.handle_edit_macros_key(key)?;
             return Ok(false);
@@ -2291,6 +2315,18 @@ impl App {
                     Some(PromptMouseTarget::ConfirmDiscardCancel)
                 } else if contains_point(discard_button, column, row) {
                     Some(PromptMouseTarget::ConfirmDiscardConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmNonDefaultBranch {
+                cancel_button,
+                add_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmNonDefaultBranchCancel)
+                } else if contains_point(add_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmNonDefaultBranchAdd)
                 } else {
                     None
                 }
@@ -2903,6 +2939,25 @@ impl App {
         false
     }
 
+    fn resolve_confirm_non_default_branch(&mut self, confirm: bool) -> bool {
+        let (path, name, branch) = match &self.prompt {
+            PromptState::ConfirmNonDefaultBranch {
+                path,
+                name,
+                current_branch,
+                ..
+            } => (path.clone(), name.clone(), current_branch.clone()),
+            _ => return false,
+        };
+        self.prompt = PromptState::None;
+        if confirm {
+            if let Err(e) = self.finish_add_project(path, name, branch) {
+                self.set_error(format!("{e:#}"));
+            }
+        }
+        false
+    }
+
     fn set_rename_cursor_from_mouse(&mut self, column: u16) {
         let input_area = match self.overlay_layout.active {
             OverlayMouseLayout::RenameSession { input } => input,
@@ -3082,6 +3137,12 @@ impl App {
             }
             PromptMouseTarget::ConfirmDiscardConfirm => {
                 return self.resolve_confirm_discard_file(true);
+            }
+            PromptMouseTarget::ConfirmNonDefaultBranchCancel => {
+                return self.resolve_confirm_non_default_branch(false);
+            }
+            PromptMouseTarget::ConfirmNonDefaultBranchAdd => {
+                return self.resolve_confirm_non_default_branch(true);
             }
             PromptMouseTarget::RenameInput => {
                 self.set_rename_cursor_from_mouse(mouse.column);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -431,6 +431,13 @@ pub(crate) enum PromptState {
         selected: usize,
         editing: Option<MacroEditState>,
     },
+    ConfirmNonDefaultBranch {
+        path: String,
+        name: String,
+        current_branch: String,
+        kind: BranchWarningKind,
+        confirm_selected: bool, // false = Cancel (default), true = Add Anyway
+    },
     DebugInput {
         lines: Vec<Line<'static>>,
         scroll_offset: u16,
@@ -441,6 +448,14 @@ pub(crate) enum PromptState {
         last_refresh: Instant,
         first_sample: bool,
     },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum BranchWarningKind {
+    /// We resolved `origin/HEAD` and know the default branch for certain.
+    Known { default_branch: String },
+    /// `origin/HEAD` unavailable; current branch is not `main` or `master`.
+    Heuristic,
 }
 
 #[derive(Clone, Debug)]
@@ -634,6 +649,10 @@ pub(crate) enum OverlayMouseLayout {
     ConfirmDiscardFile {
         cancel_button: Rect,
         discard_button: Rect,
+    },
+    ConfirmNonDefaultBranch {
+        cancel_button: Rect,
+        add_button: Rect,
     },
     RenameSession {
         input: Rect,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3040,6 +3040,131 @@ impl App {
                     discard_button: discard_area,
                 };
             }
+            PromptState::ConfirmNonDefaultBranch {
+                current_branch,
+                kind,
+                confirm_selected,
+                ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(60, 30, frame.area());
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Non-Default Branch");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                let mut lines = vec![Line::from("")];
+                match kind {
+                    BranchWarningKind::Known { default_branch } => {
+                        lines.push(Line::from(vec![
+                            Span::raw(" This repository is on branch "),
+                            Span::styled(
+                                current_branch.as_str(),
+                                Style::default().add_modifier(Modifier::BOLD),
+                            ),
+                            Span::raw(", but the"),
+                        ]));
+                        lines.push(Line::from(vec![
+                            Span::raw(" remote default branch is "),
+                            Span::styled(
+                                default_branch.as_str(),
+                                Style::default().add_modifier(Modifier::BOLD),
+                            ),
+                            Span::raw("."),
+                        ]));
+                    }
+                    BranchWarningKind::Heuristic => {
+                        lines.push(Line::from(vec![
+                            Span::raw(" This repository is on branch "),
+                            Span::styled(
+                                current_branch.as_str(),
+                                Style::default().add_modifier(Modifier::BOLD),
+                            ),
+                            Span::raw(","),
+                        ]));
+                        lines.push(Line::from(" which doesn't appear to be the main branch."));
+                    }
+                }
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!(" New worktrees will branch from \"{current_branch}\"."),
+                    Style::default().fg(self.theme.warning_fg),
+                )));
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = 16u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let add_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) = if !confirm_selected {
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+                let (add_border, add_fg) = if *confirm_selected {
+                    (self.theme.button_danger_border, self.theme.button_active_fg)
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Add Anyway",
+                    Style::default().fg(add_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(add_border)),
+                )
+                .render(add_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmNonDefaultBranch {
+                    cancel_button: cancel_area,
+                    add_button: add_area,
+                };
+            }
             PromptState::RenameSession {
                 input,
                 rename_branch,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -64,8 +64,47 @@ impl App {
             return Ok(());
         }
         let branch = git::current_branch(&path)?;
+
+        // Check whether the current branch matches the remote default branch.
+        // Two-tier warning: confident when origin/HEAD is available, heuristic
+        // when it isn't but the branch name doesn't look like a main branch.
+        let warning_kind = match git::remote_default_branch(&path) {
+            Some(default) if default != branch => Some(BranchWarningKind::Known {
+                default_branch: default,
+            }),
+            Some(_) => None, // on the default branch — no warning
+            None if branch != "main" && branch != "master" => Some(BranchWarningKind::Heuristic),
+            None => None, // looks like main/master — no warning
+        };
+
+        if let Some(kind) = warning_kind {
+            self.prompt = PromptState::ConfirmNonDefaultBranch {
+                path: path.to_string_lossy().to_string(),
+                name,
+                current_branch: branch,
+                kind,
+                confirm_selected: false,
+            };
+            return Ok(());
+        }
+
+        let path_str = path.to_string_lossy().to_string();
+        self.finish_add_project(path_str, name, branch)
+    }
+
+    /// Saves the project to config and adds it to the runtime project list.
+    /// Called directly when no branch warning is needed, or after the user
+    /// confirms "Add Anyway" in the non-default-branch dialog.
+    pub(crate) fn finish_add_project(
+        &mut self,
+        path: String,
+        name: String,
+        branch: String,
+    ) -> Result<()> {
+        let path_buf = PathBuf::from(&path);
         let display_name = if name.trim().is_empty() {
-            path.file_name()
+            path_buf
+                .file_name()
                 .and_then(|part| part.to_str())
                 .unwrap_or("project")
                 .to_string()
@@ -75,7 +114,7 @@ impl App {
         let project_id = Uuid::new_v4().to_string();
         self.config.projects.push(ProjectConfig {
             id: project_id.clone(),
-            path: path.to_string_lossy().to_string(),
+            path: path.clone(),
             name: Some(display_name.clone()),
             default_provider: None,
             commit_prompt: None,
@@ -84,12 +123,12 @@ impl App {
         self.projects.push(Project {
             id: project_id,
             name: display_name.clone(),
-            path: path.to_string_lossy().to_string(),
+            path,
             default_provider: self.config.default_provider(),
             current_branch: branch,
         });
         self.rebuild_left_items();
-        logger::info(&format!("registered project {}", path.display()));
+        logger::info(&format!("registered project {}", path_buf.display()));
         self.set_info(format!("Added project \"{display_name}\" to workspace"));
         Ok(())
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -44,6 +44,33 @@ pub fn current_branch(repo_path: &Path) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Returns the default branch name for the `origin` remote by reading
+/// `refs/remotes/origin/HEAD`.  This ref is set automatically by `git clone`;
+/// repos created with `git init` + manual remote typically lack it.
+///
+/// Returns `None` when the ref doesn't exist or the command fails — callers
+/// should fall back to a heuristic (e.g. checking if the current branch is
+/// `main` or `master`).
+pub fn remote_default_branch(repo_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_string_lossy().as_ref(),
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let full_ref = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // e.g. "refs/remotes/origin/main" → "main"
+    full_ref
+        .strip_prefix("refs/remotes/origin/")
+        .map(|s| s.to_string())
+}
+
 pub fn is_git_repo(path: &Path) -> bool {
     Command::new("git")
         .args([
@@ -1429,5 +1456,52 @@ mod tests {
             parse_github_owner_repo("https://github.com/octocat/Hello-World/tree/main"),
             Some("octocat/Hello-World".to_string()),
         );
+    }
+
+    // ── remote_default_branch tests ──────────────────────────────
+
+    #[test]
+    fn remote_default_branch_returns_none_for_local_only_repo() {
+        let repo = init_test_repo();
+        // A repo created with `git init` has no remotes, so origin/HEAD
+        // doesn't exist and the function should return None.
+        assert_eq!(remote_default_branch(repo.path()), None);
+    }
+
+    #[test]
+    fn remote_default_branch_returns_branch_from_cloned_repo() {
+        // Set up a "remote" bare repo and clone it, which auto-sets origin/HEAD.
+        let bare_dir = tempfile::tempdir().unwrap();
+        let bare = bare_dir.path();
+        let run = |cwd: &Path, args: &[&str]| {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(cwd)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(bare, &["init", "--bare", "-b", "main"]);
+
+        // Create a temporary non-bare repo, add a commit, push to the bare.
+        let staging_dir = tempfile::tempdir().unwrap();
+        let staging = staging_dir.path();
+        run(staging, &["clone", bare.to_str().unwrap(), "."]);
+        run(staging, &["config", "user.name", "test"]);
+        run(staging, &["config", "user.email", "t@t"]);
+        run(staging, &["commit", "--allow-empty", "-m", "init"]);
+        run(staging, &["push", "origin", "main"]);
+
+        // Now clone the bare repo — this sets origin/HEAD automatically.
+        let clone_dir = tempfile::tempdir().unwrap();
+        let clone = clone_dir.path();
+        run(clone, &["clone", bare.to_str().unwrap(), "."]);
+
+        assert_eq!(remote_default_branch(clone), Some("main".to_string()),);
     }
 }


### PR DESCRIPTION
When a user adds a folder as a new project, all worktrees created from it branch off whatever commit is currently checked out. If that checkout is on a feature branch rather than the remote's default branch, every new agent session starts from the wrong base — making it impossible to pull upstream updates cleanly and silently working against the wrong root codebase.

This adds a confirmation dialog that fires during project addition whenever the current branch doesn't match the remote default. Detection uses `git symbolic-ref refs/remotes/origin/HEAD` (fast, local-only, set automatically by `git clone`). When `origin/HEAD` isn't available — e.g. repos created with `git init` plus a manual remote — the check falls back to a heuristic: if the current branch is neither `main` nor `master`, a softer warning is shown. The two tiers use different wording so the user understands the confidence level behind the warning.

The dialog follows the existing confirmation-dialog pattern (`ConfirmDeleteAgent`, `ConfirmQuit`, etc.) with full keyboard and mouse support: `Tab` to toggle between **Cancel** and **Add Anyway**, `Enter`/`Space` to confirm the focused button, `Esc` to dismiss. The `add_project` flow is split into validation + `finish_add_project` so the actual save can be deferred until the user confirms. Two new tests cover `remote_default_branch` for both local-only repos (returns `None`) and cloned repos (returns the correct branch).