### PR TITLE
Add alternate braille-art duck logo with random selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="assets/dux-logo.png" width="200" align="right" />
 
-Your AI agents deserve a proper office. dux is a terminal UI that lets you run multiple AI coding agents side by side, each in its own git worktree, with full companion terminals, macros, commit generation, and a command palette that knows more tricks than you do.
+Your AI agents deserve a proper office. **dux** (pronounced "dooks") is a terminal UI that lets you run multiple AI coding agents side by side, each in its own git worktree, with full companion terminals, macros, commit generation, and a command palette that knows more tricks than you do.
 
 No protocol layers. No adapters. No JSON-RPC. Just real CLIs running in real terminals.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3992,6 +3992,7 @@ mod tests {
             force_redraw: false,
             welcome_tip_index: 0,
             welcome_logo_visible: false,
+            welcome_logo_alt: false,
             welcome_tip_selection: usize::MAX,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             gh_status: crate::model::GhStatus::Unknown,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -130,6 +130,8 @@ pub struct App {
     pub(crate) welcome_logo_visible: bool,
     /// The left-pane selection index when the logo last rendered a tip.
     pub(crate) welcome_tip_selection: usize,
+    /// When true, show the alternate (duck) logo instead of the text logo.
+    pub(crate) welcome_logo_alt: bool,
     pub(crate) branch_sync_sessions: Arc<Mutex<Vec<BranchSyncEntry>>>,
     pub(crate) gh_status: crate::model::GhStatus,
     pub(crate) github_integration_enabled: bool,
@@ -939,6 +941,7 @@ impl App {
                 .map(|d| d.as_millis() as usize)
                 .unwrap_or(0),
             welcome_logo_visible: false,
+            welcome_logo_alt: false,
             welcome_tip_selection: usize::MAX,
             branch_sync_sessions: Arc::new(Mutex::new(Vec::new())),
             gh_status: crate::model::GhStatus::Unknown,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,6 +15,29 @@ const ASCII_LOGO_WIDTH: u16 = 33;
 /// Number of lines in `ASCII_LOGO`.
 const ASCII_LOGO_HEIGHT: u16 = 7;
 
+/// Alternate braille-art duck logo, same width as the text logo.
+const ASCII_LOGO_ALT: &[&str] = &[
+    "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⠤⣄⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠔⠉⠀⠀⢸⢰⢸⢰⢰⠉⠢⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡔⢰⠀⢸⢰⢸⢸⢸⢸⢸⢸⢸⢸⢈⢦⠀⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⢠⢸⠤⣤⠤⢸⢸⢸⢸⢸⠤⠤⢐⢸⢸⡆⠀⠀⠀⠀⠀⠀⠀",
+    "⢠⠀⠀⠀⠀⠀⠀⠀⠀⢹⢸⢸⢸⢸⢸⣤⢰⢲⢤⣄⢸⢸⢸⢸⢸⡇⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠙⡄⠀⠀⠀⠀⠀⠀⠀⣄⢸⢰⣶⣿⣤⣤⣶⣤⣤⣬⣷⡤⢸⣰⠀⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠈⢦⠀⠀⠀⠀⠀⠀⠈⢦⢸⢈⠛⠿⣿⣼⣼⠿⠛⠁⢸⡼⠀⠀⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠸⠉⢻⣍⠉⠤⣀⣠⣤⣾⢸⣿⣿⣿⣶⣾⣾⣿⣿⢸⢸⠓⠤⣄⠀⠀⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⠈⠒⠭⣀⢸⢸⢈⢈⢸⢸⢸⠙⠻⢸⢸⢸⠿⠛⢸⢸⢸⢸⢸⢈⠑⢄⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⣼⢸⢸⢈⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⣠⠤⠒⠁⢸⣦⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⣿⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢩⡂⢸⢸⣀⣴⣿⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠹⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢉⠉⠉⠁⢸⠃⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⢳⢨⠘⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⢸⣴⢸⢸⢸⢸⡟⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⠀⠳⣀⢠⢨⢘⢘⢸⢸⢸⢸⢸⢸⢸⢸⣤⣿⢸⢸⢸⣀⠛⠀⠀⠀⠀⠀",
+    "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀",
+];
+/// Display width of each line in `ASCII_LOGO_ALT`.
+const ASCII_LOGO_ALT_WIDTH: u16 = 33;
+/// Number of lines in `ASCII_LOGO_ALT`.
+const ASCII_LOGO_ALT_HEIGHT: u16 = 15;
+
 /// Maximum display width for a tip line (logo width + padding on each side).
 const TIP_MAX_WIDTH: u16 = 47;
 /// Blank lines between the bottom of the logo and the tip.
@@ -716,33 +739,39 @@ impl App {
             return;
         }
 
-        // Rotate the tip when the logo becomes visible again after being
-        // hidden, or when the selected left-pane item changes while the logo
-        // stays visible (e.g. navigating between projects).
+        // Rotate the tip and randomly pick a logo variant when the logo
+        // becomes visible again after being hidden, or when the selected
+        // left-pane item changes while the logo stays visible.
         if !self.welcome_logo_visible || self.welcome_tip_selection != self.selected_left {
             self.welcome_tip_index = self.welcome_tip_index.wrapping_add(1);
+            self.welcome_logo_alt = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos() % 2 == 0)
+                .unwrap_or(false);
         }
         self.welcome_logo_visible = true;
         self.welcome_tip_selection = self.selected_left;
 
-        let total_height = ASCII_LOGO_HEIGHT + TIP_GAP + TIP_MAX_LINES;
+        // Pick the active logo variant. Fall back to the text logo when the
+        // area is too short for the taller duck.
+        let use_alt = self.welcome_logo_alt && area.height >= ASCII_LOGO_ALT_HEIGHT;
+        let (logo, logo_w, logo_h) = if use_alt {
+            (ASCII_LOGO_ALT, ASCII_LOGO_ALT_WIDTH, ASCII_LOGO_ALT_HEIGHT)
+        } else {
+            (ASCII_LOGO, ASCII_LOGO_WIDTH, ASCII_LOGO_HEIGHT)
+        };
+
+        let total_height = logo_h + TIP_GAP + TIP_MAX_LINES;
         let show_tip = area.width >= TIP_MAX_WIDTH && area.height >= total_height;
 
-        let block_height = if show_tip {
-            total_height
-        } else {
-            ASCII_LOGO_HEIGHT
-        };
-        let x = area.x + (area.width - ASCII_LOGO_WIDTH) / 2;
+        let block_height = if show_tip { total_height } else { logo_h };
+        let x = area.x + (area.width - logo_w) / 2;
         let y = area.y + (area.height - block_height) / 2;
 
         // --- logo ---
         let style = Style::default().fg(self.theme.border_normal);
-        let lines: Vec<Line> = ASCII_LOGO.iter().map(|l| Line::styled(*l, style)).collect();
-        Paragraph::new(lines).render(
-            Rect::new(x, y, ASCII_LOGO_WIDTH, ASCII_LOGO_HEIGHT),
-            frame.buffer_mut(),
-        );
+        let lines: Vec<Line> = logo.iter().map(|l| Line::styled(*l, style)).collect();
+        Paragraph::new(lines).render(Rect::new(x, y, logo_w, logo_h), frame.buffer_mut());
 
         // --- tip pill ---
         if show_tip {
@@ -777,7 +806,7 @@ impl App {
             let tip_line = Line::from(spans);
             let tip_width = TIP_MAX_WIDTH.min(area.width.saturating_sub(2));
             let tip_x = area.x + (area.width - tip_width) / 2;
-            let tip_y = y + ASCII_LOGO_HEIGHT + TIP_GAP;
+            let tip_y = y + logo_h + TIP_GAP;
 
             Paragraph::new(vec![tip_line])
                 .wrap(Wrap { trim: false })


### PR DESCRIPTION
The welcome screen now randomly picks between the original text logo and a new braille-art duck each time the tip rotates — triggered by the logo becoming visible or the left-pane selection changing. The coin flip uses `SystemTime` nanosecond parity, so no new dependencies are needed.

Both logo variants are **vertically centered as a complete unit** (logo + gap + tip), so each feels naturally positioned regardless of its height. When the terminal is too short for the taller duck, it gracefully falls back to the text logo.

Changes span three files: `render.rs` gains the `ASCII_LOGO_ALT` constant and the randomized rendering logic, `mod.rs` adds a `welcome_logo_alt: bool` field to `App`, and `input.rs` initializes it in the test constructor.