### PR TITLE
Make worktree deletion optional when deleting an agent

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4158,6 +4158,7 @@ mod tests {
             refs_watch_paths: std::collections::HashMap::new(),
             resume_fallback_candidates: std::collections::HashSet::new(),
             pending_deletions: std::collections::HashSet::new(),
+            deletion_busy_messages: std::collections::HashMap::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4157,6 +4157,7 @@ mod tests {
             refs_watcher: None,
             refs_watch_paths: std::collections::HashMap::new(),
             resume_fallback_candidates: std::collections::HashSet::new(),
+            pending_deletions: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1808,24 +1808,57 @@ impl App {
         }
 
         if let PromptState::ConfirmDeleteAgent {
-            confirm_selected, ..
+            focus,
+            delete_worktree,
+            worktree_shared,
+            ..
         } = &mut self.prompt
         {
+            // When the worktree is shared with another session it is always
+            // preserved, so the checkbox is hidden and the focus cycle skips
+            // over it (Cancel ↔ Delete only).
+            let shared = *worktree_shared;
             match self.bindings.lookup(&key, BindingScope::Dialog) {
                 Some(Action::CloseOverlay) => self.prompt = PromptState::None,
                 Some(Action::ToggleSelection) => {
-                    *confirm_selected = !*confirm_selected;
+                    // Cycle forward through all selectable elements so Tab and
+                    // arrow keys (Left/Right/h/l all map to ToggleSelection in
+                    // Dialog scope) behave identically.
+                    *focus = match (*focus, shared) {
+                        (DeleteAgentFocus::Cancel, false) => DeleteAgentFocus::Delete,
+                        (DeleteAgentFocus::Delete, false) => DeleteAgentFocus::Checkbox,
+                        (DeleteAgentFocus::Checkbox, _) => DeleteAgentFocus::Cancel,
+                        (DeleteAgentFocus::Cancel, true) => DeleteAgentFocus::Delete,
+                        (DeleteAgentFocus::Delete, true) => DeleteAgentFocus::Cancel,
+                    };
                 }
-                Some(Action::Confirm) => {
-                    let confirm = *confirm_selected;
-                    return Ok(self.resolve_confirm_delete_agent(confirm));
-                }
-                _ if key.code == KeyCode::Char(' ') => {
-                    let confirm = *confirm_selected;
-                    return Ok(self.resolve_confirm_delete_agent(confirm));
-                }
+                Some(Action::Confirm) => match *focus {
+                    DeleteAgentFocus::Checkbox => {
+                        *delete_worktree = !*delete_worktree;
+                    }
+                    DeleteAgentFocus::Cancel => {
+                        return Ok(self.resolve_confirm_delete_agent(false));
+                    }
+                    DeleteAgentFocus::Delete => {
+                        return Ok(self.resolve_confirm_delete_agent(true));
+                    }
+                },
+                // Space activates the focused element — toggles the checkbox
+                // when focused there, otherwise activates the current button.
+                _ if key.code == KeyCode::Char(' ') => match *focus {
+                    DeleteAgentFocus::Checkbox => {
+                        *delete_worktree = !*delete_worktree;
+                    }
+                    DeleteAgentFocus::Cancel => {
+                        return Ok(self.resolve_confirm_delete_agent(false));
+                    }
+                    DeleteAgentFocus::Delete => {
+                        return Ok(self.resolve_confirm_delete_agent(true));
+                    }
+                },
                 _ => {}
             }
+            return Ok(false);
         }
 
         if let PromptState::ConfirmDeleteTerminal {
@@ -2960,13 +2993,20 @@ impl App {
     }
 
     fn resolve_confirm_delete_agent(&mut self, confirm: bool) -> bool {
-        let session_id = match &self.prompt {
-            PromptState::ConfirmDeleteAgent { session_id, .. } => session_id.clone(),
+        let (session_id, delete_worktree) = match &self.prompt {
+            PromptState::ConfirmDeleteAgent {
+                session_id,
+                delete_worktree,
+                ..
+            } => (session_id.clone(), *delete_worktree),
             _ => return false,
         };
         self.prompt = PromptState::None;
-        if confirm && let Err(e) = self.do_delete_session(&session_id) {
-            self.set_error(format!("{e:#}"));
+        if confirm {
+            // Dispatches git work to a worker when needed, so the UI stays
+            // responsive. Errors arrive asynchronously via
+            // `WorkerEvent::WorktreeRemoveCompleted`.
+            self.begin_delete_session(&session_id, delete_worktree);
         }
         false
     }
@@ -3932,11 +3972,11 @@ mod tests {
 
     use super::DOUBLE_CLICK_THRESHOLD;
     use crate::app::{
-        App, CenterMode, ConfirmKillRunningPrompt, FocusPane, FullscreenOverlay, InputTarget,
-        KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
-        KillableRuntime, KillableRuntimeKind, LeftSection, MouseClickTarget, MouseLayoutState,
-        OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget, RightSection,
-        RuntimeTargetId, TextInput, WorkerEvent,
+        App, CenterMode, ConfirmKillRunningPrompt, DeleteAgentFocus, FocusPane, FullscreenOverlay,
+        InputTarget, KillRunningAction, KillRunningFocus, KillRunningFooterAction,
+        KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftSection, MouseClickTarget,
+        MouseLayoutState, OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget,
+        RightSection, RuntimeTargetId, TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -6618,7 +6658,9 @@ mod tests {
         app.prompt = PromptState::ConfirmDeleteAgent {
             session_id: app.sessions[0].id.clone(),
             branch_name: app.sessions[0].branch_name.clone(),
-            confirm_selected: false,
+            focus: DeleteAgentFocus::Cancel,
+            delete_worktree: false,
+            worktree_shared: false,
         };
         install_confirm_delete_overlay(&mut app);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -151,6 +151,12 @@ pub struct App {
     /// Session IDs spawned with resume_args that should fall back to regular
     /// args if the PTY exits before producing any output.
     pub(crate) resume_fallback_candidates: HashSet<String>,
+    /// Session IDs whose worktree is currently being removed by a background
+    /// worker. Prevents duplicate delete requests from spawning a second
+    /// worker while the first is still running; also drives the dimmed
+    /// visual cue on the left pane row so the user can see the in-flight
+    /// state.
+    pub(crate) pending_deletions: HashSet<String>,
     /// Cached syntax highlighting resources shared across diff computations.
     pub(crate) syntax_cache: SyntaxCache,
     /// Reusable snapshot buffer to avoid per-frame allocation of terminal cells.
@@ -993,6 +999,7 @@ impl App {
             refs_watcher: None,
             refs_watch_paths: HashMap::new(),
             resume_fallback_candidates: HashSet::new(),
+            pending_deletions: HashSet::new(),
             syntax_cache: SyntaxCache::new(),
             snapshot_buf: TerminalSnapshot::empty(),
             last_snapshot_id: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -157,6 +157,12 @@ pub struct App {
     /// visual cue on the left pane row so the user can see the in-flight
     /// state.
     pub(crate) pending_deletions: HashSet<String>,
+    /// Maps session IDs to the exact Busy message set by
+    /// `begin_delete_session`. Used by the worker event handler to decide
+    /// whether the current status-line content was set by this deletion (and
+    /// should be cleared) or by an unrelated operation (and should be left
+    /// alone). Cleared per-session when the worker event arrives.
+    pub(crate) deletion_busy_messages: HashMap<String, String>,
     /// Cached syntax highlighting resources shared across diff computations.
     pub(crate) syntax_cache: SyntaxCache,
     /// Reusable snapshot buffer to avoid per-frame allocation of terminal cells.
@@ -1000,6 +1006,7 @@ impl App {
             refs_watch_paths: HashMap::new(),
             resume_fallback_candidates: HashSet::new(),
             pending_deletions: HashSet::new(),
+            deletion_busy_messages: HashMap::new(),
             syntax_cache: SyntaxCache::new(),
             snapshot_buf: TerminalSnapshot::empty(),
             last_snapshot_id: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -379,6 +379,15 @@ pub(crate) struct ConfirmKillRunningPrompt {
     pub(crate) confirm_selected: bool,
 }
 
+/// Which selectable element has focus in the Delete Agent confirmation modal.
+/// Focus cycles through all three via Tab / arrow keys / h / l.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DeleteAgentFocus {
+    Cancel,
+    Delete,
+    Checkbox,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum PromptState {
     None,
@@ -403,7 +412,12 @@ pub(crate) enum PromptState {
     ConfirmDeleteAgent {
         session_id: String,
         branch_name: String,
-        confirm_selected: bool, // false = Cancel (default), true = Delete
+        focus: DeleteAgentFocus,
+        delete_worktree: bool,
+        /// True when one or more other sessions share this worktree. In that
+        /// case the worktree is always preserved regardless of the user's
+        /// choice, so the checkbox is hidden and a note is shown instead.
+        worktree_shared: bool,
     },
     ConfirmDeleteTerminal {
         terminal_id: String,
@@ -827,6 +841,15 @@ pub(crate) enum WorkerEvent {
     GhStatusChecked(crate::model::GhStatus),
     PrStatusReady(Vec<(String, Option<crate::model::PrInfo>)>),
     RefsChanged(String),
+    /// Background `git worktree remove` for a session-initiated delete has
+    /// finished. On `Ok`, the boolean indicates whether the branch was
+    /// already gone (used for the status message). On `Err`, the message is
+    /// the formatted error; the session record must be preserved so the user
+    /// can retry.
+    WorktreeRemoveCompleted {
+        session_id: String,
+        result: Result<bool, String>,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2854,7 +2854,9 @@ impl App {
             }
             PromptState::ConfirmDeleteAgent {
                 branch_name,
-                confirm_selected,
+                focus,
+                delete_worktree,
+                worktree_shared,
                 ..
             } => {
                 self.render_dim_overlay(frame);
@@ -2865,17 +2867,21 @@ impl App {
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                // Body text.
-                let [body_area, _, buttons_area] = Layout::default()
+                // Layout: body / checkbox row / spacer / buttons.
+                // Checkbox row is two lines (checkbox + descriptor) so the
+                // yellow warning can replace the descriptor in-place without
+                // shifting the button row when toggled.
+                let [body_area, checkbox_area, _, buttons_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Min(1),
+                        Constraint::Length(2),
                         Constraint::Length(1),
                         Constraint::Length(3),
                     ])
                     .areas(inner);
 
-                let lines = vec![
+                let body_lines = vec![
                     Line::from(""),
                     Line::from(vec![
                         Span::raw(" Are you sure you want to delete "),
@@ -2885,19 +2891,64 @@ impl App {
                         ),
                         Span::raw("?"),
                     ]),
-                    Line::from(""),
-                    Line::from(Span::styled(
-                        " All uncommitted and unpushed changes in this",
-                        Style::default().fg(self.theme.warning_fg),
-                    )),
-                    Line::from(Span::styled(
-                        " worktree will be permanently lost.",
-                        Style::default().fg(self.theme.warning_fg),
-                    )),
                 ];
-                Paragraph::new(lines)
+                Paragraph::new(body_lines)
                     .wrap(Wrap { trim: false })
                     .render(body_area, frame.buffer_mut());
+
+                // Checkbox row. When the worktree is shared with another
+                // session, the checkbox is meaningless (the worktree is always
+                // preserved), so it's replaced with an informational note.
+                // Otherwise, the focus ring follows the Tab cycle; when the
+                // checkbox is focused, the label is highlighted with the
+                // active button color so the user sees the same visual
+                // language whether they're hovering a button or the checkbox.
+                let (checkbox_line, descriptor_line) = if *worktree_shared {
+                    (
+                        Line::from(Span::styled(
+                            " Worktree is shared with another agent and will be preserved.",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        )),
+                        Line::from(""),
+                    )
+                } else {
+                    let check = if *delete_worktree { "x" } else { " " };
+                    let checkbox_focused = *focus == DeleteAgentFocus::Checkbox;
+                    let label_style = if checkbox_focused {
+                        Style::default()
+                            .fg(self.theme.button_active_fg)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(self.theme.input_label_fg)
+                    };
+                    let bracket_style = if checkbox_focused {
+                        Style::default()
+                            .fg(self.theme.button_active_fg)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(self.theme.hint_key_fg)
+                    };
+                    let checkbox_line = Line::from(vec![
+                        Span::raw(" "),
+                        Span::styled(format!("[{check}]"), bracket_style),
+                        Span::styled(" Also delete the worktree and branch", label_style),
+                    ]);
+                    let descriptor_line = if *delete_worktree {
+                        Line::from(Span::styled(
+                            "     All uncommitted and unpushed changes in this worktree will be permanently lost.",
+                            Style::default().fg(self.theme.warning_fg),
+                        ))
+                    } else {
+                        Line::from(Span::styled(
+                            "     Worktree and branch will be preserved on disk.",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ))
+                    };
+                    (checkbox_line, descriptor_line)
+                };
+                Paragraph::new(vec![checkbox_line, descriptor_line])
+                    .wrap(Wrap { trim: false })
+                    .render(checkbox_area, frame.buffer_mut());
 
                 // Button area: two bordered panels side by side.
                 let btn_width = 16u16;
@@ -2918,7 +2969,7 @@ impl App {
                     height: 3,
                 };
 
-                let (cancel_border, cancel_fg) = if !confirm_selected {
+                let (cancel_border, cancel_fg) = if *focus == DeleteAgentFocus::Cancel {
                     (
                         self.theme.button_confirm_border,
                         self.theme.button_active_fg,
@@ -2926,7 +2977,7 @@ impl App {
                 } else {
                     (self.theme.border_normal, self.theme.hint_desc_fg)
                 };
-                let (delete_border, delete_fg) = if *confirm_selected {
+                let (delete_border, delete_fg) = if *focus == DeleteAgentFocus::Delete {
                     (self.theme.button_danger_border, self.theme.button_active_fg)
                 } else {
                     (self.theme.border_normal, self.theme.hint_desc_fg)

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -498,11 +498,12 @@ impl App {
                             (d.to_string(), c)
                         };
                     // While a background delete is in flight for this session,
-                    // dim the whole row and italicize it so the user sees the
-                    // transient state and understands why the session is
-                    // still visible but unresponsive. This overrides PR and
-                    // status colors on purpose — "being deleted" trumps
-                    // other signals.
+                    // dim the row text and italicize it so the user sees the
+                    // transient state. This covers the dot, label, and
+                    // provider suffix; the companion-terminal badge chain is
+                    // excluded because it renders through a separate helper
+                    // and the in-flight window is too brief to justify
+                    // threading a deletion flag through it.
                     let deleting = self.pending_deletions.contains(&session.id);
                     let label_color = if deleting {
                         self.theme.session_deleting
@@ -528,7 +529,11 @@ impl App {
                             Span::styled(label, label_style),
                             Span::styled(
                                 format!(" ({})", session.provider.as_str()),
-                                Style::default().fg(self.theme.provider_label_fg),
+                                if deleting {
+                                    label_style
+                                } else {
+                                    Style::default().fg(self.theme.provider_label_fg)
+                                },
                             ),
                         ]
                         .into_iter()

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -497,17 +497,35 @@ impl App {
                             let (d, c) = self.theme.session_dot(&session.status);
                             (d.to_string(), c)
                         };
-                    let label_color = match self.pr_statuses.get(&session.id).map(|pr| &pr.state) {
-                        Some(crate::model::PrState::Merged) => self.theme.pr_merged_label,
-                        Some(crate::model::PrState::Closed) => self.theme.pr_closed_label,
-                        Some(crate::model::PrState::Open) => self.theme.pr_open_label,
-                        None => dot_color,
+                    // While a background delete is in flight for this session,
+                    // dim the whole row and italicize it so the user sees the
+                    // transient state and understands why the session is
+                    // still visible but unresponsive. This overrides PR and
+                    // status colors on purpose — "being deleted" trumps
+                    // other signals.
+                    let deleting = self.pending_deletions.contains(&session.id);
+                    let label_color = if deleting {
+                        self.theme.session_deleting
+                    } else {
+                        match self.pr_statuses.get(&session.id).map(|pr| &pr.state) {
+                            Some(crate::model::PrState::Merged) => self.theme.pr_merged_label,
+                            Some(crate::model::PrState::Closed) => self.theme.pr_closed_label,
+                            Some(crate::model::PrState::Open) => self.theme.pr_open_label,
+                            None => dot_color,
+                        }
+                    };
+                    let label_style = if deleting {
+                        Style::default()
+                            .fg(label_color)
+                            .add_modifier(Modifier::ITALIC)
+                    } else {
+                        Style::default().fg(label_color)
                     };
                     ListItem::new(Line::from(
                         vec![
                             Span::styled(connector, Style::default().fg(self.theme.project_icon)),
-                            Span::styled(format!("{dot} "), Style::default().fg(label_color)),
-                            Span::styled(label, Style::default().fg(label_color)),
+                            Span::styled(format!("{dot} "), label_style),
+                            Span::styled(label, label_style),
                             Span::styled(
                                 format!(" ({})", session.provider.as_str()),
                                 Style::default().fg(self.theme.provider_label_fg),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2890,21 +2890,24 @@ impl App {
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                // Layout: body / checkbox row / spacer / buttons.
-                // Checkbox row is two lines (checkbox + descriptor) so the
-                // yellow warning can replace the descriptor in-place without
-                // shifting the button row when toggled.
+                // Layout: body (flexible) / checkbox (1 row) / spacer / buttons.
+                // The warning text and hint live in the flexible body area so
+                // long lines can wrap safely without truncation. The checkbox
+                // is a single fixed-height row below the body.
                 let [body_area, checkbox_area, _, buttons_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Min(1),
-                        Constraint::Length(2),
+                        Constraint::Length(1),
                         Constraint::Length(1),
                         Constraint::Length(3),
                     ])
                     .areas(inner);
 
-                let body_lines = vec![
+                // Body: question text + conditional warning/hint/shared note.
+                // Long warning text is split into two explicit Lines so it
+                // renders correctly even at narrow dialog widths.
+                let mut body_lines = vec![
                     Line::from(""),
                     Line::from(vec![
                         Span::raw(" Are you sure you want to delete "),
@@ -2914,27 +2917,36 @@ impl App {
                         ),
                         Span::raw("?"),
                     ]),
+                    Line::from(""),
                 ];
+                if *worktree_shared {
+                    body_lines.push(Line::from(Span::styled(
+                        " Worktree is shared with another agent and will be preserved.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )));
+                } else if *delete_worktree {
+                    body_lines.push(Line::from(Span::styled(
+                        " All uncommitted and unpushed changes in this",
+                        Style::default().fg(self.theme.warning_fg),
+                    )));
+                    body_lines.push(Line::from(Span::styled(
+                        " worktree will be permanently lost.",
+                        Style::default().fg(self.theme.warning_fg),
+                    )));
+                } else {
+                    body_lines.push(Line::from(Span::styled(
+                        " Worktree and branch will be preserved on disk.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )));
+                }
                 Paragraph::new(body_lines)
                     .wrap(Wrap { trim: false })
                     .render(body_area, frame.buffer_mut());
 
-                // Checkbox row. When the worktree is shared with another
-                // session, the checkbox is meaningless (the worktree is always
-                // preserved), so it's replaced with an informational note.
-                // Otherwise, the focus ring follows the Tab cycle; when the
-                // checkbox is focused, the label is highlighted with the
-                // active button color so the user sees the same visual
-                // language whether they're hovering a button or the checkbox.
-                let (checkbox_line, descriptor_line) = if *worktree_shared {
-                    (
-                        Line::from(Span::styled(
-                            " Worktree is shared with another agent and will be preserved.",
-                            Style::default().fg(self.theme.hint_desc_fg),
-                        )),
-                        Line::from(""),
-                    )
-                } else {
+                // Checkbox row (1 line). When the worktree is shared, the
+                // checkbox is hidden and the line is left empty — the shared
+                // note above already explains the situation.
+                if !*worktree_shared {
                     let check = if *delete_worktree { "x" } else { " " };
                     let checkbox_focused = *focus == DeleteAgentFocus::Checkbox;
                     let label_style = if checkbox_focused {
@@ -2951,27 +2963,13 @@ impl App {
                     } else {
                         Style::default().fg(self.theme.hint_key_fg)
                     };
-                    let checkbox_line = Line::from(vec![
+                    Paragraph::new(Line::from(vec![
                         Span::raw(" "),
                         Span::styled(format!("[{check}]"), bracket_style),
                         Span::styled(" Also delete the worktree and branch", label_style),
-                    ]);
-                    let descriptor_line = if *delete_worktree {
-                        Line::from(Span::styled(
-                            "     All uncommitted and unpushed changes in this worktree will be permanently lost.",
-                            Style::default().fg(self.theme.warning_fg),
-                        ))
-                    } else {
-                        Line::from(Span::styled(
-                            "     Worktree and branch will be preserved on disk.",
-                            Style::default().fg(self.theme.hint_desc_fg),
-                        ))
-                    };
-                    (checkbox_line, descriptor_line)
-                };
-                Paragraph::new(vec![checkbox_line, descriptor_line])
-                    .wrap(Wrap { trim: false })
+                    ]))
                     .render(checkbox_area, frame.buffer_mut());
+                }
 
                 // Button area: two bordered panels side by side.
                 let btn_width = 16u16;

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -581,6 +581,14 @@ impl App {
     /// path only touches in-memory state and SQLite, which is effectively
     /// instantaneous.
     pub(crate) fn begin_delete_session(&mut self, session_id: &str, delete_worktree: bool) {
+        // Reject duplicate delete requests for the same session. The first
+        // worker will clean up when it finishes; spawning a second one would
+        // just race and confuse the status line.
+        if self.pending_deletions.contains(session_id) {
+            self.set_error("Deletion already in progress for this agent. Wait for it to finish.");
+            return;
+        }
+
         let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
             return;
         };
@@ -603,6 +611,10 @@ impl App {
                 "deleting session {} at {} (delete_worktree=true, async)",
                 session.id, session.worktree_path
             ));
+            // Mark in-flight BEFORE spawning, so a fast follow-up action from
+            // the same event loop tick can see the guard. The worker event
+            // handler clears the entry on completion (Ok or Err).
+            self.pending_deletions.insert(session.id.clone());
             let sid = session.id.clone();
             let project_path = project.path.clone();
             let worktree_path = session.worktree_path.clone();
@@ -1663,6 +1675,7 @@ mod tests {
             refs_watcher: None,
             refs_watch_paths: std::collections::HashMap::new(),
             resume_fallback_candidates: std::collections::HashSet::new(),
+            pending_deletions: std::collections::HashSet::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
@@ -2033,5 +2046,72 @@ mod tests {
         // Second call must not panic or return Err even though session is gone.
         app.finish_delete_session("s1", false, None)
             .expect("second finish is a no-op");
+    }
+
+    /// Kicking off the async delete path should mark the session as
+    /// pending so the UI can dim the row.
+    #[test]
+    fn begin_delete_session_tracks_pending_deletion() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.begin_delete_session("s1", true);
+
+        assert!(
+            app.pending_deletions.contains("s1"),
+            "session must be marked pending while async worker runs",
+        );
+    }
+
+    /// The inline (no-git) path completes immediately, so pending_deletions
+    /// should never gain the session in the first place.
+    #[test]
+    fn begin_delete_session_inline_does_not_track() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.begin_delete_session("s1", false);
+
+        assert!(
+            app.pending_deletions.is_empty(),
+            "inline path should never populate pending_deletions",
+        );
+    }
+
+    /// A second delete request for a session that's already being deleted
+    /// must be refused with an error, and must NOT spawn another worker
+    /// (i.e. the pending-deletions set size stays at 1).
+    #[test]
+    fn begin_delete_session_rejects_duplicate_request() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.begin_delete_session("s1", true);
+        assert_eq!(app.pending_deletions.len(), 1, "first call records pending");
+
+        app.begin_delete_session("s1", true);
+        assert_eq!(
+            app.pending_deletions.len(),
+            1,
+            "duplicate request must not spawn a second worker",
+        );
     }
 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -555,16 +555,22 @@ impl App {
         // Worktrees are user data — if we can't remove the worktree cleanly, we
         // must not leave the user with a deleted agent record and an orphaned
         // worktree on disk.
-        let remove_outcome = if should_remove_worktree {
-            let result = git::remove_worktree(
-                Path::new(&project.path),
-                Path::new(&session.worktree_path),
-                &session.branch_name,
-            )?;
-            Some(result.branch_already_deleted)
-        } else {
-            None
-        };
+        //
+        // If an async delete worker is already removing this worktree (the
+        // session is in `pending_deletions`), skip the synchronous git call
+        // to avoid racing it. The worker will finish the removal on its own;
+        // we only need to clean up the session record here.
+        let remove_outcome =
+            if should_remove_worktree && !self.pending_deletions.contains(session_id) {
+                let result = git::remove_worktree(
+                    Path::new(&project.path),
+                    Path::new(&session.worktree_path),
+                    &session.branch_name,
+                )?;
+                Some(result.branch_already_deleted)
+            } else {
+                None
+            };
 
         self.finish_delete_session(session_id, delete_worktree, remove_outcome)?;
         Ok(())
@@ -734,14 +740,17 @@ impl App {
                 }
             }
             (false, true, None) => {
-                // Unexpected: the caller should only set delete_worktree=true
-                // with no siblings when a successful git removal has already
-                // run, producing Some(outcome). Surface a visible error in
-                // all builds so the invalid state is noticed — debug_assert
-                // alone is a silent no-op in release.
-                self.set_error(
-                    "Internal error: worktree deletion flagged but no removal result provided.",
-                );
+                // Worktree deletion was requested but git was not invoked by
+                // this code path. This happens when an async delete worker
+                // is already removing the worktree (`do_delete_session`
+                // skips the synchronous git call to avoid racing the
+                // worker). The session record is now cleaned up; the worker
+                // will finish the worktree removal separately.
+                self.set_info(format!(
+                    "Deleted {} agent \"{}\". Worktree removal already in progress.",
+                    session.provider.as_str(),
+                    session.branch_name,
+                ));
             }
         }
         Ok(())
@@ -2205,6 +2214,76 @@ mod tests {
             app.status.text().contains("Deleted project"),
             "the project-deletion message must not be clobbered, got: {}",
             app.status.text(),
+        );
+    }
+
+    /// When `do_delete_session` is called for a session that already has an
+    /// async worker removing its worktree (`pending_deletions` contains the
+    /// session ID), the synchronous git call must be skipped to avoid racing
+    /// the worker. The session record should still be cleaned up and the
+    /// status message should note that the worktree removal is in progress.
+    #[test]
+    fn do_delete_session_skips_git_when_pending() {
+        let project_dir = tempdir().expect("project tempdir");
+        // Non-git directory — if the code accidentally ran git, it would fail.
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        // Pretend an async delete worker is already running for this session.
+        app.pending_deletions.insert("s1".to_string());
+
+        // This would fail with Err if git ran (non-git project dir). If the
+        // pending check works, git is skipped and this succeeds.
+        app.do_delete_session("s1", true)
+            .expect("must succeed by skipping git when worker is in-flight");
+
+        assert!(
+            app.sessions.iter().all(|s| s.id != "s1"),
+            "session record should be cleaned up even though git was skipped",
+        );
+        assert!(
+            app.status.text().contains("already in progress"),
+            "status should mention the in-progress removal, got: {}",
+            app.status.text(),
+        );
+    }
+
+    /// When the worker fails to delete a worktree, the error message should
+    /// include the agent label so the user knows which one failed.
+    #[test]
+    fn worktree_remove_failure_identifies_agent() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.pending_deletions.insert("s1".to_string());
+
+        app.worker_tx
+            .send(WorkerEvent::WorktreeRemoveCompleted {
+                session_id: "s1".to_string(),
+                result: Err("fatal: not a git repository".to_string()),
+            })
+            .expect("channel send");
+        app.drain_events();
+
+        let msg = app.status.text();
+        assert!(
+            msg.contains("branch-s1"),
+            "error should include the agent's branch name, got: {msg}",
+        );
+        assert!(
+            msg.contains("not a git repository"),
+            "error should include the git error, got: {msg}",
         );
     }
 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -711,6 +711,20 @@ impl App {
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
 
+        // Detect contract violation unconditionally, regardless of
+        // update_status. Callers that pass delete_worktree=true with no
+        // siblings must have already run git::remove_worktree and produced
+        // Some(outcome). Return Err so the violation surfaces in callers
+        // and tests rather than being silently treated as a success.
+        // Note: session cleanup above already ran (DB + memory), so the
+        // session is gone; the Err signals the broken invariant, not an
+        // incomplete deletion.
+        if !other_sessions_on_worktree && delete_worktree && remove_outcome.is_none() {
+            return Err(anyhow::anyhow!(
+                "Internal error: worktree deletion flagged but no removal result provided."
+            ));
+        }
+
         if update_status {
             match (other_sessions_on_worktree, delete_worktree, remove_outcome) {
                 (true, true, _) => {
@@ -754,17 +768,8 @@ impl App {
                         ));
                     }
                 }
-                (false, true, None) => {
-                    // Callers that pass delete_worktree=true with no siblings
-                    // must have already run git::remove_worktree and produced
-                    // Some(outcome). This arm is unreachable via the current
-                    // call graph but kept for exhaustiveness; surface a
-                    // visible error in all builds so any future contract
-                    // violation is noticed.
-                    self.set_error(
-                        "Internal error: worktree deletion flagged but no removal result provided.",
-                    );
-                }
+                // Guarded by the early return above; kept for exhaustiveness.
+                (false, true, None) => {}
             }
         }
         Ok(())

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -2114,4 +2114,49 @@ mod tests {
             "duplicate request must not spawn a second worker",
         );
     }
+
+    /// If the session was removed by another code path (e.g. project
+    /// deletion) while the async delete worker was running, the worker's
+    /// completion event must still overwrite the Busy status line — the
+    /// handler cannot rely on `finish_delete_session`'s idempotent early
+    /// return to do it.
+    #[test]
+    fn worktree_remove_completed_clears_busy_when_session_already_gone() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        // Simulate the Busy state set by `begin_delete_session`.
+        app.set_busy("Removing worktree for agent \"branch-s1\"\u{2026}");
+        app.pending_deletions.insert("s1".to_string());
+
+        // Another code path removes the session before the worker replies
+        // (mirrors what `delete_project` does when iterating sessions).
+        app.sessions.retain(|s| s.id != "s1");
+
+        // The worker then reports success.
+        app.worker_tx
+            .send(WorkerEvent::WorktreeRemoveCompleted {
+                session_id: "s1".to_string(),
+                result: Ok(false),
+            })
+            .expect("channel send");
+        app.drain_events();
+
+        assert!(
+            app.pending_deletions.is_empty(),
+            "pending guard must be cleared on completion",
+        );
+        assert_ne!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Busy,
+            "Busy status must not linger after worker completes, got: {}",
+            app.status.text(),
+        );
+    }
 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -556,21 +556,26 @@ impl App {
         // must not leave the user with a deleted agent record and an orphaned
         // worktree on disk.
         //
-        // If an async delete worker is already removing this worktree (the
-        // session is in `pending_deletions`), skip the synchronous git call
-        // to avoid racing it. The worker will finish the removal on its own;
-        // we only need to clean up the session record here.
-        let remove_outcome =
-            if should_remove_worktree && !self.pending_deletions.contains(session_id) {
-                let result = git::remove_worktree(
-                    Path::new(&project.path),
-                    Path::new(&session.worktree_path),
-                    &session.branch_name,
-                )?;
-                Some(result.branch_already_deleted)
-            } else {
-                None
-            };
+        // Callers must ensure no async worker is already removing this
+        // worktree (`pending_deletions` should not contain this session).
+        // `delete_selected_project` checks this at entry; `begin_delete_session`
+        // uses a separate async path entirely. If a caller violates this
+        // contract two concurrent git calls will race, so we assert in debug.
+        debug_assert!(
+            !self.pending_deletions.contains(session_id),
+            "do_delete_session called while an async delete worker is in-flight for {}",
+            session_id,
+        );
+        let remove_outcome = if should_remove_worktree {
+            let result = git::remove_worktree(
+                Path::new(&project.path),
+                Path::new(&session.worktree_path),
+                &session.branch_name,
+            )?;
+            Some(result.branch_already_deleted)
+        } else {
+            None
+        };
 
         self.finish_delete_session(session_id, delete_worktree, remove_outcome)?;
         Ok(())
@@ -639,10 +644,13 @@ impl App {
                     result,
                 });
             });
-            self.set_busy(format!(
+            let busy_msg = format!(
                 "Removing worktree for agent \"{}\"\u{2026}",
                 session.branch_name
-            ));
+            );
+            self.set_busy(&busy_msg);
+            self.deletion_busy_messages
+                .insert(session.id.clone(), busy_msg);
         } else {
             logger::info(&format!(
                 "deleting session {} at {} (delete_worktree={}, inline)",
@@ -740,17 +748,15 @@ impl App {
                 }
             }
             (false, true, None) => {
-                // Worktree deletion was requested but git was not invoked by
-                // this code path. This happens when an async delete worker
-                // is already removing the worktree (`do_delete_session`
-                // skips the synchronous git call to avoid racing the
-                // worker). The session record is now cleaned up; the worker
-                // will finish the worktree removal separately.
-                self.set_info(format!(
-                    "Deleted {} agent \"{}\". Worktree removal already in progress.",
-                    session.provider.as_str(),
-                    session.branch_name,
-                ));
+                // Callers that pass delete_worktree=true with no siblings
+                // must have already run git::remove_worktree and produced
+                // Some(outcome). This arm is unreachable via the current
+                // call graph but kept for exhaustiveness; surface a visible
+                // error in all builds so any future contract violation is
+                // noticed rather than silently swallowed.
+                self.set_error(
+                    "Internal error: worktree deletion flagged but no removal result provided.",
+                );
             }
         }
         Ok(())
@@ -863,6 +869,24 @@ impl App {
             self.set_error("Select a project first.");
             return Ok(());
         };
+
+        // Refuse if any of this project's sessions have an async worktree
+        // removal in-flight. `do_delete_session` runs git synchronously and
+        // would race the worker, potentially leaving the project deletion
+        // half-finished. The user must wait for the worker to complete (or
+        // fail) before retrying.
+        let pending_in_project = self
+            .sessions
+            .iter()
+            .any(|s| s.project_id == project.id && self.pending_deletions.contains(&s.id));
+        if pending_in_project {
+            self.set_error(
+                "Cannot delete project while agent worktree removals are in progress. \
+                 Wait for them to finish, then try again.",
+            );
+            return Ok(());
+        }
+
         logger::info(&format!("deleting project {}", project.path));
         let session_ids = self
             .sessions
@@ -1691,6 +1715,7 @@ mod tests {
             refs_watch_paths: std::collections::HashMap::new(),
             resume_fallback_candidates: std::collections::HashSet::new(),
             pending_deletions: std::collections::HashSet::new(),
+            deletion_busy_messages: std::collections::HashMap::new(),
             syntax_cache: crate::diff::SyntaxCache::new(),
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
@@ -2130,11 +2155,9 @@ mod tests {
         );
     }
 
-    /// If the session was removed by another code path (e.g. project
-    /// deletion) while the async delete worker was running, the worker's
-    /// completion event must still overwrite the Busy status line — the
-    /// handler cannot rely on `finish_delete_session`'s idempotent early
-    /// return to do it.
+    /// If the session was removed by another code path while the async
+    /// delete worker was running, the worker's completion event must still
+    /// overwrite the Busy status line when the message matches.
     #[test]
     fn worktree_remove_completed_clears_busy_when_session_already_gone() {
         let project_dir = tempdir().expect("project tempdir");
@@ -2146,12 +2169,15 @@ mod tests {
         let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
         let mut app = test_app_with_sessions(vec![s1], vec![project]);
 
-        // Simulate the Busy state set by `begin_delete_session`.
-        app.set_busy("Removing worktree for agent \"branch-s1\"\u{2026}");
+        // Simulate the Busy state set by `begin_delete_session`, including
+        // the tracking map entry.
+        let busy_msg = "Removing worktree for agent \"branch-s1\"\u{2026}";
+        app.set_busy(busy_msg);
         app.pending_deletions.insert("s1".to_string());
+        app.deletion_busy_messages
+            .insert("s1".to_string(), busy_msg.to_string());
 
-        // Another code path removes the session before the worker replies
-        // (mirrors what `delete_project` does when iterating sessions).
+        // Another code path removes the session before the worker replies.
         app.sessions.retain(|s| s.id != "s1");
 
         // The worker then reports success.
@@ -2176,11 +2202,10 @@ mod tests {
     }
 
     /// When the session is already gone AND the status line has already been
-    /// overwritten by a later action (e.g. project deletion), the worker
-    /// completion should not clobber the newer message with a generic
-    /// fallback.
+    /// overwritten by a later Info action (e.g. project deletion), the
+    /// worker completion should not clobber the newer message.
     #[test]
-    fn worktree_remove_completed_does_not_clobber_newer_status() {
+    fn worktree_remove_completed_does_not_clobber_newer_info() {
         let project_dir = tempdir().expect("project tempdir");
         let worktree_dir = tempdir().expect("worktree tempdir");
         let worktree_path = worktree_dir.path().to_string_lossy().to_string();
@@ -2191,10 +2216,11 @@ mod tests {
         let mut app = test_app_with_sessions(vec![s1], vec![project]);
 
         app.pending_deletions.insert("s1".to_string());
+        app.deletion_busy_messages
+            .insert("s1".to_string(), "Removing worktree\u{2026}".to_string());
         app.sessions.retain(|s| s.id != "s1");
 
-        // Another action (e.g. project deletion) already set a non-Busy
-        // status before the worker event arrives.
+        // Another action already set a non-Busy status.
         app.set_info("Deleted project \"demo\" and all its agents");
 
         app.worker_tx
@@ -2217,15 +2243,13 @@ mod tests {
         );
     }
 
-    /// When `do_delete_session` is called for a session that already has an
-    /// async worker removing its worktree (`pending_deletions` contains the
-    /// session ID), the synchronous git call must be skipped to avoid racing
-    /// the worker. The session record should still be cleaned up and the
-    /// status message should note that the worktree removal is in progress.
+    /// When the session is already gone AND the status line shows a Busy
+    /// message from an *unrelated* operation (push, pull, etc.), the worker
+    /// completion should not clobber it — the message text doesn't match
+    /// ours, even though the tone is also Busy.
     #[test]
-    fn do_delete_session_skips_git_when_pending() {
+    fn worktree_remove_completed_does_not_clobber_unrelated_busy() {
         let project_dir = tempdir().expect("project tempdir");
-        // Non-git directory — if the code accidentally ran git, it would fail.
         let worktree_dir = tempdir().expect("worktree tempdir");
         let worktree_path = worktree_dir.path().to_string_lossy().to_string();
 
@@ -2234,22 +2258,76 @@ mod tests {
         let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
         let mut app = test_app_with_sessions(vec![s1], vec![project]);
 
-        // Pretend an async delete worker is already running for this session.
+        app.pending_deletions.insert("s1".to_string());
+        app.deletion_busy_messages.insert(
+            "s1".to_string(),
+            "Removing worktree for agent \"branch-s1\"\u{2026}".to_string(),
+        );
+        app.sessions.retain(|s| s.id != "s1");
+
+        // An unrelated operation set its own Busy message.
+        app.set_busy("Pushing to remote\u{2026}");
+
+        app.worker_tx
+            .send(WorkerEvent::WorktreeRemoveCompleted {
+                session_id: "s1".to_string(),
+                result: Ok(false),
+            })
+            .expect("channel send");
+        app.drain_events();
+
+        // The status should still show the push Busy, not "Worktree removal
+        // finished."
+        assert_eq!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Busy,
+            "tone should remain Busy from the push",
+        );
+        assert_eq!(
+            app.status.message(),
+            "Pushing to remote\u{2026}",
+            "the push message must not be clobbered, got: {}",
+            app.status.message(),
+        );
+    }
+
+    /// Project deletion must be refused when any of the project's sessions
+    /// have an async worktree removal in-flight. Allowing it would race the
+    /// synchronous `do_delete_session` against the worker and could leave the
+    /// project half-deleted with an orphaned worktree.
+    #[test]
+    fn delete_selected_project_blocked_when_pending() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        // Simulate an async delete in-flight for this session.
         app.pending_deletions.insert("s1".to_string());
 
-        // This would fail with Err if git ran (non-git project dir). If the
-        // pending check works, git is skipped and this succeeds.
-        app.do_delete_session("s1", true)
-            .expect("must succeed by skipping git when worker is in-flight");
+        // The project is the first item in the list, select it.
+        app.selected_left = 0;
 
+        app.delete_selected_project()
+            .expect("should return Ok (error reported via status line)");
+
+        // Session must still be present — deletion was refused.
         assert!(
-            app.sessions.iter().all(|s| s.id != "s1"),
-            "session record should be cleaned up even though git was skipped",
+            app.sessions.iter().any(|s| s.id == "s1"),
+            "session must not be removed when deletion is blocked",
         );
         assert!(
-            app.status.text().contains("already in progress"),
-            "status should mention the in-progress removal, got: {}",
-            app.status.text(),
+            app.projects.iter().any(|p| p.id == "project-1"),
+            "project must not be removed when deletion is blocked",
+        );
+        assert_eq!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Error,
+            "should show an error explaining why deletion was blocked",
         );
     }
 

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -675,12 +675,17 @@ impl App {
             .iter()
             .any(|s| s.id != session.id && s.worktree_path == session.worktree_path);
 
+        // Persist the deletion FIRST so a DB failure leaves in-memory state
+        // untouched and the session remains visible in the UI. If we cleared
+        // in-memory state first and the DB call then failed, the session
+        // would vanish from the UI but reappear on restart.
+        self.session_store.delete_session(&session.id)?;
+
         self.providers.remove(&session.id);
         self.last_pty_activity.remove(&session.id);
         self.resume_fallback_candidates.remove(&session.id);
         self.clear_companion_terminals_for_session(&session.id);
         self.sessions.retain(|candidate| candidate.id != session.id);
-        self.session_store.delete_session(&session.id)?;
         self.update_branch_sync_sessions();
         self.rebuild_left_items();
         self.selected_left = self.selected_left.saturating_sub(1);
@@ -729,12 +734,13 @@ impl App {
                 }
             }
             (false, true, None) => {
-                // Unreachable: the caller only sets delete_worktree=true with
-                // no siblings when a successful git removal has already run,
-                // producing Some(outcome). Kept for exhaustiveness.
-                debug_assert!(
-                    false,
-                    "remove_outcome should be Some when finishing worktree delete without siblings"
+                // Unexpected: the caller should only set delete_worktree=true
+                // with no siblings when a successful git removal has already
+                // run, producing Some(outcome). Surface a visible error in
+                // all builds so the invalid state is noticed — debug_assert
+                // alone is a silent no-op in release.
+                self.set_error(
+                    "Internal error: worktree deletion flagged but no removal result provided.",
                 );
             }
         }
@@ -2156,6 +2162,48 @@ mod tests {
             app.status.tone(),
             crate::statusline::StatusTone::Busy,
             "Busy status must not linger after worker completes, got: {}",
+            app.status.text(),
+        );
+    }
+
+    /// When the session is already gone AND the status line has already been
+    /// overwritten by a later action (e.g. project deletion), the worker
+    /// completion should not clobber the newer message with a generic
+    /// fallback.
+    #[test]
+    fn worktree_remove_completed_does_not_clobber_newer_status() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.pending_deletions.insert("s1".to_string());
+        app.sessions.retain(|s| s.id != "s1");
+
+        // Another action (e.g. project deletion) already set a non-Busy
+        // status before the worker event arrives.
+        app.set_info("Deleted project \"demo\" and all its agents");
+
+        app.worker_tx
+            .send(WorkerEvent::WorktreeRemoveCompleted {
+                session_id: "s1".to_string(),
+                result: Ok(false),
+            })
+            .expect("channel send");
+        app.drain_events();
+
+        assert_eq!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Info,
+            "tone should remain Info",
+        );
+        assert!(
+            app.status.text().contains("Deleted project"),
+            "the project-deletion message must not be clobbered, got: {}",
             app.status.text(),
         );
     }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -577,7 +577,7 @@ impl App {
             None
         };
 
-        self.finish_delete_session(session_id, delete_worktree, remove_outcome)?;
+        self.finish_delete_session(session_id, delete_worktree, remove_outcome, true)?;
         Ok(())
     }
 
@@ -656,7 +656,7 @@ impl App {
                 "deleting session {} at {} (delete_worktree={}, inline)",
                 session.id, session.worktree_path, delete_worktree
             ));
-            if let Err(e) = self.finish_delete_session(session_id, delete_worktree, None) {
+            if let Err(e) = self.finish_delete_session(session_id, delete_worktree, None, true) {
                 self.set_error(format!("{e:#}"));
             }
         }
@@ -670,11 +670,17 @@ impl App {
     /// `remove_outcome` is `Some(branch_already_deleted)` only on the branch
     /// where we actually removed the worktree; it drives the success message
     /// variant.
+    /// `update_status` controls whether the method writes a success message
+    /// to the status line. The async worker handler passes `false` when the
+    /// status line has already been overwritten by an unrelated operation
+    /// (push, pull, etc.) to avoid clobbering it. Synchronous callers and
+    /// the handler's "our Busy is still showing" path pass `true`.
     pub(crate) fn finish_delete_session(
         &mut self,
         session_id: &str,
         delete_worktree: bool,
         remove_outcome: Option<bool>,
+        update_status: bool,
     ) -> Result<()> {
         let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
             return Ok(());
@@ -705,58 +711,60 @@ impl App {
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
 
-        match (other_sessions_on_worktree, delete_worktree, remove_outcome) {
-            (true, true, _) => {
-                self.set_info(format!(
-                    "Deleted {} agent \"{}\". Worktree preserved because other sessions still use it.",
-                    session.provider.as_str(),
-                    session.branch_name,
-                ));
-            }
-            (true, false, _) => {
-                self.set_info(format!(
-                    "Deleted {} session for agent \"{}\". Worktree preserved for remaining sessions.",
-                    session.provider.as_str(),
-                    session.branch_name,
-                ));
-            }
-            (false, false, _) => {
-                self.set_info(format!(
-                    "Deleted {} agent \"{}\". Worktree preserved at {}.",
-                    session.provider.as_str(),
-                    session.branch_name,
-                    session.worktree_path,
-                ));
-            }
-            (false, true, Some(branch_already_deleted)) => {
-                if branch_already_deleted {
+        if update_status {
+            match (other_sessions_on_worktree, delete_worktree, remove_outcome) {
+                (true, true, _) => {
                     self.set_info(format!(
-                        "Deleted agent (branch \"{}\" was already removed)",
-                        session.branch_name
-                    ));
-                } else {
-                    let project_name = project
-                        .as_ref()
-                        .map(|p| p.name.as_str())
-                        .unwrap_or("<unknown>");
-                    self.set_info(format!(
-                        "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                        "Deleted {} agent \"{}\". Worktree preserved because other sessions still use it.",
                         session.provider.as_str(),
-                        project_name,
-                        session.branch_name
+                        session.branch_name,
                     ));
                 }
-            }
-            (false, true, None) => {
-                // Callers that pass delete_worktree=true with no siblings
-                // must have already run git::remove_worktree and produced
-                // Some(outcome). This arm is unreachable via the current
-                // call graph but kept for exhaustiveness; surface a visible
-                // error in all builds so any future contract violation is
-                // noticed rather than silently swallowed.
-                self.set_error(
-                    "Internal error: worktree deletion flagged but no removal result provided.",
-                );
+                (true, false, _) => {
+                    self.set_info(format!(
+                        "Deleted {} session for agent \"{}\". Worktree preserved for remaining sessions.",
+                        session.provider.as_str(),
+                        session.branch_name,
+                    ));
+                }
+                (false, false, _) => {
+                    self.set_info(format!(
+                        "Deleted {} agent \"{}\". Worktree preserved at {}.",
+                        session.provider.as_str(),
+                        session.branch_name,
+                        session.worktree_path,
+                    ));
+                }
+                (false, true, Some(branch_already_deleted)) => {
+                    if branch_already_deleted {
+                        self.set_info(format!(
+                            "Deleted agent (branch \"{}\" was already removed)",
+                            session.branch_name
+                        ));
+                    } else {
+                        let project_name = project
+                            .as_ref()
+                            .map(|p| p.name.as_str())
+                            .unwrap_or("<unknown>");
+                        self.set_info(format!(
+                            "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                            session.provider.as_str(),
+                            project_name,
+                            session.branch_name
+                        ));
+                    }
+                }
+                (false, true, None) => {
+                    // Callers that pass delete_worktree=true with no siblings
+                    // must have already run git::remove_worktree and produced
+                    // Some(outcome). This arm is unreachable via the current
+                    // call graph but kept for exhaustiveness; surface a
+                    // visible error in all builds so any future contract
+                    // violation is noticed.
+                    self.set_error(
+                        "Internal error: worktree deletion flagged but no removal result provided.",
+                    );
+                }
             }
         }
         Ok(())
@@ -2081,10 +2089,10 @@ mod tests {
         let project = make_project("project-1", "claude");
         let mut app = test_app_with_sessions(vec![s1], vec![project]);
 
-        app.finish_delete_session("s1", false, None)
+        app.finish_delete_session("s1", false, None, true)
             .expect("first finish succeeds");
         // Second call must not panic or return Err even though session is gone.
-        app.finish_delete_session("s1", false, None)
+        app.finish_delete_session("s1", false, None, true)
             .expect("second finish is a no-op");
     }
 

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -499,21 +499,42 @@ impl App {
             self.set_error("Select a session first.");
             return Ok(());
         };
+        let worktree_shared = self
+            .sessions
+            .iter()
+            .any(|s| s.id != session.id && s.worktree_path == session.worktree_path);
         self.prompt = PromptState::ConfirmDeleteAgent {
             session_id: session.id.clone(),
             branch_name: session.branch_name.clone(),
-            confirm_selected: false, // Cancel is default
+            focus: DeleteAgentFocus::Cancel, // Cancel is the safe default
+            delete_worktree: false,          // Opt-in destructive action
+            worktree_shared,
         };
         Ok(())
     }
 
-    pub(crate) fn do_delete_session(&mut self, session_id: &str) -> Result<()> {
+    /// Delete the agent session identified by `session_id`, blocking the
+    /// calling thread for any git work. Used by bulk flows like project
+    /// deletion, where we must complete all removals before the parent
+    /// operation proceeds. User-initiated single-agent deletes go through
+    /// [`begin_delete_session`] so git work runs off the UI thread.
+    ///
+    /// When `delete_worktree` is true AND no other sessions share the worktree,
+    /// the git worktree and branch are removed first. If the git removal fails,
+    /// the session record is preserved so the caller can retry without losing
+    /// the agent. When `delete_worktree` is false, the worktree and branch
+    /// are always preserved.
+    pub(crate) fn do_delete_session(
+        &mut self,
+        session_id: &str,
+        delete_worktree: bool,
+    ) -> Result<()> {
         let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
             return Ok(());
         };
         logger::info(&format!(
-            "deleting session {} at {}",
-            session.id, session.worktree_path
+            "deleting session {} at {} (delete_worktree={}, sync)",
+            session.id, session.worktree_path, delete_worktree
         ));
         let Some(project) = self
             .projects
@@ -523,6 +544,120 @@ impl App {
         else {
             return Ok(());
         };
+        let other_sessions_on_worktree = self
+            .sessions
+            .iter()
+            .any(|s| s.id != session.id && s.worktree_path == session.worktree_path);
+
+        let should_remove_worktree = delete_worktree && !other_sessions_on_worktree;
+
+        // Attempt git operations FIRST so a failure leaves the agent intact.
+        // Worktrees are user data — if we can't remove the worktree cleanly, we
+        // must not leave the user with a deleted agent record and an orphaned
+        // worktree on disk.
+        let remove_outcome = if should_remove_worktree {
+            let result = git::remove_worktree(
+                Path::new(&project.path),
+                Path::new(&session.worktree_path),
+                &session.branch_name,
+            )?;
+            Some(result.branch_already_deleted)
+        } else {
+            None
+        };
+
+        self.finish_delete_session(session_id, delete_worktree, remove_outcome)?;
+        Ok(())
+    }
+
+    /// Kick off deletion of `session_id` from the user-facing modal.
+    ///
+    /// When the git worktree needs to be removed, the `git worktree remove`
+    /// call is dispatched to a background thread and the session record is
+    /// left in place until the worker reports success via
+    /// [`WorkerEvent::WorktreeRemoveCompleted`]. This keeps the UI responsive
+    /// even when git stalls (slow disk, held lock, large worktree). When no
+    /// git work is required the session is cleaned up synchronously — that
+    /// path only touches in-memory state and SQLite, which is effectively
+    /// instantaneous.
+    pub(crate) fn begin_delete_session(&mut self, session_id: &str, delete_worktree: bool) {
+        let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
+            return;
+        };
+        let Some(project) = self
+            .projects
+            .iter()
+            .find(|project| project.id == session.project_id)
+            .cloned()
+        else {
+            return;
+        };
+        let other_sessions_on_worktree = self
+            .sessions
+            .iter()
+            .any(|s| s.id != session.id && s.worktree_path == session.worktree_path);
+        let should_remove_worktree = delete_worktree && !other_sessions_on_worktree;
+
+        if should_remove_worktree {
+            logger::info(&format!(
+                "deleting session {} at {} (delete_worktree=true, async)",
+                session.id, session.worktree_path
+            ));
+            let sid = session.id.clone();
+            let project_path = project.path.clone();
+            let worktree_path = session.worktree_path.clone();
+            let branch_name = session.branch_name.clone();
+            let tx = self.worker_tx.clone();
+            std::thread::spawn(move || {
+                let result = git::remove_worktree(
+                    Path::new(&project_path),
+                    Path::new(&worktree_path),
+                    &branch_name,
+                )
+                .map(|r| r.branch_already_deleted)
+                .map_err(|e| format!("{e:#}"));
+                let _ = tx.send(WorkerEvent::WorktreeRemoveCompleted {
+                    session_id: sid,
+                    result,
+                });
+            });
+            self.set_busy(format!(
+                "Removing worktree for agent \"{}\"\u{2026}",
+                session.branch_name
+            ));
+        } else {
+            logger::info(&format!(
+                "deleting session {} at {} (delete_worktree={}, inline)",
+                session.id, session.worktree_path, delete_worktree
+            ));
+            if let Err(e) = self.finish_delete_session(session_id, delete_worktree, None) {
+                self.set_error(format!("{e:#}"));
+            }
+        }
+    }
+
+    /// Remove all local bookkeeping for a session whose git side has already
+    /// been handled (or does not need handling). Idempotent — if the session
+    /// is no longer present this is a no-op, which matters for the async path
+    /// where the user may have deleted the project before the worker replies.
+    ///
+    /// `remove_outcome` is `Some(branch_already_deleted)` only on the branch
+    /// where we actually removed the worktree; it drives the success message
+    /// variant.
+    pub(crate) fn finish_delete_session(
+        &mut self,
+        session_id: &str,
+        delete_worktree: bool,
+        remove_outcome: Option<bool>,
+    ) -> Result<()> {
+        let Some(session) = self.sessions.iter().find(|s| s.id == session_id).cloned() else {
+            return Ok(());
+        };
+        let project = self
+            .projects
+            .iter()
+            .find(|project| project.id == session.project_id)
+            .cloned();
         let other_sessions_on_worktree = self
             .sessions
             .iter()
@@ -539,30 +674,56 @@ impl App {
         self.selected_left = self.selected_left.saturating_sub(1);
         self.reload_changed_files();
 
-        if other_sessions_on_worktree {
-            self.set_info(format!(
-                "Deleted {} session for agent \"{}\". Worktree preserved for remaining sessions.",
-                session.provider.as_str(),
-                session.branch_name,
-            ));
-        } else {
-            let result = git::remove_worktree(
-                Path::new(&project.path),
-                Path::new(&session.worktree_path),
-                &session.branch_name,
-            )?;
-            if result.branch_already_deleted {
+        match (other_sessions_on_worktree, delete_worktree, remove_outcome) {
+            (true, true, _) => {
                 self.set_info(format!(
-                    "Deleted agent (branch \"{}\" was already removed)",
-                    session.branch_name
-                ));
-            } else {
-                self.set_info(format!(
-                    "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                    "Deleted {} agent \"{}\". Worktree preserved because other sessions still use it.",
                     session.provider.as_str(),
-                    project.name,
-                    session.branch_name
+                    session.branch_name,
                 ));
+            }
+            (true, false, _) => {
+                self.set_info(format!(
+                    "Deleted {} session for agent \"{}\". Worktree preserved for remaining sessions.",
+                    session.provider.as_str(),
+                    session.branch_name,
+                ));
+            }
+            (false, false, _) => {
+                self.set_info(format!(
+                    "Deleted {} agent \"{}\". Worktree preserved at {}.",
+                    session.provider.as_str(),
+                    session.branch_name,
+                    session.worktree_path,
+                ));
+            }
+            (false, true, Some(branch_already_deleted)) => {
+                if branch_already_deleted {
+                    self.set_info(format!(
+                        "Deleted agent (branch \"{}\" was already removed)",
+                        session.branch_name
+                    ));
+                } else {
+                    let project_name = project
+                        .as_ref()
+                        .map(|p| p.name.as_str())
+                        .unwrap_or("<unknown>");
+                    self.set_info(format!(
+                        "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                        session.provider.as_str(),
+                        project_name,
+                        session.branch_name
+                    ));
+                }
+            }
+            (false, true, None) => {
+                // Unreachable: the caller only sets delete_worktree=true with
+                // no siblings when a successful git removal has already run,
+                // producing Some(outcome). Kept for exhaustiveness.
+                debug_assert!(
+                    false,
+                    "remove_outcome should be Some when finishing worktree delete without siblings"
+                );
             }
         }
         Ok(())
@@ -695,7 +856,10 @@ impl App {
                         |item| matches!(item, LeftItem::Session(session_index) if *session_index == index),
                     )
                     .unwrap_or(self.selected_left);
-                self.do_delete_session(&session_id)?;
+                // When deleting a project we also remove each agent's
+                // worktree — the project itself is going away, so leaving
+                // orphaned worktrees around would be surprising.
+                self.do_delete_session(&session_id, true)?;
             }
         }
         self.projects.retain(|candidate| candidate.id != project.id);
@@ -1690,5 +1854,184 @@ mod tests {
             .iter()
             .any(|s| s.id != "s1" && s.worktree_path == "/tmp/wt/a");
         assert!(!has_sibling, "no sibling session should exist");
+    }
+
+    /// Build a `Project` whose `path` points at a caller-controlled directory,
+    /// so tests can decide whether git operations succeed or fail.
+    fn make_project_at(id: &str, provider: &str, path: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            name: "demo".to_string(),
+            path: path.to_string(),
+            default_provider: ProviderKind::from_str(provider),
+            current_branch: "main".to_string(),
+            path_missing: false,
+        }
+    }
+
+    /// With `delete_worktree = false`, the session record is removed but the
+    /// worktree on disk is left alone and git is never invoked. The project
+    /// path here is not a git repo — if the code accidentally invoked git it
+    /// would return `Err` and this test would catch it.
+    #[test]
+    fn do_delete_session_preserves_worktree_when_flag_off() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.do_delete_session("s1", false)
+            .expect("delete should succeed without touching git");
+
+        assert!(
+            app.sessions.iter().all(|s| s.id != "s1"),
+            "session should be removed"
+        );
+        assert!(
+            worktree_dir.path().exists(),
+            "worktree directory must be preserved on disk when delete_worktree=false",
+        );
+    }
+
+    /// When another session shares the worktree, the worktree must be
+    /// preserved even if the user checked "also delete the worktree" — other
+    /// sessions still depend on it. Git must not be invoked.
+    #[test]
+    fn do_delete_session_keeps_shared_worktree_even_when_flag_on() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        let mut s2 = make_session("s2", "codex", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        s2.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1, s2], vec![project]);
+
+        app.do_delete_session("s1", true)
+            .expect("delete should succeed without touching git for shared worktree");
+
+        assert!(
+            app.sessions.iter().all(|s| s.id != "s1"),
+            "s1 should be removed"
+        );
+        assert!(
+            app.sessions.iter().any(|s| s.id == "s2"),
+            "s2 should remain"
+        );
+        assert!(
+            worktree_dir.path().exists(),
+            "shared worktree must be preserved when siblings exist",
+        );
+    }
+
+    /// If git fails to remove the worktree, the session record must remain —
+    /// otherwise the user loses their agent with no way to retry. We force
+    /// the git call to fail by pointing the project path at a directory that
+    /// is not a git repository.
+    #[test]
+    fn do_delete_session_preserves_session_when_git_fails() {
+        let project_dir = tempdir().expect("project tempdir");
+        // Intentionally NOT a git repo — `git worktree remove` will exit
+        // non-zero, which bubbles up as Err from git::remove_worktree.
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        let err = app
+            .do_delete_session("s1", true)
+            .expect_err("git should fail against a non-git project dir");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("worktree") || msg.contains("git"),
+            "error should mention git/worktree, got: {msg}",
+        );
+
+        assert!(
+            app.sessions.iter().any(|s| s.id == "s1"),
+            "session must be preserved when git fails so user can retry",
+        );
+        assert!(
+            worktree_dir.path().exists(),
+            "worktree directory should be untouched on failure",
+        );
+    }
+
+    /// The async path (`begin_delete_session`) must NOT remove the session
+    /// immediately when the worktree deletion is going to run in a worker —
+    /// otherwise a failed git call would leave the user with a vanished
+    /// agent and no way to retry. The session should only disappear once
+    /// the worker reports success.
+    #[test]
+    fn begin_delete_session_keeps_session_until_worker_replies() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.begin_delete_session("s1", true);
+
+        // Session must still be present: the worker thread has been spawned
+        // but hasn't (at most) completed the cleanup on our thread yet.
+        assert!(
+            app.sessions.iter().any(|s| s.id == "s1"),
+            "session must remain until the worker reports success",
+        );
+    }
+
+    /// When the async path does NOT need to run git (no siblings + flag off),
+    /// cleanup is safe to run inline and the session should be gone by the
+    /// time `begin_delete_session` returns.
+    #[test]
+    fn begin_delete_session_completes_inline_when_no_git_needed() {
+        let project_dir = tempdir().expect("project tempdir");
+        let worktree_dir = tempdir().expect("worktree tempdir");
+        let worktree_path = worktree_dir.path().to_string_lossy().to_string();
+
+        let mut s1 = make_session("s1", "claude", &worktree_path);
+        s1.project_id = "project-1".to_string();
+        let project = make_project_at("project-1", "claude", &project_dir.path().to_string_lossy());
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.begin_delete_session("s1", false);
+
+        assert!(
+            app.sessions.iter().all(|s| s.id != "s1"),
+            "no-git path should complete immediately",
+        );
+        assert!(
+            worktree_dir.path().exists(),
+            "worktree directory must be preserved when the flag is off",
+        );
+    }
+
+    /// `finish_delete_session` is the handler invoked both inline and from
+    /// the worker event. It must be idempotent: if the session has already
+    /// been removed (e.g. a duplicate worker event) it should no-op.
+    #[test]
+    fn finish_delete_session_is_idempotent() {
+        let mut s1 = make_session("s1", "claude", "/tmp/wt/a");
+        s1.project_id = "project-1".to_string();
+        let project = make_project("project-1", "claude");
+        let mut app = test_app_with_sessions(vec![s1], vec![project]);
+
+        app.finish_delete_session("s1", false, None)
+            .expect("first finish succeeds");
+        // Second call must not panic or return Err even though session is gone.
+        app.finish_delete_session("s1", false, None)
+            .expect("second finish is a no-op");
     }
 }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -255,6 +255,27 @@ impl App {
                         *selected = 0;
                     }
                 }
+                WorkerEvent::WorktreeRemoveCompleted { session_id, result } => {
+                    match result {
+                        Ok(branch_already_deleted) => {
+                            if let Err(e) = self.finish_delete_session(
+                                &session_id,
+                                true,
+                                Some(branch_already_deleted),
+                            ) {
+                                self.set_error(format!(
+                                    "Worktree removed but session cleanup failed: {e:#}"
+                                ));
+                            }
+                        }
+                        Err(msg) => {
+                            // Session record is still present because we
+                            // deferred cleanup until git succeeded. The user
+                            // can retry by reopening the delete dialog.
+                            self.set_error(format!("Worktree delete failed: {msg}"));
+                        }
+                    }
+                }
                 WorkerEvent::ResourceStatsReady(stats) => {
                     self.resource_stats_in_flight = false;
                     if let PromptState::ResourceMonitor {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -282,7 +282,7 @@ impl App {
                                 our_busy_msg.as_ref().is_some_and(|msg| {
                                     self.status.tone()
                                         == crate::statusline::StatusTone::Busy
-                                        && self.status.message() == *msg
+                                        && self.status.message() == msg.as_str()
                                 });
 
                             if self.sessions.iter().any(|s| s.id == session_id) {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -295,13 +295,31 @@ impl App {
                             }
                         }
                         Err(msg) => {
-                            // Session record is still present because we
-                            // deferred cleanup until git succeeded. The user
-                            // can retry by reopening the delete dialog.
-                            // `set_error` overwrites Busy regardless of
-                            // whether the session is still in the list, so
-                            // no extra presence check is needed here.
-                            self.set_error(format!("Worktree delete failed: {msg}"));
+                            // Session record is normally still present
+                            // because we deferred cleanup until git
+                            // succeeded. Look up the session label so the
+                            // user knows which agent failed — multiple async
+                            // deletes can be in flight concurrently, and a
+                            // bare error would be ambiguous. The session
+                            // could be gone if project deletion cleaned it
+                            // up synchronously while the worker ran; fall
+                            // back to a generic message in that case.
+                            if let Some(session) =
+                                self.sessions.iter().find(|s| s.id == session_id)
+                            {
+                                let name = session
+                                    .title
+                                    .as_deref()
+                                    .unwrap_or(&session.branch_name);
+                                self.set_error(format!(
+                                    "Worktree delete failed for {} agent \"{name}\": {msg}",
+                                    session.provider.as_str(),
+                                ));
+                            } else {
+                                self.set_error(format!(
+                                    "Worktree delete failed: {msg}"
+                                ));
+                            }
                         }
                     }
                 }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -283,7 +283,14 @@ impl App {
                                         "Worktree removed but session cleanup failed: {e:#}"
                                     ));
                                 }
-                            } else {
+                            } else if self.status.tone()
+                                == crate::statusline::StatusTone::Busy
+                            {
+                                // Only overwrite when the status line is still
+                                // showing our Busy message. If another action
+                                // (e.g. project deletion) already replaced it
+                                // with a more informative message, we should
+                                // not clobber it with a generic fallback.
                                 self.set_info("Worktree removal finished.");
                             }
                         }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -256,6 +256,10 @@ impl App {
                     }
                 }
                 WorkerEvent::WorktreeRemoveCompleted { session_id, result } => {
+                    // Always clear the in-flight guard so the session is
+                    // interactive again — whether we're about to remove it
+                    // (Ok path) or leave it in place for retry (Err path).
+                    self.pending_deletions.remove(&session_id);
                     match result {
                         Ok(branch_already_deleted) => {
                             if let Err(e) = self.finish_delete_session(

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -271,35 +271,35 @@ impl App {
 
                     match result {
                         Ok(branch_already_deleted) => {
+                            // Only update the status line if the current
+                            // content is still the Busy message we set when
+                            // spawning this worker. If another operation
+                            // (push, pull, concurrent delete) has since
+                            // overwritten it, we should not clobber their
+                            // message — the session will visually disappear
+                            // from the list, which is sufficient feedback.
+                            let our_busy_still_showing =
+                                our_busy_msg.as_ref().is_some_and(|msg| {
+                                    self.status.tone()
+                                        == crate::statusline::StatusTone::Busy
+                                        && self.status.message() == *msg
+                                });
+
                             if self.sessions.iter().any(|s| s.id == session_id) {
-                                // Normal path: session still present, finish
-                                // cleanup. finish_delete_session will set its
-                                // own status message, replacing Busy.
                                 if let Err(e) = self.finish_delete_session(
                                     &session_id,
                                     true,
                                     Some(branch_already_deleted),
+                                    our_busy_still_showing,
                                 ) {
                                     self.set_error(format!(
                                         "Worktree removed but session cleanup failed: {e:#}"
                                     ));
                                 }
-                            } else {
-                                // Session was already removed by another code
-                                // path (e.g. the block on project deletion
-                                // was lifted and the project was deleted
-                                // after the worker started). Only clear the
-                                // status line if it still shows our exact
-                                // Busy message; otherwise leave the newer
-                                // content alone.
-                                let our_busy_still_showing = our_busy_msg.is_some_and(|msg| {
-                                    self.status.tone()
-                                        == crate::statusline::StatusTone::Busy
-                                        && self.status.message() == msg
-                                });
-                                if our_busy_still_showing {
-                                    self.set_info("Worktree removal finished.");
-                                }
+                            } else if our_busy_still_showing {
+                                // Session removed by another path; just clear
+                                // the lingering Busy so it doesn't stick.
+                                self.set_info("Worktree removal finished.");
                             }
                         }
                         Err(msg) => {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -260,20 +260,21 @@ impl App {
                     // interactive again — whether we're about to remove it
                     // (Ok path) or leave it in place for retry (Err path).
                     self.pending_deletions.remove(&session_id);
+
+                    // Retrieve (and remove) the exact Busy message we set
+                    // when the worker was spawned. We compare this against
+                    // the current status-line content rather than checking
+                    // tone alone, because another operation (push, pull,
+                    // refresh, concurrent delete) may have since set its own
+                    // Busy message that we must not clobber.
+                    let our_busy_msg = self.deletion_busy_messages.remove(&session_id);
+
                     match result {
                         Ok(branch_already_deleted) => {
-                            // `finish_delete_session` is intentionally
-                            // idempotent: if the session was already removed
-                            // by another code path (e.g. project deletion
-                            // cleaned it up synchronously while our worker
-                            // was running), it returns early without
-                            // touching the status line. That would leave the
-                            // Busy message from `begin_delete_session` stuck
-                            // on screen. Check session presence explicitly
-                            // and set a fallback info message so the
-                            // handler's status-line contract does not depend
-                            // on `finish_delete_session`'s internal guard.
                             if self.sessions.iter().any(|s| s.id == session_id) {
+                                // Normal path: session still present, finish
+                                // cleanup. finish_delete_session will set its
+                                // own status message, replacing Busy.
                                 if let Err(e) = self.finish_delete_session(
                                     &session_id,
                                     true,
@@ -283,15 +284,22 @@ impl App {
                                         "Worktree removed but session cleanup failed: {e:#}"
                                     ));
                                 }
-                            } else if self.status.tone()
-                                == crate::statusline::StatusTone::Busy
-                            {
-                                // Only overwrite when the status line is still
-                                // showing our Busy message. If another action
-                                // (e.g. project deletion) already replaced it
-                                // with a more informative message, we should
-                                // not clobber it with a generic fallback.
-                                self.set_info("Worktree removal finished.");
+                            } else {
+                                // Session was already removed by another code
+                                // path (e.g. the block on project deletion
+                                // was lifted and the project was deleted
+                                // after the worker started). Only clear the
+                                // status line if it still shows our exact
+                                // Busy message; otherwise leave the newer
+                                // content alone.
+                                let our_busy_still_showing = our_busy_msg.is_some_and(|msg| {
+                                    self.status.tone()
+                                        == crate::statusline::StatusTone::Busy
+                                        && self.status.message() == msg
+                                });
+                                if our_busy_still_showing {
+                                    self.set_info("Worktree removal finished.");
+                                }
                             }
                         }
                         Err(msg) => {
@@ -300,10 +308,7 @@ impl App {
                             // succeeded. Look up the session label so the
                             // user knows which agent failed — multiple async
                             // deletes can be in flight concurrently, and a
-                            // bare error would be ambiguous. The session
-                            // could be gone if project deletion cleaned it
-                            // up synchronously while the worker ran; fall
-                            // back to a generic message in that case.
+                            // bare error would be ambiguous.
                             if let Some(session) =
                                 self.sessions.iter().find(|s| s.id == session_id)
                             {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -262,20 +262,38 @@ impl App {
                     self.pending_deletions.remove(&session_id);
                     match result {
                         Ok(branch_already_deleted) => {
-                            if let Err(e) = self.finish_delete_session(
-                                &session_id,
-                                true,
-                                Some(branch_already_deleted),
-                            ) {
-                                self.set_error(format!(
-                                    "Worktree removed but session cleanup failed: {e:#}"
-                                ));
+                            // `finish_delete_session` is intentionally
+                            // idempotent: if the session was already removed
+                            // by another code path (e.g. project deletion
+                            // cleaned it up synchronously while our worker
+                            // was running), it returns early without
+                            // touching the status line. That would leave the
+                            // Busy message from `begin_delete_session` stuck
+                            // on screen. Check session presence explicitly
+                            // and set a fallback info message so the
+                            // handler's status-line contract does not depend
+                            // on `finish_delete_session`'s internal guard.
+                            if self.sessions.iter().any(|s| s.id == session_id) {
+                                if let Err(e) = self.finish_delete_session(
+                                    &session_id,
+                                    true,
+                                    Some(branch_already_deleted),
+                                ) {
+                                    self.set_error(format!(
+                                        "Worktree removed but session cleanup failed: {e:#}"
+                                    ));
+                                }
+                            } else {
+                                self.set_info("Worktree removal finished.");
                             }
                         }
                         Err(msg) => {
                             // Session record is still present because we
                             // deferred cleanup until git succeeded. The user
                             // can retry by reopening the delete dialog.
+                            // `set_error` overwrites Busy regardless of
+                            // whether the session is still in the list, so
+                            // no extra presence check is needed here.
                             self.set_error(format!("Worktree delete failed: {msg}"));
                         }
                     }

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -60,6 +60,11 @@ impl StatusLine {
         self.tone
     }
 
+    /// The raw message text, without tone-specific prefixes or spinners.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
     fn spinner_frame(&self) -> &'static str {
         const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
         let index = ((self.since.elapsed().as_millis() / 100) as usize) % FRAMES.len();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -24,10 +24,11 @@ pub struct Theme {
     pub session_detached: Color,
     pub session_exited: Color,
     /// Foreground used for a session row whose worktree is currently being
-    /// removed by a background worker. Visual cue is meant to be subtle —
-    /// the in-flight window is usually brief — but distinct from
-    /// `session_exited` so an eventual theme tweak can differentiate them
-    /// without a refactor.
+    /// removed by a background worker. Defaults to the same shade as
+    /// `session_exited`; the render code adds `Modifier::ITALIC` to
+    /// visually distinguish the two states. A separate theme slot so that
+    /// future theme customization can differentiate the colors without a
+    /// code change.
     pub session_deleting: Color,
     pub status_info_fg: Color,
     pub status_info_bg: Color,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -23,6 +23,12 @@ pub struct Theme {
     pub session_active: Color,
     pub session_detached: Color,
     pub session_exited: Color,
+    /// Foreground used for a session row whose worktree is currently being
+    /// removed by a background worker. Visual cue is meant to be subtle —
+    /// the in-flight window is usually brief — but distinct from
+    /// `session_exited` so an eventual theme tweak can differentiate them
+    /// without a refactor.
+    pub session_deleting: Color,
     pub status_info_fg: Color,
     pub status_info_bg: Color,
     pub status_busy_fg: Color,
@@ -103,6 +109,7 @@ impl Theme {
             session_active: Color::Rgb(210, 210, 210),
             session_detached: Color::Yellow,
             session_exited: Color::Rgb(100, 100, 100),
+            session_deleting: Color::Rgb(100, 100, 100),
             status_info_fg: Color::Rgb(100, 100, 100),
             status_info_bg: Color::Rgb(25, 25, 25),
             status_busy_fg: Color::Yellow,


### PR DESCRIPTION
Today, deleting an agent always removes the underlying git worktree and branch, which can permanently destroy uncommitted work. This PR decouples the two: the confirmation dialog gains an opt-in checkbox labeled *Also delete the worktree and branch*, and the safer default is to **preserve the worktree** and only remove the session record. When the checkbox is on, the yellow warning about losing changes appears; when it's off, a quieter note reassures the user that the worktree stays on disk. When another agent already shares the worktree, the checkbox is hidden entirely and replaced with a note explaining that the worktree will be preserved regardless — the choice would have no effect.

The git `worktree remove` call has been moved to a background worker so the UI no longer freezes while git runs, matching the project tenet that all blocking git work must run off the main thread. The session record is now only cleaned up after the worker reports success, so a failed `git worktree remove` leaves the agent intact with a red status line, and the user can simply retry from the dialog. Bulk paths like *Delete Project* keep the previous synchronous behavior because they must complete before the project is removed from state.

Navigation inside the dialog stays on the existing `ToggleSelection` bindings: `Tab`, `h`, `l`, and the arrow keys all cycle focus through Cancel, Delete, and the checkbox (or just Cancel/Delete when the checkbox is hidden). `Space` and `Enter` activate the focused element — toggling the checkbox or confirming the button. Coverage: the existing delete tests were kept, and new unit tests cover the async dispatch path, the inline no-git path, and idempotence of the shared cleanup helper. `cargo fmt`, `cargo test` (572 passing), and `cargo clippy --all-targets` are clean; interactive QA of the dialog itself is still TODO on the reviewer's side.