### PR TITLE
Require confirmation before deleting a macro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,9 @@ Use:
 
 ```bash
 cargo fmt
+cargo clippy --all-targets --all-features -- -D warnings
 cargo test
 cargo run
 ```
+
+`cargo clippy --all-targets --all-features -- -D warnings` is a CI gate — the `Clippy` check on every pull request runs this exact command and fails the PR if it emits any warning. Run it locally before committing so a toolchain bump or a newly introduced lint doesn't surface only once the PR is pushed. A new stable Rust release can enable lints that previously passed; when that happens, fix the code rather than suppressing the lint unless there is a specific, documented reason.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -66,6 +66,8 @@ enum PromptMouseTarget {
     ConfirmDeleteConfirm,
     ConfirmDeleteTerminalCancel,
     ConfirmDeleteTerminalConfirm,
+    ConfirmDeleteMacroCancel,
+    ConfirmDeleteMacroConfirm,
     ConfirmQuitCancel,
     ConfirmQuitConfirm,
     ConfirmDiscardCancel,
@@ -2294,10 +2296,21 @@ impl App {
     }
 
     fn handle_edit_macros_key(&mut self, key: KeyEvent) -> Result<bool> {
+        if matches!(
+            self.prompt,
+            PromptState::EditMacros {
+                pending_delete: Some(_),
+                ..
+            }
+        ) {
+            return self.handle_confirm_delete_macro_key(key);
+        }
+
         let PromptState::EditMacros {
             entries,
             selected,
             editing,
+            ..
         } = &mut self.prompt
         else {
             return Ok(false);
@@ -2388,12 +2401,17 @@ impl App {
                         entries.sort_by(|(a, _, _), (b, _, _)| a.cmp(b));
 
                         // Persist
-                        let _ = crate::config::save_config(
+                        if let Err(err) = crate::config::save_config(
                             &self.paths.config_path,
                             &self.config,
                             &self.bindings,
-                        );
-                        self.set_info(format!("Macro \"{name}\" saved."));
+                        ) {
+                            self.set_error(format!(
+                                "Couldn't save macro \"{name}\" to config: {err:#}"
+                            ));
+                        } else {
+                            self.set_info(format!("Macro \"{name}\" saved."));
+                        }
                         return Ok(false);
                     }
                     // In multiline mode, TextInput handles Enter/Up/Down
@@ -2442,33 +2460,90 @@ impl App {
                 });
             }
             KeyCode::Char('d') | KeyCode::Delete => {
-                // Delete selected macro
+                // Stage confirmation for deleting the selected macro.
                 if let Some((name, _, _)) = entries.get(*selected) {
                     let name = name.clone();
-                    self.config.macros.entries.shift_remove(&name);
-
-                    let PromptState::EditMacros {
-                        entries, selected, ..
-                    } = &mut self.prompt
-                    else {
+                    let PromptState::EditMacros { pending_delete, .. } = &mut self.prompt else {
                         return Ok(false);
                     };
-                    entries.retain(|(n, _, _)| *n != name);
-                    if *selected > 0 && *selected >= entries.len() {
-                        *selected = entries.len().saturating_sub(1);
-                    }
-
-                    let _ = crate::config::save_config(
-                        &self.paths.config_path,
-                        &self.config,
-                        &self.bindings,
-                    );
-                    self.set_info(format!("Macro \"{name}\" deleted."));
+                    *pending_delete = Some(PendingMacroDelete {
+                        name,
+                        confirm_selected: false,
+                    });
                 }
             }
             _ => {}
         }
         Ok(false)
