### PR TITLE
Suppress selection highlight on single click in terminal pane

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1052,6 +1052,7 @@ impl App {
 
                     // Overlay selection highlight if this cell is selected.
                     if let Some(sel) = &self.terminal_selection
+                        && sel.anchor != sel.end
                         && sel.contains(cell.row, cell.col)
                     {
                         ratatui_cell.set_style(self.theme.selection_style());


### PR DESCRIPTION
When clicking inside the interactive terminal pane (e.g. to focus it), a single cell would briefly flash with the selection highlight between the `MouseDown` and `MouseUp` events. This happened because `terminal_selection` is set immediately on `MouseDown` with `anchor == end`, and `contains()` returns `true` for that position — causing the renderer to apply the selection style to the clicked cell even though no drag occurred. Users reported this as confusing, interpreting the flash as the cell being copied to the clipboard.

The fix adds a guard to the selection rendering condition at `render.rs:1055` so the highlight is only drawn when `anchor != end`, meaning an actual drag has moved to a different cell. The existing `MouseUp` logic already correctly checks `anchor == end` and clears the selection without copying, so only the visual feedback needed fixing.

This is a single-line change with no impact on drag-to-select or copy behavior. Clicking no longer flashes a highlight; dragging across 1+ cells highlights and copies as before.