### PR TITLE
Fix release pipeline by replacing retired macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
             runner: ubuntu-24.04-arm
             archive: dux-linux-arm64.tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             archive: dux-darwin-amd64.tar.gz
           - target: aarch64-apple-darwin
             runner: macos-latest


### PR DESCRIPTION
The `macos-13` runner used for the `x86_64-apple-darwin` build has been retired by GitHub Actions, causing the release workflow to fail with *"The configuration 'macos-13-us-default' is not supported"*. This replaces it with `macos-latest`, which is an Apple Silicon runner capable of cross-compiling to the x86_64 target since the Rust toolchain step already installs it explicitly.

Both macOS targets (`x86_64-apple-darwin` and `aarch64-apple-darwin`) now run on `macos-latest`. The rest of the pipeline — including `strip`, packaging, and upload — works unchanged because macOS tooling handles both architectures natively.

The remaining runners (`ubuntu-latest`, `ubuntu-24.04-arm`) were verified against the current [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and are still valid.