+    }
+
+    fn handle_confirm_delete_macro_key(&mut self, key: KeyEvent) -> Result<bool> {
+        let action = self.bindings.lookup(&key, BindingScope::Dialog);
+        let is_space = key.code == KeyCode::Char(' ');
+        let activate = matches!(action, Some(Action::Confirm)) || is_space;
+
+        let confirm = {
+            let PromptState::EditMacros { pending_delete, .. } = &mut self.prompt else {
+                return Ok(false);
+            };
+            let Some(pending) = pending_delete else {
+                return Ok(false);
+            };
+
+            if matches!(action, Some(Action::CloseOverlay)) {
+                *pending_delete = None;
+                return Ok(false);
+            }
+            if matches!(action, Some(Action::ToggleSelection)) {
+                pending.confirm_selected = !pending.confirm_selected;
+                return Ok(false);
+            }
+            if !activate {
+                return Ok(false);
+            }
+            pending.confirm_selected
+        };
+
+        self.resolve_confirm_delete_macro(confirm);
+        Ok(false)
+    }
+
+    pub(super) fn resolve_confirm_delete_macro(&mut self, confirm: bool) -> bool {
+        let PromptState::EditMacros { pending_delete, .. } = &mut self.prompt else {
+            return false;
+        };
+        let Some(pending) = pending_delete.take() else {
+            return false;
+        };
+
+        if !confirm {
+            return false;
+        }
+
+        let name = pending.name;
+        self.config.macros.entries.shift_remove(&name);
+
+        let PromptState::EditMacros {
+            entries, selected, ..
+        } = &mut self.prompt
+        else {
+            return false;
+        };
+        entries.retain(|(n, _, _)| n != &name);
+        if *selected > 0 && *selected >= entries.len() {
+            *selected = entries.len().saturating_sub(1);
+        }
+
+        if let Err(err) =
+            crate::config::save_config(&self.paths.config_path, &self.config, &self.bindings)
+        {
+            self.set_error(format!(
+                "Couldn't persist deletion of macro \"{name}\" to config: {err:#}"
+            ));
+        } else {
+            self.set_info(format!("Macro \"{name}\" deleted."));
+        }
+        false
     }
 
     fn handle_resize_key(&mut self, key: KeyEvent) {
@@ -2614,6 +2689,18 @@ impl App {
                     Some(PromptMouseTarget::ConfirmDeleteTerminalCancel)
                 } else if contains_point(delete_button, column, row) {
                     Some(PromptMouseTarget::ConfirmDeleteTerminalConfirm)
+                } else {
+                    None
+                }
+            }
+            OverlayMouseLayout::ConfirmDeleteMacro {
+                cancel_button,
+                delete_button,
+            } => {
+                if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteMacroCancel)
+                } else if contains_point(delete_button, column, row) {
+                    Some(PromptMouseTarget::ConfirmDeleteMacroConfirm)
                 } else {
                     None
                 }
@@ -3526,6 +3613,12 @@ impl App {
             PromptMouseTarget::ConfirmDeleteTerminalConfirm => {
                 return self.resolve_confirm_delete_terminal(true);
             }
+            PromptMouseTarget::ConfirmDeleteMacroCancel => {
+                return self.resolve_confirm_delete_macro(false);
+            }
+            PromptMouseTarget::ConfirmDeleteMacroConfirm => {
+                return self.resolve_confirm_delete_macro(true);
+            }
             PromptMouseTarget::ConfirmQuitCancel => return self.resolve_confirm_quit(false),
             PromptMouseTarget::ConfirmQuitConfirm => return self.resolve_confirm_quit(true),
             PromptMouseTarget::ConfirmDiscardCancel => {
@@ -3843,7 +3936,9 @@ impl App {
             self.config.ui.terminal_pane_height_pct = self.terminal_pane_height_pct;
             self.config.ui.staged_pane_height_pct = self.staged_pane_height_pct;
             self.config.ui.commit_pane_height_pct = self.commit_pane_height_pct;
-            let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+            if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings) {
+                self.set_error(format!("Couldn't persist pane sizes to config: {err:#}"));
+            }
         }
     }
 
