### PR TITLE
Add curl-pipe-bash install script to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.archive }}
+
+  upload-install-script:
+    name: Upload install script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload install script
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload ${{ github.event.release.tag_name }} install.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ Every agent runs through a PTY, the same pseudo-terminal your shell uses. That m
 brew install patrickdappollonio/tap/dux
 ```
 
+**Shell:**
+
+```bash
+curl -sSfL https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh | bash
+```
+
+By default, the script installs to `~/.local/bin` if it exists and is in your `PATH`, otherwise `/usr/local/bin`. You can override the install directory or pin a specific version:
+
+```bash
+# Custom install directory
+curl -sSfL https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh | DUX_INSTALL_DIR=~/.bin bash
+
+# Specific version
+curl -sSfL https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh | DUX_VERSION=v0.1.0 bash
+```
+
 **Binary download:**
 
 Grab the latest release for your platform from the [Releases](https://github.com/patrickdappollonio/dux/releases) page. Extract it, drop the `dux` binary somewhere on your `PATH`, and run it. On first launch, dux creates a fully commented config file. That file *is* the documentation.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="patrickdappollonio/dux"
+BINARY="dux"
+
+# Allow overriding the version and install directory via environment variables.
+VERSION="${DUX_VERSION:-}"
+INSTALL_DIR="${DUX_INSTALL_DIR:-}"
+
+log() { printf '%s\n' "$@"; }
+err() { log "$@" >&2; exit 1; }
+
+detect_os() {
+    local os
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case "$os" in
+        linux)  echo "linux" ;;
+        darwin) echo "darwin" ;;
+        *)      err "Unsupported operating system: $os" ;;
+    esac
+}
+
+detect_arch() {
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|amd64)       echo "amd64" ;;
+        aarch64|arm64)      echo "arm64" ;;
+        *)                  err "Unsupported architecture: $arch" ;;
+    esac
+}
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+http_get() {
+    local url="$1"
+    if has_cmd curl; then
+        curl -sSfL "$url"
+    elif has_cmd wget; then
+        wget -qO- "$url"
+    else
+        err "Either curl or wget is required to download files."
+    fi
+}
+
+http_download() {
+    local url="$1" dest="$2"
+    if has_cmd curl; then
+        curl -sSfL -o "$dest" "$url"
+    elif has_cmd wget; then
+        wget -qO "$dest" "$url"
+    else
+        err "Either curl or wget is required to download files."
+    fi
+}
+
+resolve_version() {
+    if [ -n "$VERSION" ]; then
+        # Ensure the version starts with 'v'.
+        case "$VERSION" in
+            v*) echo "$VERSION" ;;
+            *)  echo "v$VERSION" ;;
+        esac
+        return
+    fi
+
+    log "Fetching latest release version..."
+    local response
+    response="$(http_get "https://api.github.com/repos/${REPO}/releases/latest")" \
+        || err "Failed to fetch latest release from GitHub API. Set DUX_VERSION to install a specific version."
+
+    # Parse the tag_name from the JSON response without requiring jq.
+    local tag
+    tag="$(echo "$response" | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+    [ -n "$tag" ] || err "Could not determine latest release version. Set DUX_VERSION to install a specific version."
+    echo "$tag"
+}
+
+resolve_install_dir() {
+    # 1. Explicit override.
+    if [ -n "$INSTALL_DIR" ]; then
+        echo "$INSTALL_DIR"
+        return
+    fi
+
+    # 2. ~/.local/bin if it exists and is in PATH.
+    local local_bin="$HOME/.local/bin"
+    if [ -d "$local_bin" ]; then
+        case ":$PATH:" in
+            *":$local_bin:"*) echo "$local_bin"; return ;;
+        esac
+    fi
+
+    # 3. Traditional fallback.
+    echo "/usr/local/bin"
+}
+
+main() {
+    local os arch version install_dir archive url tmpdir
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    version="$(resolve_version)"
+    install_dir="$(resolve_install_dir)"
+    archive="${BINARY}-${os}-${arch}.tar.gz"
+    url="https://github.com/${REPO}/releases/download/${version}/${archive}"
+
+    log "Installing ${BINARY} ${version} (${os}/${arch}) to ${install_dir}"
+
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    log "Downloading ${url}..."
+    http_download "$url" "${tmpdir}/${archive}"
+
+    tar xzf "${tmpdir}/${archive}" -C "$tmpdir"
+
+    # Install the binary — use sudo only if the target directory is not writable.
+    if [ -w "$install_dir" ]; then
+        install -m 755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}"
+    else
+        log "Installation directory ${install_dir} is not writable, using sudo..."
+        sudo install -m 755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}"
+    fi
+
+    log ""
+    log "${BINARY} ${version} has been installed to ${install_dir}/${BINARY}"
+
+    if ! has_cmd "$BINARY"; then
+        log ""
+        log "Warning: ${install_dir} is not in your PATH."
+        log "Add it to your shell profile:"
+        log "  export PATH=\"${install_dir}:\$PATH\""
+    fi
+}
+
+main


### PR DESCRIPTION
Adds an `install.sh` script that auto-detects OS (linux/darwin) and architecture (amd64/arm64), fetches the latest release from the GitHub API, and downloads the correct binary archive. The install location defaults to `~/.local/bin` when it exists and is in `$PATH` — which covers immutable Linux distros like Fedora Silverblue where `/usr/local/bin` may be read-only — and falls back to `/usr/local/bin` otherwise. Both the target version (`DUX_VERSION`) and install directory (`DUX_INSTALL_DIR`) can be overridden via environment variables.

The release workflow now includes a separate job that uploads `install.sh` as a release asset alongside the platform-specific tarballs. This means the install URL (`https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh`) resolves to the script bundled with the release rather than tracking `main`, so the script version always matches the release it installs.

The README documents the new shell install method between the existing Homebrew and binary download sections, including examples for overriding the install directory and pinning a specific version.