### PR TITLE
Allow worktree creation from existing branches

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -47,6 +47,8 @@ enum PromptMouseTarget {
     ConfirmDiscardConfirm,
     ConfirmNonDefaultBranchCancel,
     ConfirmNonDefaultBranchAdd,
+    ConfirmUseExistingBranchCancel,
+    ConfirmUseExistingBranchUse,
     RenameInput,
     NameNewAgentInput,
 }
@@ -1909,6 +1911,28 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ConfirmUseExistingBranch {
+            confirm_selected, ..
+        } = &mut self.prompt
+        {
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
+                    *confirm_selected = !*confirm_selected;
+                }
+                Some(Action::Confirm) => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_use_existing_branch(confirm));
+                }
+                _ if key.code == KeyCode::Char(' ') => {
+                    let confirm = *confirm_selected;
+                    return Ok(self.resolve_confirm_use_existing_branch(confirm));
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if matches!(self.prompt, PromptState::EditMacros { .. }) {
             self.handle_edit_macros_key(key)?;
             return Ok(false);
@@ -1952,6 +1976,29 @@ impl App {
                     let PromptState::NameNewAgent { mut request, .. } = old_prompt else {
                         unreachable!()
                     };
+
+                    // For NewProject requests, check whether the branch already
+                    // exists locally or on the remote before creating a new one.
+                    if let CreateAgentRequest::NewProject { ref project, .. } = request {
+                        let repo_path = std::path::PathBuf::from(&project.path);
+                        if let Some(location) = git::branch_exists(&repo_path, &name) {
+                            if let CreateAgentRequest::NewProject {
+                                ref mut custom_name,
+                                ..
+                            } = request
+                            {
+                                *custom_name = Some(name.clone());
+                            }
+                            self.prompt = PromptState::ConfirmUseExistingBranch {
+                                request,
+                                branch_name: name,
+                                location,
+                                confirm_selected: false,
+                            };
+                            return Ok(false);
+                        }
+                    }
+
                     let msg = match &request {
                         CreateAgentRequest::NewProject { project, .. } => {
                             format!(
@@ -2379,6 +2426,18 @@ impl App {
                     Some(PromptMouseTarget::ConfirmNonDefaultBranchCancel)
                 } else if contains_point(add_button, column, row) {
                     Some(PromptMouseTarget::ConfirmNonDefaultBranchAdd)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmUseExistingBranch {
+                cancel_button,
+                use_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmUseExistingBranchCancel)
+                } else if contains_point(use_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmUseExistingBranchUse)
                 } else {
                     None
                 }
@@ -3020,6 +3079,40 @@ impl App {
         false
     }
 
+    fn resolve_confirm_use_existing_branch(&mut self, confirm: bool) -> bool {
+        let old_prompt = std::mem::replace(&mut self.prompt, PromptState::None);
+        let PromptState::ConfirmUseExistingBranch {
+            mut request,
+            branch_name,
+            ..
+        } = old_prompt
+        else {
+            return false;
+        };
+        if !confirm {
+            return false;
+        }
+        if let CreateAgentRequest::NewProject {
+            use_existing_branch,
+            ..
+        } = &mut request
+        {
+            *use_existing_branch = true;
+        }
+        let msg = if let CreateAgentRequest::NewProject { ref project, .. } = request {
+            format!(
+                "Attaching to existing branch \"{branch_name}\" for project \"{}\" and launching a fresh session...",
+                project.name
+            )
+        } else {
+            unreachable!()
+        };
+        if let Err(e) = self.dispatch_create_agent_request(request, msg) {
+            self.set_error(format!("{e:#}"));
+        }
+        false
+    }
+
     fn set_rename_cursor_from_mouse(&mut self, column: u16) {
         let input_area = match self.overlay_layout.active {
             OverlayMouseLayout::RenameSession { input } => input,
@@ -3215,6 +3308,12 @@ impl App {
             }
             PromptMouseTarget::ConfirmNonDefaultBranchAdd => {
                 return self.resolve_confirm_non_default_branch(true);
+            }
+            PromptMouseTarget::ConfirmUseExistingBranchCancel => {
+                return self.resolve_confirm_use_existing_branch(false);
+            }
+            PromptMouseTarget::ConfirmUseExistingBranchUse => {
+                return self.resolve_confirm_use_existing_branch(true);
             }
             PromptMouseTarget::RenameInput => {
                 self.set_rename_cursor_from_mouse(mouse.column);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -447,6 +447,12 @@ pub(crate) enum PromptState {
         kind: BranchWarningKind,
         confirm_selected: bool, // false = Cancel (default), true = Add Anyway
     },
+    ConfirmUseExistingBranch {
+        request: CreateAgentRequest,
+        branch_name: String,
+        location: crate::git::BranchLocation,
+        confirm_selected: bool, // false = Cancel (default), true = Use Existing
+    },
     DebugInput {
         lines: Vec<Line<'static>>,
         scroll_offset: u16,
@@ -701,6 +707,10 @@ pub(crate) enum OverlayMouseLayout {
         cancel_button: Rect,
         add_button: Rect,
     },
+    ConfirmUseExistingBranch {
+        cancel_button: Rect,
+        use_button: Rect,
+    },
     RenameSession {
         input: Rect,
     },
@@ -766,6 +776,7 @@ pub(crate) enum CreateAgentRequest {
     NewProject {
         project: Project,
         custom_name: Option<String>,
+        use_existing_branch: bool,
     },
     ForkSession {
         project: Project,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3383,6 +3383,121 @@ impl App {
                     add_button: add_area,
                 };
             }
+            PromptState::ConfirmUseExistingBranch {
+                branch_name,
+                location,
+                confirm_selected,
+                ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(60, 30, frame.area());
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Branch Already Exists");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                let location_label = match location {
+                    crate::git::BranchLocation::Local => "local",
+                    crate::git::BranchLocation::Remote => "remote",
+                };
+                let mut lines = vec![Line::from("")];
+                lines.push(Line::from(vec![
+                    Span::raw(" A "),
+                    Span::raw(location_label),
+                    Span::raw(" branch named "),
+                    Span::styled(
+                        branch_name.as_str(),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                ]));
+                lines.push(Line::from(" already exists."));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    " A new worktree will be created using this branch,",
+                    Style::default().fg(self.theme.warning_fg),
+                )));
+                lines.push(Line::from(Span::styled(
+                    " allowing you to continue working on it.",
+                    Style::default().fg(self.theme.warning_fg),
+                )));
+                Paragraph::new(lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = 16u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let use_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) = if !confirm_selected {
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+                let (use_border, use_fg) = if *confirm_selected {
+                    (
+                        self.theme.button_confirm_border,
+                        self.theme.button_active_fg,
+                    )
+                } else {
+                    (self.theme.border_normal, self.theme.hint_desc_fg)
+                };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Use Existing",
+                    Style::default().fg(use_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(use_border)),
+                )
+                .render(use_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::ConfirmUseExistingBranch {
+                    cancel_button: cancel_area,
+                    use_button: use_area,
+                };
+            }
             PromptState::RenameSession {
                 input,
                 rename_branch,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -146,6 +146,7 @@ impl App {
                 request: CreateAgentRequest::NewProject {
                     project,
                     custom_name: None,
+                    use_existing_branch: false,
                 },
                 input: TextInput::new().with_char_map(crate::git::agent_name_char_map),
             };
@@ -157,6 +158,7 @@ impl App {
             CreateAgentRequest::NewProject {
                 project: project.clone(),
                 custom_name: None,
+                use_existing_branch: false,
             },
             format!(
                 "Creating a new agent worktree for project \"{}\" and launching a fresh session...",

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -744,10 +744,24 @@ pub(crate) fn run_create_agent_job(
                 custom_name,
                 use_existing_branch,
             } => {
-                let progress = if use_existing_branch {
+                let repo_path = PathBuf::from(&project.path);
+
+                // Resolve the branch name early so we can check for an
+                // existing branch before calling git worktree add.  When no
+                // custom name was provided, a random pet name is generated.
+                let resolved_name = custom_name.unwrap_or_else(git::docker_style_name);
+
+                // If the caller already confirmed via the UI dialog,
+                // `use_existing_branch` is true.  Otherwise, do a last-mile
+                // check — this covers auto-generated pet names that
+                // coincidentally match an existing branch.
+                let attach_existing =
+                    use_existing_branch || git::branch_exists(&repo_path, &resolved_name).is_some();
+
+                let progress = if attach_existing {
                     format!(
-                        "Attaching to existing branch for project \"{}\"...",
-                        project.name
+                        "Attaching to existing branch \"{}\" for project \"{}\"...",
+                        resolved_name, project.name
                     )
                 } else {
                     format!(
@@ -756,15 +770,13 @@ pub(crate) fn run_create_agent_job(
                     )
                 };
                 let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(progress));
-                let repo_path = PathBuf::from(&project.path);
-                let (branch_name, worktree_path) = if use_existing_branch {
+
+                let (branch_name, worktree_path) = if attach_existing {
                     match git::create_worktree_existing_branch(
                         &repo_path,
                         &paths.worktrees_root,
                         &project.name,
-                        custom_name
-                            .as_deref()
-                            .expect("use_existing_branch requires custom_name"),
+                        &resolved_name,
                     ) {
                         Ok(result) => result,
                         Err(err) => {
@@ -784,7 +796,7 @@ pub(crate) fn run_create_agent_job(
                         &repo_path,
                         &paths.worktrees_root,
                         &project.name,
-                        custom_name.as_deref(),
+                        Some(&resolved_name),
                     ) {
                         Ok(result) => result,
                         Err(err) => {
@@ -800,7 +812,7 @@ pub(crate) fn run_create_agent_job(
                         }
                     }
                 };
-                let status_message = if use_existing_branch {
+                let status_message = if attach_existing {
                     format!(
                         "Attached to existing branch \"{}\" in project \"{}\". The worktree is ready in a fresh session.",
                         branch_name, project.name

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -742,37 +742,77 @@ pub(crate) fn run_create_agent_job(
             CreateAgentRequest::NewProject {
                 project,
                 custom_name,
+                use_existing_branch,
             } => {
-                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-                    "Creating a new worktree for project \"{}\"...",
-                    project.name
-                )));
+                let progress = if use_existing_branch {
+                    format!(
+                        "Attaching to existing branch for project \"{}\"...",
+                        project.name
+                    )
+                } else {
+                    format!(
+                        "Creating a new worktree for project \"{}\"...",
+                        project.name
+                    )
+                };
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(progress));
                 let repo_path = PathBuf::from(&project.path);
-                let (branch_name, worktree_path) = match git::create_worktree(
-                    &repo_path,
-                    &paths.worktrees_root,
-                    &project.name,
-                    custom_name.as_deref(),
-                ) {
-                    Ok(result) => result,
-                    Err(err) => {
-                        logger::error(&format!(
-                            "worktree creation failed for {}: {err}",
-                            project.path
-                        ));
-                        let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
-                            "Failed to create a new worktree for project \"{}\": {err}",
-                            project.name
-                        )));
-                        return;
+                let (branch_name, worktree_path) = if use_existing_branch {
+                    match git::create_worktree_existing_branch(
+                        &repo_path,
+                        &paths.worktrees_root,
+                        &project.name,
+                        custom_name
+                            .as_deref()
+                            .expect("use_existing_branch requires custom_name"),
+                    ) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            logger::error(&format!(
+                                "worktree creation (existing branch) failed for {}: {err}",
+                                project.path
+                            ));
+                            let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                                "Failed to attach to existing branch for project \"{}\": {err}",
+                                project.name
+                            )));
+                            return;
+                        }
+                    }
+                } else {
+                    match git::create_worktree(
+                        &repo_path,
+                        &paths.worktrees_root,
+                        &project.name,
+                        custom_name.as_deref(),
+                    ) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            logger::error(&format!(
+                                "worktree creation failed for {}: {err}",
+                                project.path
+                            ));
+                            let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                                "Failed to create a new worktree for project \"{}\": {err}",
+                                project.name
+                            )));
+                            return;
+                        }
                     }
                 };
-                let status_message = format!(
-                    "Created {} agent \"{}\" in project \"{}\". The new worktree is ready in a fresh session.",
-                    project.default_provider.as_str(),
-                    branch_name,
-                    project.name
-                );
+                let status_message = if use_existing_branch {
+                    format!(
+                        "Attached to existing branch \"{}\" in project \"{}\". The worktree is ready in a fresh session.",
+                        branch_name, project.name
+                    )
+                } else {
+                    format!(
+                        "Created {} agent \"{}\" in project \"{}\". The new worktree is ready in a fresh session.",
+                        project.default_provider.as_str(),
+                        branch_name,
+                        project.name
+                    )
+                };
                 (
                     project.clone(),
                     project.default_provider.clone(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -9,6 +9,15 @@ use content_inspector::{ContentType, inspect};
 
 use crate::model::ChangedFile;
 
+/// Where a branch was found when checking for its existence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BranchLocation {
+    /// The branch exists as a local `refs/heads/` ref.
+    Local,
+    /// The branch exists only as a remote tracking ref (`refs/remotes/origin/`).
+    Remote,
+}
+
 enum DiffStat {
     Text(usize, usize),
     Binary,
@@ -123,6 +132,82 @@ pub fn pull_current_branch(repo_path: &Path) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Checks whether a branch exists locally or on the `origin` remote.
+///
+/// Uses the plumbing command `git rev-parse --verify --quiet` and inspects
+/// only the exit code — no stdout is parsed.
+pub fn branch_exists(repo_path: &Path, name: &str) -> Option<BranchLocation> {
+    let repo = repo_path.to_string_lossy();
+    let local_ref = format!("refs/heads/{name}");
+    let local = Command::new("git")
+        .args([
+            "-C",
+            repo.as_ref(),
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &local_ref,
+        ])
+        .output()
+        .ok()
+        .is_some_and(|o| o.status.success());
+    if local {
+        return Some(BranchLocation::Local);
+    }
+    let remote_ref = format!("refs/remotes/origin/{name}");
+    let remote = Command::new("git")
+        .args([
+            "-C",
+            repo.as_ref(),
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &remote_ref,
+        ])
+        .output()
+        .ok()
+        .is_some_and(|o| o.status.success());
+    if remote {
+        return Some(BranchLocation::Remote);
+    }
+    None
+}
+
+/// Creates a worktree that checks out an **existing** branch (no `-b`).
+///
+/// When the branch exists only as a remote tracking ref, git automatically
+/// creates a local branch that tracks the remote.
+pub fn create_worktree_existing_branch(
+    repo_path: &Path,
+    worktrees_root: &Path,
+    project_name: &str,
+    branch_name: &str,
+) -> Result<(String, PathBuf)> {
+    let project_root = worktrees_root.join(project_name);
+    fs::create_dir_all(&project_root)?;
+    let worktree_path = project_root.join(branch_name);
+    let repo = repo_path.to_string_lossy();
+    let worktree = worktree_path.to_string_lossy();
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo.as_ref(),
+            "worktree",
+            "add",
+            worktree.as_ref(),
+            branch_name,
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let canonical = worktree_path.canonicalize().unwrap_or(worktree_path);
+    Ok((branch_name.to_string(), canonical))
 }
 
 pub fn create_worktree(
@@ -1103,6 +1188,52 @@ mod tests {
 
         let branch = current_branch(&wt).unwrap();
         assert_eq!(branch, "same-name");
+    }
+
+    // ── branch_exists tests ────────────────────────────────────
+
+    #[test]
+    fn branch_exists_returns_none_for_nonexistent() {
+        let repo = init_test_repo();
+        assert_eq!(branch_exists(repo.path(), "no-such-branch"), None);
+    }
+
+    #[test]
+    fn branch_exists_returns_local_for_existing_branch() {
+        let repo = init_test_repo();
+        let _wt = add_worktree(repo.path(), "feature-x");
+        // "feature-x" now exists as a local branch.
+        assert_eq!(
+            branch_exists(repo.path(), "feature-x"),
+            Some(BranchLocation::Local)
+        );
+    }
+
+    // ── create_worktree_existing_branch tests ────────────────
+
+    #[test]
+    fn create_worktree_existing_branch_succeeds_for_local_branch() {
+        let repo = init_test_repo();
+        // Create a branch without a worktree that points to it.
+        run_git(repo.path(), &["branch", "reuse-me"]);
+        let worktrees_root = repo.path().join("wt-root");
+        let (name, path) =
+            create_worktree_existing_branch(repo.path(), &worktrees_root, "proj", "reuse-me")
+                .unwrap();
+        assert_eq!(name, "reuse-me");
+        assert!(path.exists());
+        assert_eq!(current_branch(&path).unwrap(), "reuse-me");
+    }
+
+    #[test]
+    fn create_worktree_existing_branch_fails_when_already_checked_out() {
+        let repo = init_test_repo();
+        let _wt = add_worktree(repo.path(), "occupied");
+        // "occupied" is checked out in _wt — git forbids a second worktree.
+        let worktrees_root = repo.path().join("wt-root");
+        let result =
+            create_worktree_existing_branch(repo.path(), &worktrees_root, "proj", "occupied");
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
When a user provides a custom agent name that matches a branch already present locally or on the remote, dux currently fails with a raw git error (`fatal: branch 'X' already exists`). This PR detects that situation before running `git worktree add`, presents a confirmation dialog explaining where the branch was found (local or remote), and — if confirmed — creates the worktree by checking out the existing branch instead of trying to create a new one with `-b`. This lets users pick up work on branches they or teammates have already started.

The implementation adds `branch_exists()` using the plumbing command `git rev-parse --verify --quiet` (exit-code only, no stdout parsing) and a companion `create_worktree_existing_branch()` that runs `git worktree add <path> <branch>` without `-b`. When the branch exists only on the remote, git automatically sets up local tracking. The new `ConfirmUseExistingBranch` prompt follows the same keyboard, mouse, and rendering patterns as the existing `ConfirmNonDefaultBranch` dialog, with non-destructive "confirm" styling on the "Use Existing" button. The check also runs in the worker thread for auto-generated pet names, so even randomly generated names that happen to match an existing branch will silently attach to it rather than failing.