### PR TITLE
Fix test compilation broken by missing path_missing field

### DIFF
--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1533,6 +1533,7 @@ mod tests {
             path: "/tmp/project".to_string(),
             default_provider: ProviderKind::from_str(provider),
             current_branch: "main".to_string(),
+            path_missing: false,
         }
     }
 


### PR DESCRIPTION
The `path_missing` field was added to the `Project` struct in #172 to support rendering missing projects gracefully, but the `make_project` test helper in `src/app/sessions.rs` was not updated to include it. This caused all 565 tests to fail to compile.

This adds `path_missing: false` to the test helper, restoring the test suite to a passing state. The value `false` is the correct default since test projects point to `/tmp/project` and are not expected to model missing paths.

This is a one-line fix with no behavioral changes to production code — only the test helper is affected.