### PR TITLE
Append README install instructions to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,47 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ github.event.release.tag_name }} install.sh
+
+  update-release-notes:
+    name: Append install instructions
+    runs-on: ubuntu-latest
+    needs: [build, upload-install-script]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Append install section to release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Extract the Install section body from README
+          # (between "## Install" and next "## ", excluding both headings)
+          install_section=$(sed -n '/^## Install$/,/^## /{/^## /d; p}' README.md | sed -e :a -e '/^\n*$/{$d;N;ba;}')
+
+          # Get current release body
+          current_body=$(gh release view "${{ github.event.release.tag_name }}" --json body -q '.body')
+
+          # Split at "Full Changelog" line and reassemble
+          if echo "$current_body" | grep -q '^\*\*Full Changelog\*\*'; then
+            before=$(echo "$current_body" | sed '/^\*\*Full Changelog\*\*/,$d' | sed -e :a -e '/^\n*$/{$d;N;ba;}')
+            changelog_line=$(echo "$current_body" | grep '^\*\*Full Changelog\*\*')
+            new_body="${before}
+
+          ---
+
+          ## Install
+
+          ${install_section}
+
+          ${changelog_line}"
+          else
+            # No Full Changelog line — just append
+            new_body="${current_body}
+
+          ---
+
+          ## Install
+
+          ${install_section}"
+          fi
+
+          gh release edit "${{ github.event.release.tag_name }}" --notes "$new_body"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,9 @@ jobs:
 
           ---
 
-          ## Install
+          ## Installation
+
+          Use any of the following options to install dux on your system:
 
           ${install_section}
 
@@ -113,7 +115,9 @@ jobs:
 
           ---
 
-          ## Install
+          ## Installation
+
+          Use any of the following options to install dux on your system:
 
           ${install_section}"
           fi


### PR DESCRIPTION
When a GitHub release is published, the release notes are written manually but don't include installation instructions. This adds a new CI job that automatically extracts the `## Install` section from `README.md` and appends it to the release notes after a horizontal rule, right before the `**Full Changelog**` link. This keeps install instructions in sync with the README without requiring manual copy-paste on every release.

The new `update-release-notes` job runs after both `build` and `upload-install-script` complete. It uses `sed` to extract the install section body from the README, splits the existing release notes at the `**Full Changelog**` line, and reassembles them with the install content inserted between. If no changelog line is present, the install section is simply appended.

The approach was dry-run tested locally against the v0.1.0 release body and current README content to verify correct extraction, formatting, and placement.