### PR TITLE
Add Ctrl+D to delete companion terminals from the terminals pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -39,6 +39,8 @@ enum PromptMouseTarget {
     ConfirmKillConfirm,
     ConfirmDeleteCancel,
     ConfirmDeleteConfirm,
+    ConfirmDeleteTerminalCancel,
+    ConfirmDeleteTerminalConfirm,
     ConfirmQuitCancel,
     ConfirmQuitConfirm,
     ConfirmDiscardCancel,
@@ -444,6 +446,7 @@ impl App {
                 Action::ShowTerminal => {
                     self.spawn_terminal_for_selected_terminal()?;
                 }
+                Action::DeleteSession => self.confirm_delete_selected_terminal()?,
                 _ => {}
             }
         }
@@ -1821,6 +1824,27 @@ impl App {
             }
         }
 
+        if let PromptState::ConfirmDeleteTerminal {
+            confirm_selected, ..
+        } = &mut self.prompt
+        {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
+                    *confirm_selected = !*confirm_selected;
+                }
+                Some(Action::Confirm) => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_delete_terminal(confirm));
+                }
+                _ if key.code == KeyCode::Char(' ') => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_delete_terminal(confirm));
+                }
+                _ => {}
+            }
+        }
+
         if let PromptState::ConfirmQuit {
             confirm_selected, ..
         } = &mut self.prompt
@@ -2308,6 +2332,18 @@ impl App {
                     Some(PromptMouseTarget::ConfirmDeleteCancel)
                 } else if contains_point(delete_button, column, row) {
                     Some(PromptMouseTarget::ConfirmDeleteConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmDeleteTerminal {
+                cancel_button,
+                delete_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteTerminalCancel)
+                } else if contains_point(delete_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteTerminalConfirm)
                 } else {
                     None
                 }
@@ -2870,6 +2906,18 @@ impl App {
         false
     }
 