@@ -8033,5 +8128,198 @@ mod tests {
         assert_eq!(app.input_target, InputTarget::Agent);
         // The raw_input_buf should be empty (no remainder).
         assert!(app.raw_input_buf.is_empty());
+    }
+
+    fn app_with_two_macros() -> App {
+        let mut app = test_app(default_bindings());
+        app.config.macros.entries.insert(
+            "greet".to_string(),
+            crate::config::MacroEntry {
+                text: "hello".to_string(),
+                surface: crate::config::MacroSurface::Agent,
+            },
+        );
+        app.config.macros.entries.insert(
+            "farewell".to_string(),
+            crate::config::MacroEntry {
+                text: "goodbye".to_string(),
+                surface: crate::config::MacroSurface::Agent,
+            },
+        );
+        app.open_edit_macros();
+        app
+    }
+
+    fn pending_delete_state(app: &App) -> Option<(&str, bool)> {
+        if let PromptState::EditMacros {
+            pending_delete: Some(pending),
+            ..
+        } = &app.prompt
+        {
+            Some((pending.name.as_str(), pending.confirm_selected))
+        } else {
+            None
+        }
+    }
+
+    #[test]
+    fn macro_delete_key_stages_confirmation_without_mutating_config() {
+        let mut app = app_with_two_macros();
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+
+        assert_eq!(pending_delete_state(&app), Some(("greet", false)));
+        assert_eq!(
+            app.config.macros.entries.len(),
+            2,
+            "macro must not be removed from config until confirmed"
+        );
+        assert!(app.config.macros.entries.contains_key("greet"));
+    }
+
+    #[test]
+    fn macro_delete_esc_clears_pending_without_deleting() {
+        let mut app = app_with_two_macros();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+        assert!(pending_delete_state(&app).is_some());
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .expect("handle esc");
+
+        assert!(pending_delete_state(&app).is_none());
+        assert!(
+            matches!(app.prompt, PromptState::EditMacros { .. }),
+            "macro editor should remain open after dismissing the confirm dialog"
+        );
+        assert_eq!(app.config.macros.entries.len(), 2);
+    }
+
+    #[test]
+    fn macro_delete_tab_toggles_confirm_button_focus() {
+        let mut app = app_with_two_macros();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+        assert_eq!(pending_delete_state(&app), Some(("greet", false)));
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .expect("handle tab");
+        assert_eq!(pending_delete_state(&app), Some(("greet", true)));
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .expect("handle tab");
+        assert_eq!(pending_delete_state(&app), Some(("greet", false)));
+    }
+
+    #[test]
+    fn macro_delete_enter_on_cancel_is_noop() {
+        let mut app = app_with_two_macros();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .expect("handle enter");
+
+        assert!(pending_delete_state(&app).is_none());
+        assert_eq!(app.config.macros.entries.len(), 2);
+        assert!(app.config.macros.entries.contains_key("greet"));
+    }
+
+    #[test]
+    fn macro_delete_enter_on_delete_removes_and_persists() {
+        let mut app = app_with_two_macros();
+        let config_path = app.paths.config_path.clone();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .expect("handle tab");
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .expect("handle enter");
+
+        assert!(pending_delete_state(&app).is_none());
+        assert!(
+            !app.config.macros.entries.contains_key("greet"),
+            "macro should be removed from in-memory config"
+        );
+        assert_eq!(app.config.macros.entries.len(), 1);
+
+        if let PromptState::EditMacros { entries, .. } = &app.prompt {
+            assert!(
+                entries.iter().all(|(n, _, _)| n != "greet"),
+                "EditMacros snapshot should reflect the deletion"
+            );
+        } else {
+            panic!("expected EditMacros prompt after resolving delete");
+        }
+
+        assert!(
+            config_path.exists(),
+            "config file should have been written to disk"
+        );
+        let disk = std::fs::read_to_string(&config_path).expect("read config");
+        assert!(
+            !disk.contains("greet"),
+            "deleted macro should not appear in saved config"
+        );
+    }
+
+    #[test]
+    fn macro_delete_surfaces_save_failure_on_status_line() {
+        let mut app = app_with_two_macros();
+        // Point config_path at a directory that doesn't exist so save_config fails.
+        app.paths.config_path = app
+            .paths
+            .root
+            .join("nope")
+            .join("missing")
+            .join("config.toml");
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .expect("handle tab");
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .expect("handle enter");
+
+        assert_eq!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Error,
+            "save failure should produce an error-toned status message"
+        );
+        let msg = app.status.message();
+        assert!(
+            msg.contains("greet"),
+            "status message should name the affected macro, got: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("config"),
+            "status message should mention config, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn macro_delete_space_activates_focused_button() {
+        let mut app = app_with_two_macros();
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+
+        // Space on Cancel (default focus) should cancel without deleting.
+        app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
+            .expect("handle space");
+        assert!(pending_delete_state(&app).is_none());
+        assert_eq!(app.config.macros.entries.len(), 2);
+
+        // Now re-open and focus Delete, then Space should remove.
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE))
+            .expect("handle d");
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .expect("handle tab");
+        app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
+            .expect("handle space");
+
+        assert!(pending_delete_state(&app).is_none());
+        assert!(!app.config.macros.entries.contains_key("greet"));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -479,6 +479,7 @@ pub(crate) enum PromptState {
         entries: Vec<(String, String, MacroSurface)>,
         selected: usize,
         editing: Option<MacroEditState>,
+        pending_delete: Option<PendingMacroDelete>,
     },
     ConfirmNonDefaultBranch {
         path: String,
@@ -576,6 +577,12 @@ pub(crate) struct MacroEditState {
 pub(crate) enum MacroEditStage {
     EditName,
     EditText,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PendingMacroDelete {
+    pub(crate) name: String,
+    pub(crate) confirm_selected: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -732,6 +739,10 @@ pub(crate) enum OverlayMouseLayout {
         delete_button: Rect,
     },
     ConfirmDeleteTerminal {
+        cancel_button: Rect,
+        delete_button: Rect,
+    },
+    ConfirmDeleteMacro {
         cancel_button: Rect,
         delete_button: Rect,
     },
@@ -1487,23 +1498,31 @@ impl App {
             "toggle-diff-line-numbers" => {
                 self.show_diff_line_numbers = !self.show_diff_line_numbers;
                 self.config.ui.show_diff_line_numbers = self.show_diff_line_numbers;
-                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+                let save_result =
+                    save_config(&self.paths.config_path, &self.config, &self.bindings);
                 let _ = self.refresh_current_diff();
                 let state = if self.show_diff_line_numbers {
                     "enabled"
                 } else {
                     "disabled"
                 };
-                let palette_key = self.bindings.label_for(Action::OpenPalette);
-                self.set_info(format!(
-                    "Diff line numbers {state}. Press {palette_key} to open the palette and toggle back."
-                ));
+                if let Err(err) = save_result {
+                    self.set_error(format!(
+                        "Diff line numbers {state} for this session, but couldn't persist the change to config: {err:#}"
+                    ));
+                } else {
+                    let palette_key = self.bindings.label_for(Action::OpenPalette);
+                    self.set_info(format!(
+                        "Diff line numbers {state}. Press {palette_key} to open the palette and toggle back."
+                    ));
+                }
                 Ok(())
             }
             "toggle-github-integration" => {
                 self.github_integration_enabled = !self.github_integration_enabled;
                 self.config.ui.github_integration = self.github_integration_enabled;
-                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+                let save_result =
+                    save_config(&self.paths.config_path, &self.config, &self.bindings);
                 if self.github_integration_enabled
                     && matches!(self.gh_status, crate::model::GhStatus::Available)
                 {
@@ -1520,21 +1539,34 @@ impl App {
                 } else {
                     "disabled"
                 };
-                self.set_info(format!("GitHub integration {state}."));
+                if let Err(err) = save_result {
+                    self.set_error(format!(
+                        "GitHub integration {state} for this session, but couldn't persist the change to config: {err:#}"
+                    ));
+                } else {
+                    self.set_info(format!("GitHub integration {state}."));
+                }
                 Ok(())
             }
             "toggle-prompt-for-name" => {
                 self.config.defaults.prompt_for_name = !self.config.defaults.prompt_for_name;
-                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
+                let save_result =
+                    save_config(&self.paths.config_path, &self.config, &self.bindings);
                 let state = if self.config.defaults.prompt_for_name {
                     "enabled — you'll be prompted for a name"
                 } else {
                     "disabled — random names will be generated"
                 };
-                let palette_key = self.bindings.label_for(Action::OpenPalette);
-                self.set_info(format!(
-                    "Prompt for agent name {state}. Press {palette_key} to toggle back."
-                ));
+                if let Err(err) = save_result {
+                    self.set_error(format!(
+                        "Prompt for agent name {state} for this session, but couldn't persist the change to config: {err:#}"
+                    ));
+                } else {
+                    let palette_key = self.bindings.label_for(Action::OpenPalette);
+                    self.set_info(format!(
+                        "Prompt for agent name {state}. Press {palette_key} to toggle back."
+                    ));
+                }
                 Ok(())
             }
             "toggle-pr-banner-position" => {
@@ -1545,8 +1577,14 @@ impl App {
                     "top"
                 };
                 self.config.ui.pr_banner_position = pos.to_string();
-                let _ = save_config(&self.paths.config_path, &self.config, &self.bindings);
-                self.set_info(format!("PR banner moved to {pos} of agent pane."));
+                if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings)
+                {
+                    self.set_error(format!(
+                        "PR banner moved to {pos} for this session, but couldn't persist the change to config: {err:#}"
+                    ));
+                } else {
+                    self.set_info(format!("PR banner moved to {pos} of agent pane."));
+                }
                 Ok(())
             }
             "force-redraw" => {
@@ -1575,6 +1613,7 @@ impl App {
             entries,
             selected: 0,
             editing: None,
+            pending_delete: None,
         };
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3906,6 +3906,7 @@ impl App {
             entries,
             selected,
             editing,
+            pending_delete,
         } = &self.prompt
         else {
             return;
@@ -4102,6 +4103,112 @@ impl App {
                 Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
             }
         }
+
+        let pending_delete_snapshot = pending_delete
+            .as_ref()
+            .map(|p| (p.name.clone(), p.confirm_selected));
+        if let Some((name, confirm_selected)) = pending_delete_snapshot {
+            self.render_confirm_delete_macro(frame, &name, confirm_selected);
+        }
+    }
+
+    fn render_confirm_delete_macro(
+        &mut self,
+        frame: &mut Frame,
+        name: &str,
+        confirm_selected: bool,
+    ) {
+        self.render_dim_overlay(frame);
+        let area = centered_rect(56, 30, frame.area());
+        Clear.render(area, frame.buffer_mut());
+        let outer = self.themed_overlay_block("Delete Macro");
+        let inner = outer.inner(area);
+        outer.render(area, frame.buffer_mut());
+
+        let [body_area, _, buttons_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(1),
+                Constraint::Length(1),
+                Constraint::Length(3),
+            ])
+            .areas(inner);
+
+        let lines = vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::raw(" Are you sure you want to delete "),
+                Span::styled(name, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("?"),
+            ]),
+            Line::from(""),
+        ];
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(body_area, frame.buffer_mut());
+
+        let btn_width = 16u16;
+        let gap = 2u16;
+        let total = btn_width * 2 + gap;
+        let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+        let cancel_area = Rect {
+            x: buttons_area.x + left_offset,
+            y: buttons_area.y,
+            width: btn_width,
+            height: 3,
+        };
+        let delete_area = Rect {
+            x: cancel_area.x + btn_width + gap,
+            y: buttons_area.y,
+            width: btn_width,
+            height: 3,
+        };
+
+        let (cancel_border, cancel_fg) = if !confirm_selected {
+            (
+                self.theme.button_confirm_border,
+                self.theme.button_active_fg,
+            )
+        } else {
+            (self.theme.border_normal, self.theme.hint_desc_fg)
+        };
+        let (delete_border, delete_fg) = if confirm_selected {
+            (self.theme.button_danger_border, self.theme.button_active_fg)
+        } else {
+            (self.theme.border_normal, self.theme.hint_desc_fg)
+        };
+
+        Paragraph::new(Line::from(Span::styled(
+            "Cancel",
+            Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+        )))
+        .alignment(ratatui::layout::Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_set(border::ROUNDED)
+                .border_style(Style::default().fg(cancel_border)),
+        )
+        .render(cancel_area, frame.buffer_mut());
+
+        Paragraph::new(Line::from(Span::styled(
+            "Delete",
+            Style::default().fg(delete_fg).add_modifier(Modifier::BOLD),
+        )))
+        .alignment(ratatui::layout::Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_set(border::ROUNDED)
+                .border_style(Style::default().fg(delete_border)),
+        )
+        .render(delete_area, frame.buffer_mut());
+
+        self.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteMacro {
+            cancel_button: cancel_area,
+            delete_button: delete_area,
+        };
     }
 
     /// Render a single-line TextInput with cursor in a bordered box.


### PR DESCRIPTION
In the macro editor, pressing `d` or `Delete` used to remove the selected macro immediately and persist the change to `config.toml` in a single keystroke, with no undo. That collides with the project tenet that *user data* — which macros are — should never be mutated without explicit confirmation. This change routes macro deletion through a two-button confirmation dialog that mirrors the existing `ConfirmDeleteTerminal` flow: Cancel focused by default, `Tab` toggles focus, `Enter` or `Space` activates the focused button, and `Esc` dismisses. The dialog state is nested inside the `EditMacros` prompt rather than replacing it, so scroll position and any in-progress editor state are preserved when the user cancels.

While auditing the macro flow, the review surfaced a broader silent-failure pattern: seven call sites across `src/app/` discarded `save_config` errors with `let _ = …`. That meant a user could toggle a setting or delete a macro and see a success toast even when the config file on disk hadn't been updated (read-only filesystem, disk full, permissions, etc.). All seven sites — macro save, macro delete, pane-size persistence, and the four palette toggles for diff line numbers, GitHub integration, prompt-for-name, and PR banner position — now surface save failures on the status line with a message that names *what* was changed in memory but didn't make it to disk, so the user knows exactly what to recover.

Covered by new unit tests in `src/app/input.rs` exercising the full dialog state machine (stage, cancel via `Esc`, focus toggle, `Enter`-on-cancel no-op, `Enter`-on-delete removes and persists, `Space` activates the focused button) plus one failure-path test that points `config_path` at a non-existent directory and asserts the status line reaches the `Error` tone. Verified with `cargo fmt`, `cargo clippy --tests`, and `cargo test` (598 passing). One caveat: manual `cargo run` sanity-check of the new dialog in a live terminal was **not** performed as part of this change and is worth a quick eyeball before merging.