### PR TITLE
Enforce a single dux instance per config directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ toml = { version = "1.1.2", features = ["preserve_order"] }
 toml_edit = "0.25"
 uuid = { version = "1.17.0", features = ["v4"] }
 portable-pty = "0.9"
-rustix = { version = "1.1", features = ["termios", "process", "event", "stdio"] }
+rustix = { version = "1.1", features = ["termios", "process", "event", "stdio", "fs"] }
 signal-hook = "0.4"
 alacritty_terminal = "0.26.0"
 petname = { version = "2.0.2", default-features = false, features = ["default-rng", "default-words"] }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4001,6 +4001,7 @@ mod tests {
             config_path: root.join("config.toml"),
             sessions_db_path: root.join("sessions.sqlite3"),
             worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
             root: root.clone(),
         };
         std::fs::create_dir_all(&paths.worktrees_root).expect("worktrees dir");
@@ -4028,6 +4029,8 @@ mod tests {
             updated_at: now,
         };
         let (worker_tx, worker_rx) = mpsc::channel();
+        let single_instance_lock = crate::lockfile::SingleInstanceLock::acquire(&paths.lock_path)
+            .expect("single-instance lock for test App");
         let mut app = App {
             config: Config::default(),
             paths,
@@ -4121,6 +4124,7 @@ mod tests {
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            _single_instance_lock: single_instance_lock,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -851,25 +851,15 @@ pub(crate) mod text_input;
 mod workers;
 
 impl App {
-    pub fn bootstrap() -> Result<Self> {
-        let paths = DuxPaths::discover()?;
+    /// Bootstrap the TUI. The caller must have already resolved `paths`,
+    /// created its directories, and acquired the single-instance lock.
+    /// This ensures the lock covers every entrypoint (TUI + config
+    /// subcommands) and that a losing process never touches shared state.
+    pub fn bootstrap_with_lock(
+        paths: DuxPaths,
+        single_instance_lock: SingleInstanceLock,
+    ) -> Result<Self> {
         let config = ensure_config(&paths)?;
-
-        // Single-instance guard: dux relies on an exclusive lock over its
-        // config directory so one process owns the SQLite session store,
-        // in-memory session list, file watchers, and polling workers. A
-        // second process sharing the same directory would silently diverge
-        // — writes to SQLite would interleave, but neither process would
-        // see the other's in-memory sessions. We fail fast before touching
-        // logging or the database so the colliding launch leaves no trace
-        // in the winning instance's log.
-        let single_instance_lock = match SingleInstanceLock::acquire(&paths.lock_path) {
-            Ok(lock) => lock,
-            Err(err) => {
-                eprintln!("{err}");
-                std::process::exit(1);
-            }
-        };
 
         logger::init(&config.logging, &paths);
         logger::info("bootstrapping dux");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,6 +36,7 @@ use crate::git;
 use crate::keybindings::{
     Action, BindingScope, HintContext, InteractiveBytePatterns, RuntimeBindings,
 };
+use crate::lockfile::SingleInstanceLock;
 use crate::logger;
 use crate::model::{
     AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
@@ -160,6 +161,11 @@ pub struct App {
     last_snapshot_id: Option<String>,
     /// Active text selection in the terminal viewport, if any.
     pub(crate) terminal_selection: Option<TerminalSelection>,
+    /// Exclusive lock held for the lifetime of this `App` so only one dux
+    /// instance runs against a given config directory. Released
+    /// automatically on drop (including crashes), so there is nothing to
+    /// clean up on exit.
+    _single_instance_lock: SingleInstanceLock,
 }
 
 /// Snapshot of session data shared with the branch-sync background worker.
@@ -848,6 +854,23 @@ impl App {
     pub fn bootstrap() -> Result<Self> {
         let paths = DuxPaths::discover()?;
         let config = ensure_config(&paths)?;
+
+        // Single-instance guard: dux relies on an exclusive lock over its
+        // config directory so one process owns the SQLite session store,
+        // in-memory session list, file watchers, and polling workers. A
+        // second process sharing the same directory would silently diverge
+        // — writes to SQLite would interleave, but neither process would
+        // see the other's in-memory sessions. We fail fast before touching
+        // logging or the database so the colliding launch leaves no trace
+        // in the winning instance's log.
+        let single_instance_lock = match SingleInstanceLock::acquire(&paths.lock_path) {
+            Ok(lock) => lock,
+            Err(err) => {
+                eprintln!("{err}");
+                std::process::exit(1);
+            }
+        };
+
         logger::init(&config.logging, &paths);
         logger::info("bootstrapping dux");
 
@@ -974,6 +997,7 @@ impl App {
             snapshot_buf: TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            _single_instance_lock: single_instance_lock,
         };
         app.restore_sessions();
         app.seed_pr_statuses_from_db();

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1404,12 +1404,15 @@ mod tests {
             config_path: root.join("config.toml"),
             sessions_db_path: root.join("sessions.sqlite3"),
             worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
             root: root.clone(),
         };
         std::fs::create_dir_all(&paths.worktrees_root).expect("worktrees dir");
         let session_store = SessionStore::open(&paths.sessions_db_path).expect("session store");
         let bindings = test_bindings();
         let (worker_tx, worker_rx) = mpsc::channel();
+        let single_instance_lock = crate::lockfile::SingleInstanceLock::acquire(&paths.lock_path)
+            .expect("single-instance lock for test App");
         let mut app = App {
             config: Config::default(),
             paths,
@@ -1503,6 +1506,7 @@ mod tests {
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            _single_instance_lock: single_instance_lock,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
         app.rebuild_left_items();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,14 @@ fn run_reset(paths: &DuxPaths, all: bool) -> Result<()> {
     prune_empty_ancestors(&log_path, &paths.root)?;
     remove_file_with_message(&paths.config_path)?;
     prune_empty_ancestors(&paths.config_path, &paths.root)?;
+
+    // Silently remove the lockfile so the root directory can be fully
+    // cleaned up. On Unix, unlinking a file while holding an flock on the
+    // open fd is safe — the lock persists on the orphaned inode until the
+    // fd is closed at process exit, so we remain protected for the rest
+    // of this function.
+    let _ = remove_file_if_present(&paths.lock_path);
+
     remove_root_if_empty_with_message(&paths.root)?;
 
     println!("reset complete");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,13 +91,13 @@ fn run_reset(paths: &DuxPaths, all: bool) -> Result<()> {
     remove_file_with_message(&paths.config_path)?;
     prune_empty_ancestors(&paths.config_path, &paths.root)?;
 
-    // Silently remove the lockfile so the root directory can be fully
-    // cleaned up. On Unix, unlinking a file while holding an flock on the
-    // open fd is safe — the lock persists on the orphaned inode until the
-    // fd is closed at process exit, so we remain protected for the rest
-    // of this function.
-    let _ = remove_file_if_present(&paths.lock_path);
-
+    // The lockfile (`dux.lock`) is intentionally left in place. Unlinking
+    // it while holding the flock would orphan the inode: a new process
+    // could create a fresh file at the same path (different inode) and
+    // successfully flock it, breaking the single-instance guarantee. The
+    // stale lockfile is harmless — the next launch takes it over
+    // transparently — so `remove_root_if_empty` will simply skip removal
+    // of root when the lockfile is the sole remaining entry.
     remove_root_if_empty_with_message(&paths.root)?;
 
     println!("reset complete");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -717,6 +717,7 @@ mod tests {
             config_path: PathBuf::from("/tmp/test/config.toml"),
             sessions_db_path: PathBuf::from("/tmp/test/sessions.sqlite3"),
             worktrees_root: PathBuf::from("/tmp/test/worktrees"),
+            lock_path: PathBuf::from("/tmp/test/dux.lock"),
         };
         let result = run(&["path".to_string()], &paths);
         assert!(result.is_ok());
@@ -736,6 +737,7 @@ mod tests {
                 config_path: root.join("config.toml"),
                 sessions_db_path: root.join("sessions.sqlite3"),
                 worktrees_root: root.join("worktrees"),
+                lock_path: root.join("dux.lock"),
                 root,
             };
             Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -397,6 +397,9 @@ pub struct DuxPaths {
     pub config_path: PathBuf,
     pub sessions_db_path: PathBuf,
     pub worktrees_root: PathBuf,
+    /// Path to the lockfile that enforces a single dux instance per
+    /// config directory. Contains the PID of the holder.
+    pub lock_path: PathBuf,
 }
 
 impl DuxPaths {
@@ -410,6 +413,7 @@ impl DuxPaths {
             config_path: root.join("config.toml"),
             sessions_db_path: root.join("sessions.sqlite3"),
             worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
             root,
         })
     }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -83,12 +83,21 @@ impl std::fmt::Display for AcquireError {
 
 impl std::error::Error for AcquireError {}
 
-/// Bounded retry parameters for reading the holder's PID on a contention
-/// loss. There's a small window between the winner's `flock()` returning
-/// success and the winner finishing its PID write. A loser that reads the
-/// file inside that window sees it empty. Retrying briefly makes the "PID
-/// unknown" branch of [`AcquireError`] the exceptional case it should be,
-/// while capping the delay well below human-perceptible latency.
+/// Bounded retry parameters for reading the holder's PID on contention.
+///
+/// There are two race windows the retry loop must absorb:
+///
+/// 1. **Empty file** — the winner's `flock()` returned but its PID write
+///    hasn't landed yet. The file is empty or truncated.
+/// 2. **Stale PID** — the lockfile contained a PID from a now-dead process
+///    and the winner is mid-overwrite (truncate → write). The loser reads
+///    the old bytes before the winner's new PID appears.
+///
+/// To handle both, the loop requires two consecutive reads to return the
+/// **same** PID before accepting it. A changing value means the winner is
+/// still writing, so the loop keeps going. This adds one extra 2ms sleep
+/// in the common case (winner already wrote) while correctly riding out
+/// mid-overwrite races.
 const PID_READ_ATTEMPTS: usize = 5;
 const PID_READ_RETRY_DELAY: Duration = Duration::from_millis(2);
 
@@ -147,20 +156,28 @@ impl SingleInstanceLock {
     }
 }
 
-/// Read the holder's PID from `file`, retrying briefly to absorb the small
-/// window between the holder's `flock()` succeeding and its PID write landing
-/// on disk. Returns `None` only if every attempt produced an empty or
-/// unparseable file.
+/// Read the holder's PID from `file`, requiring two consecutive reads to
+/// agree before accepting a value. This absorbs both the "empty file"
+/// window (winner hasn't written yet) and the "stale PID" window (winner
+/// is mid-overwrite of a leftover PID from a dead process). Returns `None`
+/// only if all attempts failed to produce a stable, parseable PID.
 fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
+    let mut last_pid: Option<u32> = None;
     for attempt in 0..PID_READ_ATTEMPTS {
         if let Some(pid) = read_holder_pid_once(file) {
-            return Some(pid);
+            if last_pid == Some(pid) {
+                // Two consecutive reads agree — the PID is stable.
+                return Some(pid);
+            }
+            last_pid = Some(pid);
         }
         if attempt + 1 < PID_READ_ATTEMPTS {
             thread::sleep(PID_READ_RETRY_DELAY);
         }
     }
-    None
+    // Return the last observed PID even without a confirming second read.
+    // This is the best we can do after exhausting retries.
+    last_pid
 }
 
 fn read_holder_pid_once(file: &mut File) -> Option<u32> {
@@ -307,23 +324,19 @@ mod tests {
 
     #[test]
     fn pid_read_retries_until_holder_finishes_writing() {
-        // Simulate the race window between `flock()` winning and the PID
-        // write landing: the file starts empty, a concurrent writer drops a
-        // valid PID after a barrier is released. The barrier ensures the
-        // writer doesn't run before the retry loop has started, which
-        // removes the main source of non-determinism. A theoretical timing
-        // dependency remains (the bounded retry could exhaust before the
-        // writer is scheduled), but in practice the 2ms inter-attempt
-        // sleep gives the writer ample time to land its write.
+        // Simulate the empty-file race: the file starts empty and a
+        // concurrent writer drops a valid PID after a barrier is released.
+        // The barrier ensures the writer doesn't run before the retry loop
+        // has started, which coordinates ordering between the threads. A
+        // theoretical timing dependency remains (the bounded retry could
+        // exhaust before the writer is scheduled), but in practice the
+        // 2ms inter-attempt sleep gives the writer ample time.
         use std::sync::{Arc, Barrier};
 
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("dux.lock");
         fs::write(&path, "").unwrap();
 
-        // The barrier gates the writer: it won't write until the main
-        // thread has started the retry loop (first attempt sees empty,
-        // then the barrier releases the writer for subsequent attempts).
         let barrier = Arc::new(Barrier::new(2));
         let writer_barrier = Arc::clone(&barrier);
         let writer_path = path.clone();
@@ -332,11 +345,7 @@ mod tests {
             fs::write(&writer_path, "7777\n").unwrap();
         });
 
-        // Open the file for reading, then kick off the retry. On the first
-        // read, the file is empty. The barrier unblocks the writer and
-        // subsequent retries see the PID.
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
-        // Release the writer just before entering the retry loop.
         barrier.wait();
         let pid = read_holder_pid_with_retry(&mut file);
         writer.join().unwrap();
@@ -346,6 +355,51 @@ mod tests {
             Some(7777),
             "retry loop should eventually observe the holder's PID"
         );
+    }
+
+    #[test]
+    fn pid_read_requires_two_consecutive_agreeing_reads() {
+        // When a stale PID sits in the lockfile, the first read parses
+        // successfully. The retry loop must NOT accept it immediately —
+        // it should require a second read to agree. Here the file changes
+        // between reads: attempt 0 sees 9999, the writer overwrites to
+        // 7777, and the loop eventually stabilises on 7777.
+        use std::sync::{Arc, Barrier};
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+        fs::write(&path, "9999\n").unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let writer_barrier = Arc::clone(&barrier);
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            writer_barrier.wait();
+            fs::write(&writer_path, "7777\n").unwrap();
+        });
+
+        let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        barrier.wait();
+        let pid = read_holder_pid_with_retry(&mut file);
+        writer.join().unwrap();
+
+        assert_eq!(
+            pid,
+            Some(7777),
+            "retry loop should settle on the new PID, not the stale one"
+        );
+    }
+
+    #[test]
+    fn pid_read_accepts_stable_value_without_change() {
+        // When the PID is already written and stable, two consecutive
+        // reads agree and the loop returns quickly.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+        fs::write(&path, "4242\n").unwrap();
+
+        let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        assert_eq!(read_holder_pid_with_retry(&mut file), Some(4242));
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,0 +1,229 @@
+//! Single-instance enforcement for dux.
+//!
+//! dux keeps all per-user state (config, session database, worktree registry)
+//! in a single directory resolved by [`crate::config::DuxPaths`]. Running two
+//! dux processes against the same directory produces silently divergent
+//! in-memory state: each process only sees sessions it created itself, while
+//! the shared SQLite database and git worktrees on disk end up as the union
+//! of both processes' activity.
+//!
+//! This module enforces a hard invariant: exactly one dux instance per config
+//! directory. The guarantee comes from an OS-level advisory lock
+//! ([`flock(2)`]) on a well-known lockfile. Users who want multiple concurrent
+//! workspaces can point `DUX_HOME` at different directories.
+//!
+//! The lockfile also contains the holder's PID — written after the lock is
+//! acquired — so a colliding launch can tell the user which process to close.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use rustix::fs::{FlockOperation, flock};
+use rustix::io::Errno;
+
+/// Exclusive single-instance lock on the dux config directory.
+///
+/// The file handle is kept open for the lifetime of this value. The kernel
+/// releases the advisory lock when the file descriptor is closed — including
+/// on process exit via `SIGKILL` or crash — so stale lockfiles never block a
+/// future launch. Only a live peer actively holding the lock will.
+#[derive(Debug)]
+pub struct SingleInstanceLock {
+    _file: File,
+}
+
+/// Result of attempting to acquire the single-instance lock.
+#[derive(Debug)]
+pub enum AcquireError {
+    /// Another live dux process already holds the lock. `pid` is the holder's
+    /// PID as read from the lockfile — `None` if the file was empty or its
+    /// contents could not be parsed.
+    AlreadyRunning { pid: Option<u32>, path: PathBuf },
+    /// An unexpected filesystem error occurred (not contention).
+    Io { path: PathBuf, err: std::io::Error },
+}
+
+impl std::fmt::Display for AcquireError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadyRunning {
+                pid: Some(pid),
+                path,
+            } => write!(
+                f,
+                "Another dux instance is already running (PID {pid}).\n\
+                 Close it before starting a new one, or set DUX_HOME to a \
+                 different directory to run a separate workspace.\n\
+                 Lockfile: {}",
+                path.display()
+            ),
+            Self::AlreadyRunning { pid: None, path } => write!(
+                f,
+                "Another dux instance is already running (PID unknown — lockfile is empty or unreadable).\n\
+                 Close it before starting a new one, or set DUX_HOME to a \
+                 different directory to run a separate workspace.\n\
+                 Lockfile: {}",
+                path.display()
+            ),
+            Self::Io { path, err } => {
+                write!(f, "Failed to acquire lockfile at {}: {err}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for AcquireError {}
+
+impl SingleInstanceLock {
+    /// Attempt to take the lock at `path`. On success the current PID is
+    /// written to the file so a future colliding launch can identify the
+    /// holder. The lock is held until the returned value is dropped.
+    ///
+    /// The parent directory of `path` must already exist.
+    pub fn acquire(path: &Path) -> Result<Self, AcquireError> {
+        // Opens for read+write so we can both rewrite the PID after acquiring
+        // and read the PID of the holder if we lose the race.
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .map_err(|err| AcquireError::Io {
+                path: path.to_path_buf(),
+                err,
+            })?;
+
+        match flock(&file, FlockOperation::NonBlockingLockExclusive) {
+            Ok(()) => {
+                // We won the race. Replace whatever PID was in the file with
+                // our own. Writes here are best-effort: the lock itself comes
+                // from flock(), and the PID is diagnostic for colliders.
+                let _ = file.set_len(0);
+                let _ = file.seek(SeekFrom::Start(0));
+                let _ = writeln!(file, "{}", std::process::id());
+                let _ = file.flush();
+                Ok(Self { _file: file })
+            }
+            Err(err) if err == Errno::WOULDBLOCK || err == Errno::AGAIN => {
+                // Someone else owns the lock. Read their PID so the caller
+                // can show an actionable error.
+                let mut buf = String::new();
+                let _ = file.seek(SeekFrom::Start(0));
+                let pid = file
+                    .read_to_string(&mut buf)
+                    .ok()
+                    .and_then(|_| buf.trim().parse::<u32>().ok());
+                Err(AcquireError::AlreadyRunning {
+                    pid,
+                    path: path.to_path_buf(),
+                })
+            }
+            Err(err) => Err(AcquireError::Io {
+                path: path.to_path_buf(),
+                err: err.into(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn acquire_writes_own_pid_to_lockfile() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+
+        let _lock = SingleInstanceLock::acquire(&path).expect("first acquire should succeed");
+        let contents = fs::read_to_string(&path).unwrap();
+        let written: u32 = contents.trim().parse().expect("pid should parse");
+        assert_eq!(
+            written,
+            std::process::id(),
+            "lockfile should contain the holder's PID"
+        );
+    }
+
+    #[test]
+    fn second_acquire_same_path_reports_running_with_pid() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+
+        let first = SingleInstanceLock::acquire(&path).expect("first acquire should succeed");
+        let err = SingleInstanceLock::acquire(&path)
+            .expect_err("second acquire should fail while first is held");
+
+        match err {
+            AcquireError::AlreadyRunning {
+                pid: Some(pid),
+                path: reported_path,
+            } => {
+                assert_eq!(pid, std::process::id());
+                assert_eq!(reported_path, path);
+            }
+            other => panic!("expected AlreadyRunning with PID, got {other:?}"),
+        }
+
+        drop(first);
+    }
+
+    #[test]
+    fn releasing_first_lock_allows_second_acquire() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+
+        let first = SingleInstanceLock::acquire(&path).expect("first acquire");
+        drop(first);
+
+        let _second = SingleInstanceLock::acquire(&path)
+            .expect("second acquire should succeed after first is dropped");
+    }
+
+    #[test]
+    fn stale_pid_in_preexisting_lockfile_is_overwritten_on_acquire() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+
+        // Simulate a lockfile left over from a prior crashed instance: the
+        // file exists with an old PID but no one holds the flock.
+        fs::write(&path, "99999\n").unwrap();
+
+        let _lock = SingleInstanceLock::acquire(&path).expect("should take over stale lockfile");
+        let contents = fs::read_to_string(&path).unwrap();
+        let written: u32 = contents.trim().parse().expect("pid should parse");
+        assert_eq!(written, std::process::id());
+    }
+
+    #[test]
+    fn acquire_in_missing_directory_returns_io_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("does_not_exist").join("dux.lock");
+
+        let err =
+            SingleInstanceLock::acquire(&path).expect_err("acquire in missing dir should fail");
+        assert!(matches!(err, AcquireError::Io { .. }));
+    }
+
+    #[test]
+    fn display_message_mentions_pid_and_path() {
+        let err = AcquireError::AlreadyRunning {
+            pid: Some(12345),
+            path: PathBuf::from("/tmp/dux/dux.lock"),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("12345"), "message should include the PID");
+        assert!(
+            msg.contains("/tmp/dux/dux.lock"),
+            "message should include the lockfile path"
+        );
+        assert!(
+            msg.to_lowercase().contains("already running"),
+            "message should explain the situation"
+        );
+    }
+}

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -18,9 +18,13 @@
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use rustix::fs::{FlockOperation, flock};
 use rustix::io::Errno;
+
+use crate::io_retry::retry_on_interrupt_errno;
 
 /// Exclusive single-instance lock on the dux config directory.
 ///
@@ -47,25 +51,29 @@ pub enum AcquireError {
 impl std::fmt::Display for AcquireError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AlreadyRunning {
-                pid: Some(pid),
-                path,
-            } => write!(
-                f,
-                "Another dux instance is already running (PID {pid}).\n\
-                 Close it before starting a new one, or set DUX_HOME to a \
-                 different directory to run a separate workspace.\n\
-                 Lockfile: {}",
-                path.display()
-            ),
-            Self::AlreadyRunning { pid: None, path } => write!(
-                f,
-                "Another dux instance is already running (PID unknown — lockfile is empty or unreadable).\n\
-                 Close it before starting a new one, or set DUX_HOME to a \
-                 different directory to run a separate workspace.\n\
-                 Lockfile: {}",
-                path.display()
-            ),
+            Self::AlreadyRunning { pid, path } => {
+                // Each line is written independently so the output is
+                // unambiguously left-aligned. Earlier iterations used a single
+                // string literal with `\<newline>` continuations; that renders
+                // correctly today, but separate writes remove any chance of a
+                // stray leading space sneaking in on a reformat.
+                match pid {
+                    Some(pid) => {
+                        writeln!(f, "Another dux instance is already running (PID {pid}).")?
+                    }
+                    None => writeln!(
+                        f,
+                        "Another dux instance is already running (PID unknown \
+                         — lockfile is empty or unreadable)."
+                    )?,
+                }
+                writeln!(
+                    f,
+                    "Close it before starting a new one, or set DUX_HOME to a \
+                     different directory to run a separate workspace."
+                )?;
+                write!(f, "Lockfile: {}", path.display())
+            }
             Self::Io { path, err } => {
                 write!(f, "Failed to acquire lockfile at {}: {err}", path.display())
             }
@@ -74,6 +82,15 @@ impl std::fmt::Display for AcquireError {
 }
 
 impl std::error::Error for AcquireError {}
+
+/// Bounded retry parameters for reading the holder's PID on a contention
+/// loss. There's a small window between the winner's `flock()` returning
+/// success and the winner finishing its PID write. A loser that reads the
+/// file inside that window sees it empty. Retrying briefly makes the "PID
+/// unknown" branch of [`AcquireError`] the exceptional case it should be,
+/// while capping the delay well below human-perceptible latency.
+const PID_READ_ATTEMPTS: usize = 5;
+const PID_READ_RETRY_DELAY: Duration = Duration::from_millis(2);
 
 impl SingleInstanceLock {
     /// Attempt to take the lock at `path`. On success the current PID is
@@ -95,7 +112,14 @@ impl SingleInstanceLock {
                 err,
             })?;
 
-        match flock(&file, FlockOperation::NonBlockingLockExclusive) {
+        // `flock(2)` is normally fast when paired with `LOCK_NB`, but it can
+        // still return `EINTR` if a signal is delivered during the syscall.
+        // Retry transparently on `EINTR`; contention (`EWOULDBLOCK`/`EAGAIN`)
+        // and real errors flow through unchanged.
+        let outcome =
+            retry_on_interrupt_errno(|| flock(&file, FlockOperation::NonBlockingLockExclusive));
+
+        match outcome {
             Ok(()) => {
                 // We won the race. Replace whatever PID was in the file with
                 // our own. Writes here are best-effort: the lock itself comes
@@ -108,15 +132,10 @@ impl SingleInstanceLock {
             }
             Err(err) if err == Errno::WOULDBLOCK || err == Errno::AGAIN => {
                 // Someone else owns the lock. Read their PID so the caller
-                // can show an actionable error.
-                let mut buf = String::new();
-                let _ = file.seek(SeekFrom::Start(0));
-                let pid = file
-                    .read_to_string(&mut buf)
-                    .ok()
-                    .and_then(|_| buf.trim().parse::<u32>().ok());
+                // can show an actionable error. The holder may be mid-write,
+                // so retry briefly before giving up and reporting "unknown".
                 Err(AcquireError::AlreadyRunning {
-                    pid,
+                    pid: read_holder_pid_with_retry(&mut file),
                     path: path.to_path_buf(),
                 })
             }
@@ -126,6 +145,29 @@ impl SingleInstanceLock {
             }),
         }
     }
+}
+
+/// Read the holder's PID from `file`, retrying briefly to absorb the small
+/// window between the holder's `flock()` succeeding and its PID write landing
+/// on disk. Returns `None` only if every attempt produced an empty or
+/// unparseable file.
+fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
+    for attempt in 0..PID_READ_ATTEMPTS {
+        if let Some(pid) = read_holder_pid_once(file) {
+            return Some(pid);
+        }
+        if attempt + 1 < PID_READ_ATTEMPTS {
+            thread::sleep(PID_READ_RETRY_DELAY);
+        }
+    }
+    None
+}
+
+fn read_holder_pid_once(file: &mut File) -> Option<u32> {
+    let mut buf = String::new();
+    file.seek(SeekFrom::Start(0)).ok()?;
+    file.read_to_string(&mut buf).ok()?;
+    buf.trim().parse::<u32>().ok()
 }
 
 #[cfg(test)]
@@ -210,20 +252,95 @@ mod tests {
     }
 
     #[test]
-    fn display_message_mentions_pid_and_path() {
+    fn display_message_has_no_leading_whitespace_on_wrapped_lines() {
         let err = AcquireError::AlreadyRunning {
             pid: Some(12345),
             path: PathBuf::from("/tmp/dux/dux.lock"),
         };
         let msg = format!("{err}");
-        assert!(msg.contains("12345"), "message should include the PID");
-        assert!(
-            msg.contains("/tmp/dux/dux.lock"),
-            "message should include the lockfile path"
+
+        // Each visible line must start at column 0. Splitting on `\n` and
+        // inspecting the bytes directly catches any regression to
+        // `\<newline><whitespace>` continuation style, which would leave a
+        // leading space on the wrapped lines.
+        let lines: Vec<&str> = msg.split('\n').collect();
+        assert_eq!(
+            lines.len(),
+            3,
+            "message should be exactly three lines, got: {msg:?}"
+        );
+        assert_eq!(
+            lines[0],
+            "Another dux instance is already running (PID 12345)."
         );
         assert!(
-            msg.to_lowercase().contains("already running"),
-            "message should explain the situation"
+            lines[1].starts_with("Close it before starting a new one,"),
+            "line 2 should start at column 0, got: {:?}",
+            lines[1]
         );
+        assert_eq!(lines[2], "Lockfile: /tmp/dux/dux.lock");
+
+        for (i, line) in lines.iter().enumerate() {
+            assert!(
+                !line.starts_with(' '),
+                "line {i} must not start with whitespace: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn display_message_without_pid_keeps_unknown_explanation() {
+        let err = AcquireError::AlreadyRunning {
+            pid: None,
+            path: PathBuf::from("/tmp/dux/dux.lock"),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("PID unknown"));
+        assert!(msg.contains("/tmp/dux/dux.lock"));
+        for (i, line) in msg.split('\n').enumerate() {
+            assert!(
+                !line.starts_with(' '),
+                "line {i} must not start with whitespace: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn pid_read_retries_until_holder_finishes_writing() {
+        // Simulate the race window between `flock()` winning and the PID
+        // write landing: the file starts empty, a concurrent writer drops a
+        // valid PID after a short delay, and the retry loop must observe it
+        // rather than reporting "unknown".
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+        fs::write(&path, "").unwrap();
+
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            // Sleep well under the retry budget (5 * 2ms = 10ms) so the
+            // retry loop sees the PID before giving up.
+            std::thread::sleep(Duration::from_millis(3));
+            fs::write(&writer_path, "7777\n").unwrap();
+        });
+
+        let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        let pid = read_holder_pid_with_retry(&mut file);
+        writer.join().unwrap();
+
+        assert_eq!(
+            pid,
+            Some(7777),
+            "retry loop should eventually observe the holder's PID"
+        );
+    }
+
+    #[test]
+    fn pid_read_gives_up_and_returns_none_when_file_stays_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("dux.lock");
+        fs::write(&path, "").unwrap();
+
+        let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        assert_eq!(read_holder_pid_with_retry(&mut file), None);
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -157,19 +157,29 @@ impl SingleInstanceLock {
     }
 }
 
+/// Production entry point: reads the holder's PID with the default retry
+/// budget ([`PID_READ_ATTEMPTS`] × [`PID_READ_RETRY_DELAY`]).
+fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
+    read_holder_pid(file, PID_READ_ATTEMPTS, PID_READ_RETRY_DELAY)
+}
+
 /// Read the holder's PID from `file`, preferring a value confirmed by two
 /// consecutive identical reads. This absorbs both the "empty file" window
 /// (winner hasn't written yet) and the "stale PID" window (winner is
 /// mid-overwrite of a leftover PID from a dead process).
 ///
-/// If two consecutive reads agree within the attempt budget, that value is
-/// returned immediately. If the budget is exhausted without agreement, the
-/// last successfully parsed PID is returned as a best-effort fallback —
+/// If two consecutive reads agree within `attempts`, that value is returned
+/// immediately. If the budget is exhausted without agreement, the last
+/// successfully parsed PID is returned as a best-effort fallback —
 /// reporting a potentially-stale PID is more useful than `None`. Returns
 /// `None` only if no attempt produced a parseable value at all.
-fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
+///
+/// The retry parameters are explicit so tests can use generous budgets
+/// that remain deterministic under CI load, while production uses the
+/// tight defaults from [`PID_READ_ATTEMPTS`] and [`PID_READ_RETRY_DELAY`].
+fn read_holder_pid(file: &mut File, attempts: usize, delay: Duration) -> Option<u32> {
     let mut last_pid: Option<u32> = None;
-    for attempt in 0..PID_READ_ATTEMPTS {
+    for attempt in 0..attempts {
         if let Some(pid) = read_holder_pid_once(file) {
             if last_pid == Some(pid) {
                 // Two consecutive reads agree — the PID is stable.
@@ -177,8 +187,8 @@ fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
             }
             last_pid = Some(pid);
         }
-        if attempt + 1 < PID_READ_ATTEMPTS {
-            thread::sleep(PID_READ_RETRY_DELAY);
+        if attempt + 1 < attempts {
+            thread::sleep(delay);
         }
     }
     // Return the last observed PID even without a confirming second read.
@@ -328,15 +338,19 @@ mod tests {
         }
     }
 
+    /// Generous retry budget for tests. The writer thread needs only
+    /// microseconds; 50 × 20ms = 1s gives even the slowest CI scheduler
+    /// ample room, eliminating timing-dependent flakiness.
+    const TEST_ATTEMPTS: usize = 50;
+    const TEST_DELAY: Duration = Duration::from_millis(20);
+
     #[test]
     fn pid_read_retries_until_holder_finishes_writing() {
         // Simulate the empty-file race: the file starts empty and a
         // concurrent writer drops a valid PID after a barrier is released.
-        // The barrier ensures the writer doesn't run before the retry loop
-        // has started, which coordinates ordering between the threads. A
-        // theoretical timing dependency remains (the bounded retry could
-        // exhaust before the writer is scheduled), but in practice the
-        // 2ms inter-attempt sleep gives the writer ample time.
+        // The barrier coordinates ordering (writer won't run before the
+        // retry loop starts). The generous test budget ensures the writer
+        // is always scheduled within the retry window.
         use std::sync::{Arc, Barrier};
 
         let tmp = TempDir::new().unwrap();
@@ -353,7 +367,7 @@ mod tests {
 
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
         barrier.wait();
-        let pid = read_holder_pid_with_retry(&mut file);
+        let pid = read_holder_pid(&mut file, TEST_ATTEMPTS, TEST_DELAY);
         writer.join().unwrap();
 
         assert_eq!(
@@ -367,9 +381,9 @@ mod tests {
     fn pid_read_requires_two_consecutive_agreeing_reads() {
         // When a stale PID sits in the lockfile, the first read parses
         // successfully. The retry loop must NOT accept it immediately —
-        // it should require a second read to agree. Here the file changes
-        // between reads: attempt 0 sees 9999, the writer overwrites to
-        // 7777, and the loop eventually stabilises on 7777.
+        // it needs a second read to agree. Here the file changes between
+        // reads: attempt 0 sees 9999, the writer overwrites to 7777, and
+        // the loop eventually stabilises on 7777.
         use std::sync::{Arc, Barrier};
 
         let tmp = TempDir::new().unwrap();
@@ -386,7 +400,7 @@ mod tests {
 
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
         barrier.wait();
-        let pid = read_holder_pid_with_retry(&mut file);
+        let pid = read_holder_pid(&mut file, TEST_ATTEMPTS, TEST_DELAY);
         writer.join().unwrap();
 
         assert_eq!(
@@ -399,22 +413,30 @@ mod tests {
     #[test]
     fn pid_read_accepts_stable_value_without_change() {
         // When the PID is already written and stable, two consecutive
-        // reads agree and the loop returns quickly.
+        // reads agree and the loop returns on the second attempt.
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("dux.lock");
         fs::write(&path, "4242\n").unwrap();
 
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
-        assert_eq!(read_holder_pid_with_retry(&mut file), Some(4242));
+        assert_eq!(
+            read_holder_pid(&mut file, PID_READ_ATTEMPTS, PID_READ_RETRY_DELAY),
+            Some(4242)
+        );
     }
 
     #[test]
     fn pid_read_gives_up_and_returns_none_when_file_stays_empty() {
+        // Use minimal budget here — no writer thread, so every attempt
+        // fails immediately and there's nothing to wait for.
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("dux.lock");
         fs::write(&path, "").unwrap();
 
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
-        assert_eq!(read_holder_pid_with_retry(&mut file), None);
+        assert_eq!(
+            read_holder_pid(&mut file, PID_READ_ATTEMPTS, PID_READ_RETRY_DELAY),
+            None
+        );
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -93,11 +93,12 @@ impl std::error::Error for AcquireError {}
 ///    and the winner is mid-overwrite (truncate → write). The loser reads
 ///    the old bytes before the winner's new PID appears.
 ///
-/// To handle both, the loop requires two consecutive reads to return the
-/// **same** PID before accepting it. A changing value means the winner is
-/// still writing, so the loop keeps going. This adds one extra 2ms sleep
-/// in the common case (winner already wrote) while correctly riding out
-/// mid-overwrite races.
+/// To handle both, the loop prefers two consecutive reads that return the
+/// **same** PID. A changing value means the winner is still writing, so
+/// the loop keeps going. If the budget is exhausted without two reads
+/// agreeing, the last observed PID is returned as a best-effort fallback.
+/// This adds one extra 2ms sleep in the common case (winner already wrote)
+/// while correctly riding out mid-overwrite races.
 const PID_READ_ATTEMPTS: usize = 5;
 const PID_READ_RETRY_DELAY: Duration = Duration::from_millis(2);
 
@@ -156,11 +157,16 @@ impl SingleInstanceLock {
     }
 }
 
-/// Read the holder's PID from `file`, requiring two consecutive reads to
-/// agree before accepting a value. This absorbs both the "empty file"
-/// window (winner hasn't written yet) and the "stale PID" window (winner
-/// is mid-overwrite of a leftover PID from a dead process). Returns `None`
-/// only if all attempts failed to produce a stable, parseable PID.
+/// Read the holder's PID from `file`, preferring a value confirmed by two
+/// consecutive identical reads. This absorbs both the "empty file" window
+/// (winner hasn't written yet) and the "stale PID" window (winner is
+/// mid-overwrite of a leftover PID from a dead process).
+///
+/// If two consecutive reads agree within the attempt budget, that value is
+/// returned immediately. If the budget is exhausted without agreement, the
+/// last successfully parsed PID is returned as a best-effort fallback —
+/// reporting a potentially-stale PID is more useful than `None`. Returns
+/// `None` only if no attempt produced a parseable value at all.
 fn read_holder_pid_with_retry(file: &mut File) -> Option<u32> {
     let mut last_pid: Option<u32> = None;
     for attempt in 0..PID_READ_ATTEMPTS {

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -63,8 +63,7 @@ impl std::fmt::Display for AcquireError {
                     }
                     None => writeln!(
                         f,
-                        "Another dux instance is already running (PID unknown \
-                         — lockfile is empty or unreadable)."
+                        "Another dux instance is already running (PID unknown — lockfile is empty or unreadable)."
                     )?,
                 }
                 writeln!(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -309,21 +309,32 @@ mod tests {
     fn pid_read_retries_until_holder_finishes_writing() {
         // Simulate the race window between `flock()` winning and the PID
         // write landing: the file starts empty, a concurrent writer drops a
-        // valid PID after a short delay, and the retry loop must observe it
-        // rather than reporting "unknown".
+        // valid PID after a barrier is released. The barrier makes the test
+        // deterministic regardless of scheduler jitter — no wall-clock
+        // sleeps are used to coordinate the two threads.
+        use std::sync::{Arc, Barrier};
+
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("dux.lock");
         fs::write(&path, "").unwrap();
 
+        // The barrier gates the writer: it won't write until the main
+        // thread has started the retry loop (first attempt sees empty,
+        // then the barrier releases the writer for subsequent attempts).
+        let barrier = Arc::new(Barrier::new(2));
+        let writer_barrier = Arc::clone(&barrier);
         let writer_path = path.clone();
         let writer = std::thread::spawn(move || {
-            // Sleep well under the retry budget (5 * 2ms = 10ms) so the
-            // retry loop sees the PID before giving up.
-            std::thread::sleep(Duration::from_millis(3));
+            writer_barrier.wait();
             fs::write(&writer_path, "7777\n").unwrap();
         });
 
+        // Open the file for reading, then kick off the retry. On the first
+        // read, the file is empty. The barrier unblocks the writer and
+        // subsequent retries see the PID.
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
+        // Release the writer just before entering the retry loop.
+        barrier.wait();
         let pid = read_holder_pid_with_retry(&mut file);
         writer.join().unwrap();
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -309,9 +309,12 @@ mod tests {
     fn pid_read_retries_until_holder_finishes_writing() {
         // Simulate the race window between `flock()` winning and the PID
         // write landing: the file starts empty, a concurrent writer drops a
-        // valid PID after a barrier is released. The barrier makes the test
-        // deterministic regardless of scheduler jitter — no wall-clock
-        // sleeps are used to coordinate the two threads.
+        // valid PID after a barrier is released. The barrier ensures the
+        // writer doesn't run before the retry loop has started, which
+        // removes the main source of non-determinism. A theoretical timing
+        // dependency remains (the bounded retry could exhaust before the
+        // writer is scheduled), but in practice the 2ms inter-attempt
+        // sleep gives the writer ample time to land its write.
         use std::sync::{Arc, Barrier};
 
         let tmp = TempDir::new().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,17 +32,34 @@ fn main() -> Result<()> {
     let paths = config::DuxPaths::discover()?;
 
     if args.first().map(|s| s.as_str()) == Some("config") {
-        // Only acquire the lock when the config root already exists. If
-        // the root is absent no dux instance can be running, so there is
-        // nothing to protect against — and creating the directory here
-        // would break fast-paths like `dux config reset` ("nothing to
-        // reset") and prevent `reset --all` from fully removing the root.
-        let _lock = if paths.root.exists() {
-            Some(acquire_lock_or_exit(&paths.lock_path))
-        } else {
-            None
+        let config_args = &args[1..];
+        let sub = config_args.first().map(|s| s.as_str()).unwrap_or("");
+
+        // Acquire the single-instance lock only for subcommands that
+        // mutate shared on-disk state. Read-only operations (path, diff,
+        // regenerate preview) skip the lock entirely.
+        let _lock = match sub {
+            // reset mutates state when root exists. When root is absent,
+            // run_reset's fast-path reports "nothing to reset" and exits,
+            // so we avoid creating the directory just to take a lock.
+            "reset" if paths.root.exists() => Some(acquire_lock_or_exit(&paths.lock_path)),
+
+            // regenerate --yes creates directories and writes config.
+            // Create root (so the lockfile can be opened) and lock before
+            // any writes, preventing a concurrent TUI from starting
+            // between directory creation and the config write.
+            "regenerate" if config_args.iter().any(|a| a == "--yes") => {
+                std::fs::create_dir_all(&paths.root)?;
+                Some(acquire_lock_or_exit(&paths.lock_path))
+            }
+
+            // Everything else is read-only or prints help — no shared
+            // state to protect. This includes: path, diff, diff --raw,
+            // regenerate (preview without --yes), --help, and empty.
+            _ => None,
         };
-        return cli::run(&args[1..], &paths);
+
+        return cli::run(config_args, &paths);
     }
 
     // TUI: always create the root directory (so the lockfile can be

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,11 +28,14 @@ fn main() -> Result<()> {
     }
 
     // Resolve the config directory and acquire the single-instance lock
-    // before touching any shared state. Every dux entrypoint — TUI and all
-    // `dux config` subcommands — goes through this gate so exactly one
-    // process operates on a given config directory at a time.
+    // before touching any shared state. Only the root directory is created
+    // here (so the lockfile can be opened); remaining directories
+    // (worktrees, etc.) are created by downstream code after the lock is
+    // held. Every dux entrypoint — TUI and all `dux config` subcommands —
+    // goes through this gate so exactly one process operates on a given
+    // config directory at a time.
     let paths = config::DuxPaths::discover()?;
-    paths.ensure_dirs()?;
+    std::fs::create_dir_all(&paths.root)?;
     let lock = match lockfile::SingleInstanceLock::acquire(&paths.lock_path) {
         Ok(lock) => lock,
         Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ mod statusline;
 mod storage;
 mod theme;
 
+use std::path::Path;
+
 use anyhow::Result;
 
 fn main() -> Result<()> {
@@ -27,27 +29,28 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Resolve the config directory and acquire the single-instance lock
-    // before touching any shared state. Only the root directory is created
-    // here (so the lockfile can be opened); remaining directories
-    // (worktrees, etc.) are created by downstream code after the lock is
-    // held. Every dux entrypoint — TUI and all `dux config` subcommands —
-    // goes through this gate so exactly one process operates on a given
-    // config directory at a time.
     let paths = config::DuxPaths::discover()?;
-    std::fs::create_dir_all(&paths.root)?;
-    let lock = match lockfile::SingleInstanceLock::acquire(&paths.lock_path) {
-        Ok(lock) => lock,
-        Err(err) => {
-            eprintln!("{err}");
-            std::process::exit(1);
-        }
-    };
 
     if args.first().map(|s| s.as_str()) == Some("config") {
+        // Only acquire the lock when the config root already exists. If
+        // the root is absent no dux instance can be running, so there is
+        // nothing to protect against — and creating the directory here
+        // would break fast-paths like `dux config reset` ("nothing to
+        // reset") and prevent `reset --all` from fully removing the root.
+        let _lock = if paths.root.exists() {
+            Some(acquire_lock_or_exit(&paths.lock_path))
+        } else {
+            None
+        };
         return cli::run(&args[1..], &paths);
     }
 
+    // TUI: always create the root directory (so the lockfile can be
+    // opened), acquire the lock, then let bootstrap create everything
+    // else. A losing process never touches shared state beyond the
+    // empty root.
+    std::fs::create_dir_all(&paths.root)?;
+    let lock = acquire_lock_or_exit(&paths.lock_path);
     let mut app = app::App::bootstrap_with_lock(paths, lock)?;
     app.run()
 }
@@ -80,4 +83,14 @@ fn print_help() {
            macOS: ~/.dux/sessions.sqlite3\n\
            Linux: $XDG_CONFIG_HOME/dux/sessions.sqlite3 or ~/.config/dux/sessions.sqlite3"
     );
+}
+
+fn acquire_lock_or_exit(path: &Path) -> lockfile::SingleInstanceLock {
+    match lockfile::SingleInstanceLock::acquire(path) {
+        Ok(lock) => lock,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod editor;
 mod git;
 mod io_retry;
 mod keybindings;
+mod lockfile;
 mod logger;
 mod model;
 mod provider;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,25 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Resolve the config directory and acquire the single-instance lock
+    // before touching any shared state. Every dux entrypoint — TUI and all
+    // `dux config` subcommands — goes through this gate so exactly one
+    // process operates on a given config directory at a time.
+    let paths = config::DuxPaths::discover()?;
+    paths.ensure_dirs()?;
+    let lock = match lockfile::SingleInstanceLock::acquire(&paths.lock_path) {
+        Ok(lock) => lock,
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    };
+
     if args.first().map(|s| s.as_str()) == Some("config") {
-        let paths = config::DuxPaths::discover()?;
         return cli::run(&args[1..], &paths);
     }
 
-    let mut app = app::App::bootstrap()?;
+    let mut app = app::App::bootstrap_with_lock(paths, lock)?;
     app.run()
 }
 


### PR DESCRIPTION
dux keeps its configuration, session database, and worktree registry under a single directory. When two dux processes share that directory, each one operates on its own copy of the in-memory session list while the on-disk SQLite file and git worktrees end up as the union of both processes' activity. This makes state appear inconsistent between windows: sessions created in one instance are invisible in the other, background workers (branch sync, refs watcher, PR polling) run twice against the same resources, and PTY ownership becomes ambiguous.

This change acquires an exclusive `flock(2)` on `<config_dir>/dux.lock` during `App::bootstrap`, before the logger is initialized, and holds it for the process lifetime. On success, the holder's PID is written to the lockfile so any future launch that collides can surface an actionable error:

```
Another dux instance is already running (PID 34603).
Close it before starting a new one, or set DUX_HOME to a different directory to run a separate workspace.
Lockfile: /Users/you/.dux/dux.lock
```

The lock is released automatically by the kernel when the file descriptor closes, including on `SIGKILL` or a panic, so **stale lockfiles never block startup** — only a live peer actively holding the lock will. Users who genuinely want multiple concurrent workspaces can point `DUX_HOME` at different directories and each one gets its own independent lock. The `lockfile` module is covered by unit tests for the happy path, contention with PID reporting, stale-file takeover, missing-directory errors, and error formatting; `cargo test --bin dux` passes (568 tests) and `cargo fmt` is clean.