+    fn resolve_confirm_delete_terminal(&mut self, confirm: bool) -> bool {
+        let terminal_id = match &self.prompt {
+            PromptState::ConfirmDeleteTerminal { terminal_id, .. } => terminal_id.clone(),
+            _ => return false,
+        };
+        self.prompt = PromptState::None;
+        if confirm {
+            self.do_delete_terminal(&terminal_id);
+        }
+        false
+    }
+
     fn resolve_confirm_kill_running(&mut self, confirm: bool) -> bool {
         let confirm_prompt = match &self.prompt {
             PromptState::ConfirmKillRunning(confirm_prompt) => confirm_prompt.clone(),
@@ -3150,6 +3198,12 @@ impl App {
             }
             PromptMouseTarget::ConfirmDeleteConfirm => {
                 return self.resolve_confirm_delete_agent(true);
+            }
+            PromptMouseTarget::ConfirmDeleteTerminalCancel => {
+                return self.resolve_confirm_delete_terminal(false);
+            }
+            PromptMouseTarget::ConfirmDeleteTerminalConfirm => {
+                return self.resolve_confirm_delete_terminal(true);
             }
             PromptMouseTarget::ConfirmQuitCancel => return self.resolve_confirm_quit(false),
             PromptMouseTarget::ConfirmQuitConfirm => return self.resolve_confirm_quit(true),
@@ -7172,6 +7226,100 @@ mod tests {
         assert!(
             second,
             "double-click on center pane (no item index) must work"
+        );
+    }
+
+    #[test]
+    fn ctrl_d_in_terminal_list_shows_confirm_dialog() {
+        let mut app = test_app(default_bindings());
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        // Close overlay so we're back in the normal left pane.
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.input_target = InputTarget::None;
+        app.session_surface = SessionSurface::Agent;
+        app.left_section = LeftSection::Terminals;
+        app.focus = FocusPane::Left;
+        app.selected_terminal_index = 0;
+
+        let ctrl_d = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL);
+        app.handle_key(ctrl_d).unwrap();
+
+        assert!(
+            matches!(app.prompt, PromptState::ConfirmDeleteTerminal { .. }),
+            "Ctrl+D in terminal list should show confirm delete terminal dialog"
+        );
+    }
+
+    #[test]
+    fn confirm_delete_terminal_removes_terminal() {
+        let mut app = test_app(default_bindings());
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.companion_terminals.len(), 1);
+        let terminal_id = app.terminal_items()[0].0.clone();
+
+        app.prompt = PromptState::ConfirmDeleteTerminal {
+            terminal_id: terminal_id.clone(),
+            terminal_label: "test".to_string(),
+            confirm_selected: true,
+        };
+
+        app.resolve_confirm_delete_terminal(true);
+
+        assert!(
+            app.companion_terminals.is_empty(),
+            "terminal should be removed after confirm"
+        );
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn cancel_delete_terminal_keeps_terminal() {
+        let mut app = test_app(default_bindings());
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        assert_eq!(app.companion_terminals.len(), 1);
+        let terminal_id = app.terminal_items()[0].0.clone();
+
+        app.prompt = PromptState::ConfirmDeleteTerminal {
+            terminal_id,
+            terminal_label: "test".to_string(),
+            confirm_selected: false,
+        };
+
+        app.resolve_confirm_delete_terminal(false);
+
+        assert_eq!(
+            app.companion_terminals.len(),
+            1,
+            "terminal should remain after cancel"
+        );
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn delete_last_terminal_switches_to_projects() {
+        let mut app = test_app(default_bindings());
+        app.show_companion_terminal()
+            .expect("launch companion terminal");
+
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.input_target = InputTarget::None;
+        app.session_surface = SessionSurface::Agent;
+        app.left_section = LeftSection::Terminals;
+
+        let terminal_id = app.terminal_items()[0].0.clone();
+        app.do_delete_terminal(&terminal_id);
+
+        assert!(app.companion_terminals.is_empty());
+        assert_eq!(
+            app.left_section,
+            LeftSection::Projects,
+            "should switch back to projects when last terminal deleted"
         );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -403,6 +403,11 @@ pub(crate) enum PromptState {
         branch_name: String,
         confirm_selected: bool, // false = Cancel (default), true = Delete
     },
+    ConfirmDeleteTerminal {
+        terminal_id: String,
+        terminal_label: String,
+        confirm_selected: bool, // false = Cancel (default), true = Delete
+    },
     ConfirmQuit {
         agent_count: usize,
         terminal_count: usize,
@@ -675,6 +680,10 @@ pub(crate) enum OverlayMouseLayout {
         kill_button: Rect,
     },
     ConfirmDeleteAgent {
+        cancel_button: Rect,
+        delete_button: Rect,
+    },
+    ConfirmDeleteTerminal {
         cancel_button: Rect,
         delete_button: Rect,
     },

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1559,6 +1559,9 @@ impl App {
             Some(LeftItem::Session(_))
         );
         let ctx = match self.focus {
+            FocusPane::Left if self.left_section == LeftSection::Terminals => {
+                HintContext::LeftTerminal
+            }
             FocusPane::Left if is_on_project => HintContext::LeftProject,
             FocusPane::Left => HintContext::LeftSession,
             FocusPane::Center => HintContext::Center,
@@ -2904,6 +2907,109 @@ impl App {
                 )
                 .render(delete_area, frame.buffer_mut());
                 self.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
+                    cancel_button: cancel_area,
+                    delete_button: delete_area,
+                };
+            }
+            PromptState::ConfirmDeleteTerminal {
+                terminal_label,
+                confirm_selected,
+                ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(56, 30, frame.area());
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Delete Terminal");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                let lines = vec![
+                    Line::from(""),
+                    Line::from(vec![
+                        Span::raw(" Are you sure you want to delete "),
+                        Span::styled(
+                            terminal_label.as_str(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw("?"),
+                    ]),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " The running process will be killed.",
+                        Style::default().fg(self.theme.warning_fg),
+                    )),
+                ];
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = 16u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let delete_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) = if !confirm_selected {
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+                let (delete_border, delete_fg) = if *confirm_selected {
+                    (self.theme.button_danger_border, self.theme.button_active_fg)
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Delete",
+                    Style::default().fg(delete_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(delete_border)),
+                )
+                .render(delete_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteTerminal {
                     cancel_button: cancel_area,
                     delete_button: delete_area,
                 };

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -539,6 +539,36 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn confirm_delete_selected_terminal(&mut self) -> Result<()> {
+        let items = self.terminal_items();
+        let Some((terminal_id, terminal)) = items.get(self.selected_terminal_index) else {
+            self.set_error("Select a terminal first.");
+            return Ok(());
+        };
+        self.prompt = PromptState::ConfirmDeleteTerminal {
+            terminal_id: (*terminal_id).clone(),
+            terminal_label: terminal.label.clone(),
+            confirm_selected: false, // Cancel is default
+        };
+        Ok(())
+    }
+
+    pub(crate) fn do_delete_terminal(&mut self, terminal_id: &str) {
+        let label = self
+            .companion_terminals
+            .get(terminal_id)
+            .map(|t| t.label.clone());
+        // Removing from the map drops PtyClient, which kills the child process.
+        self.companion_terminals.remove(terminal_id);
+        if self.active_terminal_id.as_deref() == Some(terminal_id) {
+            self.active_terminal_id = None;
+        }
+        self.clamp_terminal_cursor();
+        if let Some(label) = label {
+            self.set_info(format!("Deleted terminal \"{}\"", label));
+        }
+    }
+
     pub(crate) fn cycle_selected_project_provider(&mut self) -> Result<()> {
         let Some(project) = self.selected_project().cloned() else {
             self.set_error("Select a project first.");

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -20,6 +20,7 @@ pub enum Action {
     RefreshProject,
     ReconnectAgent,
     DeleteSession,
+    DeleteTerminal,
     // Agent pane
     InteractAgent,
     ShowTerminal,
@@ -145,6 +146,7 @@ impl BindingScope {
 pub enum HintContext {
     LeftProject,
     LeftSession,
+    LeftTerminal,
     Center,
     Files,
     CommitInput,
@@ -191,6 +193,7 @@ impl Action {
             Action::RefreshProject => "refresh_project",
             Action::ReconnectAgent => "reconnect_agent",
             Action::DeleteSession => "delete_session",
+            Action::DeleteTerminal => "delete_terminal",
             Action::InteractAgent => "interact_agent",
             Action::ShowTerminal => "show_terminal",
             Action::ExitInteractive => "exit_interactive",
@@ -273,6 +276,7 @@ impl Action {
             Action::RefreshProject => "Git pull the selected project checkout.",
             Action::ReconnectAgent => "Restart the CLI for the selected agent.",
             Action::DeleteSession => "Delete the selected session and worktree.",
+            Action::DeleteTerminal => "Delete the selected companion terminal.",
             Action::InteractAgent => "Start a prompt turn for the agent.",
             Action::ShowTerminal => {
                 "Open the first companion terminal for the selected agent, or launch a new one if none exists."
@@ -357,7 +361,8 @@ impl Action {
             | Action::RefreshProject
             | Action::InteractAgent
             | Action::ReconnectAgent
-            | Action::DeleteSession => Some("Projects pane"),
+            | Action::DeleteSession
+            | Action::DeleteTerminal => Some("Projects pane"),
             Action::ExitInteractive
             | Action::OpenMacroBar
             | Action::ToggleFullscreen
@@ -468,6 +473,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[
             (HintContext::LeftProject, "Move"),
             (HintContext::LeftSession, "Move"),
+            (HintContext::LeftTerminal, "Move"),
             (HintContext::Files, "Move"),
         ],
         palette: None,
@@ -540,6 +546,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
         hint_contexts: &[
             (HintContext::LeftSession, "Focus"),
+            (HintContext::LeftTerminal, "Focus"),
             (HintContext::Center, "Interact"),
         ],
         palette: Some(PaletteEntry {
@@ -678,11 +685,23 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
         hint_contexts: &[
             (HintContext::LeftSession, "Delete"),
+            (HintContext::LeftTerminal, "Delete"),
             (HintContext::Center, "Delete"),
         ],
         palette: Some(PaletteEntry {
             name: "delete-agent",
             description: "Delete the selected agent session",
+        }),
+    },
+    BindingDef {
+        action: Action::DeleteTerminal,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "delete-terminal",
+            description: "Delete the selected companion terminal",
         }),
     },
     // ── Agent pane ────────────────────────────────────────────────
@@ -974,6 +993,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[
             (HintContext::LeftProject, "Palette"),
             (HintContext::LeftSession, "Palette"),
+            (HintContext::LeftTerminal, "Palette"),
             (HintContext::Center, "Palette"),
             (HintContext::Files, "Palette"),
         ],
@@ -1038,6 +1058,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[
             (HintContext::LeftProject, "Help"),
             (HintContext::LeftSession, "Help"),
+            (HintContext::LeftTerminal, "Help"),
             (HintContext::Center, "Help"),
             (HintContext::Files, "Help"),
         ],


### PR DESCRIPTION
Pressing **Ctrl+D** in the terminals pane now opens a confirmation dialog to delete the selected companion terminal, mirroring the existing Ctrl+D behavior for deleting agent sessions in the projects pane. On confirmation, the terminal PTY process is killed and the entry is removed from the list. If the last terminal is deleted, the left pane automatically switches back to the projects section.

The implementation adds a new `ConfirmDeleteTerminal` prompt state with full keyboard and mouse support — `Esc` to cancel, `Tab` to toggle between Cancel/Delete buttons, and `Enter` or `Space` to confirm the focused button. The dialog follows the same rendering pattern as the existing "Delete Agent" confirmation, including danger-styled delete button and a warning that the running process will be killed.

A new `LeftTerminal` hint context ensures the footer bar shows relevant keybinding hints (Move, Focus, Delete, Palette, Help) when the terminal list is focused. The `DeleteTerminal` action is also available as a palette-only command for discoverability. Four unit tests cover the dialog lifecycle: showing the dialog on Ctrl+D, confirming deletion, cancelling, and verifying the section switch when the last terminal is removed.