### PR TITLE
Make modal checkboxes clickable with the mouse

### DIFF
--- a/src/app/checkbox.rs
+++ b/src/app/checkbox.rs
@@ -40,6 +40,10 @@ impl<'a> Checkbox<'a> {
     const GAP: &'static str = " ";
     const INDENT: &'static str = "     ";
 
+    pub(crate) const fn indent() -> &'static str {
+        Self::INDENT
+    }
+
     pub(crate) fn new(label: &'a str) -> Self {
         Self {
             label,
@@ -129,6 +133,13 @@ impl<'a> Checkbox<'a> {
 
 impl Widget for CheckboxLayout {
     fn render(self, area: Rect, buf: &mut Buffer) {
+        for clear_offset in 0..area.height {
+            let y = area.y.saturating_add(clear_offset);
+            for x_offset in 0..area.width {
+                buf[(area.x.saturating_add(x_offset), y)].reset();
+            }
+        }
+
         for (offset, line) in self.lines.into_iter().enumerate() {
             let y = area.y.saturating_add(offset as u16);
             if y >= area.y.saturating_add(area.height) {
@@ -267,5 +278,10 @@ mod tests {
 
         assert_eq!(unchecked_spans[1].content.as_ref(), "[ ]");
         assert_eq!(checked_spans[1].content.as_ref(), "[x]");
+    }
+
+    #[test]
+    fn checkbox_indent_width_matches_indent_text() {
+        assert_eq!(Checkbox::indent().chars().count(), 5);
     }
 }

--- a/src/app/checkbox.rs
+++ b/src/app/checkbox.rs
@@ -97,6 +97,17 @@ impl<'a> Checkbox<'a> {
         }
     }
 
+    pub(crate) fn inline_prefix(&self, marker_style: Style) -> Vec<Span<'static>> {
+        vec![
+            Span::raw(Self::PREFIX),
+            Span::styled(
+                if self.checked { "[x]" } else { "[ ]" }.to_string(),
+                self.marker_style(marker_style),
+            ),
+            Span::raw(Self::GAP),
+        ]
+    }
+
     pub(crate) fn marker_style(&self, base_marker_style: Style) -> Style {
         match self.state {
             CheckboxState::Normal => base_marker_style,
@@ -242,5 +253,19 @@ mod tests {
                 .add_modifier
                 .contains(Modifier::BOLD)
         );
+    }
+
+    #[test]
+    fn checkbox_inline_prefix_uses_shared_ascii_marker() {
+        let unchecked = Checkbox::new("")
+            .checked(false)
+            .state(CheckboxState::Normal);
+        let checked = Checkbox::new("").checked(true).state(CheckboxState::Normal);
+
+        let unchecked_spans = unchecked.inline_prefix(Style::default());
+        let checked_spans = checked.inline_prefix(Style::default());
+
+        assert_eq!(unchecked_spans[1].content.as_ref(), "[ ]");
+        assert_eq!(checked_spans[1].content.as_ref(), "[x]");
     }
 }

--- a/src/app/checkbox.rs
+++ b/src/app/checkbox.rs
@@ -1,0 +1,246 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::prelude::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Widget;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum CheckboxState {
+    Normal,
+    Hovered,
+    Focused,
+    Disabled,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CheckboxLayout {
+    pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) height: u16,
+}
+
+impl CheckboxLayout {
+    pub(crate) fn empty() -> Self {
+        Self {
+            lines: Vec::new(),
+            height: 0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Checkbox<'a> {
+    label: &'a str,
+    checked: bool,
+    state: CheckboxState,
+}
+
+impl<'a> Checkbox<'a> {
+    const PREFIX: &'static str = " ";
+    const GAP: &'static str = " ";
+    const INDENT: &'static str = "     ";
+
+    pub(crate) fn new(label: &'a str) -> Self {
+        Self {
+            label,
+            checked: false,
+            state: CheckboxState::Normal,
+        }
+    }
+
+    pub(crate) fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
+    }
+
+    pub(crate) fn state(mut self, state: CheckboxState) -> Self {
+        self.state = state;
+        self
+    }
+
+    pub(crate) fn layout(
+        &self,
+        max_width: u16,
+        marker_style: Style,
+        label_style: Style,
+    ) -> CheckboxLayout {
+        if max_width == 0 {
+            return CheckboxLayout::empty();
+        }
+
+        let indent_width = Self::INDENT.chars().count();
+        let available = usize::from(max_width);
+        let label_width = available.saturating_sub(indent_width).max(1);
+        let wrapped = wrap_checkbox_label(self.label, label_width);
+        let marker = if self.checked { "[x]" } else { "[ ]" };
+        let mut lines = Vec::with_capacity(wrapped.len().max(1));
+
+        for (index, text) in wrapped.into_iter().enumerate() {
+            if index == 0 {
+                lines.push(Line::from(vec![
+                    Span::raw(Self::PREFIX),
+                    Span::styled(marker.to_string(), marker_style),
+                    Span::raw(Self::GAP),
+                    Span::styled(text, label_style),
+                ]));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::raw(Self::INDENT),
+                    Span::styled(text, label_style),
+                ]));
+            }
+        }
+
+        CheckboxLayout {
+            height: lines.len() as u16,
+            lines,
+        }
+    }
+
+    pub(crate) fn marker_style(&self, base_marker_style: Style) -> Style {
+        match self.state {
+            CheckboxState::Normal => base_marker_style,
+            CheckboxState::Hovered => base_marker_style.add_modifier(Modifier::BOLD),
+            CheckboxState::Focused => base_marker_style.add_modifier(Modifier::BOLD),
+            CheckboxState::Disabled => base_marker_style,
+        }
+    }
+
+    pub(crate) fn label_style(&self, base_label_style: Style) -> Style {
+        match self.state {
+            CheckboxState::Normal => base_label_style,
+            CheckboxState::Hovered => base_label_style.add_modifier(Modifier::BOLD),
+            CheckboxState::Focused => base_label_style.add_modifier(Modifier::BOLD),
+            CheckboxState::Disabled => base_label_style,
+        }
+    }
+}
+
+impl Widget for CheckboxLayout {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        for (offset, line) in self.lines.into_iter().enumerate() {
+            let y = area.y.saturating_add(offset as u16);
+            if y >= area.y.saturating_add(area.height) {
+                break;
+            }
+            line.render(
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+                buf,
+            );
+        }
+    }
+}
+
+fn wrap_checkbox_label(label: &str, max_width: usize) -> Vec<String> {
+    if label.is_empty() {
+        return vec![String::new()];
+    }
+
+    let mut lines = Vec::new();
+    for paragraph in label.split('\n') {
+        let mut current = String::new();
+        let mut current_width = 0usize;
+        for word in paragraph.split_whitespace() {
+            let word_width = word.chars().count();
+            if current.is_empty() {
+                if word_width <= max_width {
+                    current.push_str(word);
+                    current_width = word_width;
+                } else {
+                    push_broken_word_lines(word, max_width, &mut lines);
+                }
+                continue;
+            }
+
+            let next_width = current_width + 1 + word_width;
+            if next_width <= max_width {
+                current.push(' ');
+                current.push_str(word);
+                current_width = next_width;
+            } else {
+                lines.push(std::mem::take(&mut current));
+                current_width = 0;
+                if word_width <= max_width {
+                    current.push_str(word);
+                    current_width = word_width;
+                } else {
+                    push_broken_word_lines(word, max_width, &mut lines);
+                }
+            }
+        }
+
+        if !current.is_empty() {
+            lines.push(current);
+        } else if paragraph.is_empty() {
+            lines.push(String::new());
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+fn push_broken_word_lines(word: &str, max_width: usize, lines: &mut Vec<String>) {
+    let mut chunk = String::new();
+    let mut chunk_width = 0usize;
+    for ch in word.chars() {
+        if chunk_width == max_width {
+            lines.push(std::mem::take(&mut chunk));
+            chunk_width = 0;
+        }
+        chunk.push(ch);
+        chunk_width += 1;
+    }
+    if !chunk.is_empty() {
+        lines.push(chunk);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn checkbox_wraps_label_with_continuation_indent() {
+        let checkbox = Checkbox::new("Also delete the worktree and branch")
+            .checked(false)
+            .state(CheckboxState::Normal);
+
+        let layout = checkbox.layout(20, Style::default(), Style::default());
+
+        assert_eq!(layout.height, 3);
+        assert_eq!(layout.lines.len(), 3);
+        assert_eq!(layout.lines[0].spans[0].content.as_ref(), " ");
+        assert_eq!(layout.lines[0].spans[1].content.as_ref(), "[ ]");
+        assert_eq!(layout.lines[1].spans[0].content.as_ref(), "     ");
+        assert_eq!(layout.lines[2].spans[0].content.as_ref(), "     ");
+    }
+
+    #[test]
+    fn checkbox_hover_and_focus_bolden_label_and_marker() {
+        let marker = Style::default();
+        let label = Style::default();
+        let hovered = Checkbox::new("Label").state(CheckboxState::Hovered);
+        let focused = Checkbox::new("Label").state(CheckboxState::Focused);
+
+        assert!(
+            hovered
+                .marker_style(marker)
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+        assert!(
+            focused
+                .label_style(label)
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+    }
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -74,6 +74,7 @@ enum PromptMouseTarget {
     ConfirmNonDefaultBranchAdd,
     ConfirmUseExistingBranchCancel,
     ConfirmUseExistingBranchUse,
+    Checkbox(OverlayCheckboxId),
     RenameInput,
     NameNewAgentInput,
 }
@@ -2597,8 +2598,11 @@ impl App {
             OverlayMouseLayout::ConfirmDeleteAgent {
                 cancel_button,
                 delete_button,
+                checkbox,
             } => {
-                if contains_point(cancel_button, column, row) {
+                if checkbox.is_some_and(|checkbox| contains_point(checkbox.rect, column, row)) {
+                    checkbox.map(|checkbox| PromptMouseTarget::Checkbox(checkbox.id))
+                } else if contains_point(cancel_button, column, row) {
                     Some(PromptMouseTarget::ConfirmDeleteCancel)
                 } else if contains_point(delete_button, column, row) {
                     Some(PromptMouseTarget::ConfirmDeleteConfirm)
@@ -2666,8 +2670,12 @@ impl App {
                     None
                 }
             }
-            OverlayMouseLayout::RenameSession { input } => {
-                contains_point(input, column, row).then_some(PromptMouseTarget::RenameInput)
+            OverlayMouseLayout::RenameSession { input, checkbox } => {
+                if checkbox.is_some_and(|checkbox| contains_point(checkbox.rect, column, row)) {
+                    checkbox.map(|checkbox| PromptMouseTarget::Checkbox(checkbox.id))
+                } else {
+                    contains_point(input, column, row).then_some(PromptMouseTarget::RenameInput)
+                }
             }
             OverlayMouseLayout::NameNewAgent { input } => {
                 contains_point(input, column, row).then_some(PromptMouseTarget::NameNewAgentInput)
@@ -3346,7 +3354,7 @@ impl App {
 
     fn set_rename_cursor_from_mouse(&mut self, column: u16) {
         let input_area = match self.overlay_layout.active {
-            OverlayMouseLayout::RenameSession { input } => input,
+            OverlayMouseLayout::RenameSession { input, .. } => input,
             _ => return,
         };
         if let PromptState::RenameSession { input, .. } = &mut self.prompt {
@@ -3361,6 +3369,29 @@ impl App {
         };
         if let PromptState::NameNewAgent { input, .. } = &mut self.prompt {
             input.cursor = cursor_from_single_line_position(&input.text, input_area, 0, column);
+        }
+    }
+
+    fn toggle_overlay_checkbox(&mut self, checkbox_id: OverlayCheckboxId) {
+        match checkbox_id {
+            OverlayCheckboxId::DeleteAgentWorktree => {
+                if let PromptState::ConfirmDeleteAgent {
+                    delete_worktree,
+                    focus,
+                    worktree_shared,
+                    ..
+                } = &mut self.prompt
+                    && !*worktree_shared
+                {
+                    *delete_worktree = !*delete_worktree;
+                    *focus = DeleteAgentFocus::Checkbox;
+                }
+            }
+            OverlayCheckboxId::RenameSessionBranch => {
+                if let PromptState::RenameSession { rename_branch, .. } = &mut self.prompt {
+                    *rename_branch = !*rename_branch;
+                }
+            }
         }
     }
 
@@ -3545,6 +3576,9 @@ impl App {
             }
             PromptMouseTarget::ConfirmUseExistingBranchUse => {
                 return self.resolve_confirm_use_existing_branch(true);
+            }
+            PromptMouseTarget::Checkbox(checkbox_id) => {
+                self.toggle_overlay_checkbox(checkbox_id);
             }
             PromptMouseTarget::RenameInput => {
                 self.set_rename_cursor_from_mouse(mouse.column);
@@ -4192,8 +4226,9 @@ mod tests {
         App, CenterMode, ConfirmKillRunningPrompt, DeleteAgentFocus, FocusPane, FullscreenOverlay,
         InputTarget, KillRunningAction, KillRunningFocus, KillRunningFooterAction,
         KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftSection, MouseClickTarget,
-        MouseLayoutState, OverlayMouseLayout, OverlayMouseLayoutState, PromptState, PullTarget,
-        RightSection, RuntimeTargetId, TextInput, WorkerEvent,
+        MouseLayoutState, OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout,
+        OverlayMouseLayoutState, PromptState, PullTarget, RightSection, RuntimeTargetId, TextInput,
+        WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -4461,6 +4496,10 @@ mod tests {
         app.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
             cancel_button: Rect::new(34, 10, 16, 3),
             delete_button: Rect::new(52, 10, 16, 3),
+            checkbox: Some(OverlayCheckbox {
+                id: OverlayCheckboxId::DeleteAgentWorktree,
+                rect: Rect::new(24, 7, 44, 1),
+            }),
         };
     }
 
@@ -4481,6 +4520,10 @@ mod tests {
     fn install_rename_overlay(app: &mut App) {
         app.overlay_layout.active = OverlayMouseLayout::RenameSession {
             input: Rect::new(24, 10, 30, 1),
+            checkbox: Some(OverlayCheckbox {
+                id: OverlayCheckboxId::RenameSessionBranch,
+                rect: Rect::new(24, 12, 34, 2),
+            }),
         };
     }
 
@@ -6895,6 +6938,33 @@ mod tests {
     }
 
     #[test]
+    fn mouse_click_delete_dialog_checkbox_toggles_delete_worktree() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfirmDeleteAgent {
+            session_id: app.sessions[0].id.clone(),
+            branch_name: app.sessions[0].branch_name.clone(),
+            focus: DeleteAgentFocus::Cancel,
+            delete_worktree: false,
+            worktree_shared: false,
+        };
+        install_confirm_delete_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 7));
+
+        match &app.prompt {
+            PromptState::ConfirmDeleteAgent {
+                delete_worktree,
+                focus,
+                ..
+            } => {
+                assert!(*delete_worktree);
+                assert_eq!(*focus, DeleteAgentFocus::Checkbox);
+            }
+            other => panic!("expected delete prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn mouse_click_rename_input_moves_cursor() {
         let mut app = test_app(default_bindings());
         let sid = app.sessions[0].id.clone();
@@ -6910,6 +6980,25 @@ mod tests {
         match &app.prompt {
             PromptState::RenameSession { input, .. } => assert_eq!(input.cursor, 5),
             _ => panic!("expected rename prompt"),
+        }
+    }
+
+    #[test]
+    fn mouse_click_rename_checkbox_toggles_branch_rename() {
+        let mut app = test_app(default_bindings());
+        let sid = app.sessions[0].id.clone();
+        app.prompt = PromptState::RenameSession {
+            session_id: sid,
+            input: TextInput::with_text("rename me".to_string()),
+            rename_branch: false,
+        };
+        install_rename_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 12));
+
+        match &app.prompt {
+            PromptState::RenameSession { rename_branch, .. } => assert!(*rename_branch),
+            other => panic!("expected rename prompt, got {other:?}"),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -691,6 +691,18 @@ impl OverlayMouseLayoutState {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OverlayCheckboxId {
+    DeleteAgentWorktree,
+    RenameSessionBranch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct OverlayCheckbox {
+    pub(crate) id: OverlayCheckboxId,
+    pub(crate) rect: Rect,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) enum OverlayMouseLayout {
     #[default]
@@ -730,6 +742,7 @@ pub(crate) enum OverlayMouseLayout {
     ConfirmDeleteAgent {
         cancel_button: Rect,
         delete_button: Rect,
+        checkbox: Option<OverlayCheckbox>,
     },
     ConfirmDeleteTerminal {
         cancel_button: Rect,
@@ -753,6 +766,7 @@ pub(crate) enum OverlayMouseLayout {
     },
     RenameSession {
         input: Rect,
+        checkbox: Option<OverlayCheckbox>,
     },
     NameNewAgent {
         input: Rect,
@@ -887,6 +901,7 @@ pub(crate) enum PullTarget {
     Session,
 }
 
+mod checkbox;
 mod input;
 mod render;
 mod sessions;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2527,11 +2527,9 @@ impl App {
                         .iter()
                         .filter_map(|index| prompt.runtimes.get(*index))
                         .map(|runtime| {
-                            let checked = if prompt.selected_ids.contains(&runtime.id) {
-                                "[x]"
-                            } else {
-                                "[ ]"
-                            };
+                            let checkbox = Checkbox::new("")
+                                .checked(prompt.selected_ids.contains(&runtime.id))
+                                .state(CheckboxState::Normal);
                             let label = if runtime.label.chars().count() > label_col {
                                 runtime.label.chars().take(label_col).collect::<String>()
                             } else {
@@ -2542,11 +2540,9 @@ impl App {
                                 KillableRuntimeKind::Agent => self.theme.session_active,
                                 KillableRuntimeKind::Terminal => self.theme.session_detached,
                             };
-                            let mut spans = vec![
-                                Span::styled(
-                                    format!("{checked} "),
-                                    Style::default().fg(self.theme.hint_key_fg),
-                                ),
+                            let mut spans =
+                                checkbox.inline_prefix(Style::default().fg(self.theme.hint_key_fg));
+                            spans.extend([
                                 Span::styled(
                                     format!("{:>6} ", runtime.kind.badge()),
                                     Style::default().fg(kind_color).add_modifier(Modifier::BOLD),
@@ -2555,7 +2551,7 @@ impl App {
                                     label_padded,
                                     Style::default().add_modifier(Modifier::BOLD),
                                 ),
-                            ];
+                            ]);
                             spans.extend(runtime_context_spans(
                                 &format!("  {}", runtime.context),
                                 Style::default()

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,3 +1,4 @@
+use super::checkbox::{Checkbox, CheckboxState};
 use super::*;
 
 /// ASCII art logo displayed in the agent pane when no content is active.
@@ -44,6 +45,8 @@ const TIP_MAX_WIDTH: u16 = 47;
 const TIP_GAP: u16 = 2;
 /// Maximum number of wrapped lines a tip may occupy.
 const TIP_MAX_LINES: u16 = 3;
+
+const CHECKBOX_PREFIX_WIDTH: u16 = 5;
 
 /// Welcome-screen tips shown beneath the ASCII logo. Wrap text in backticks
 /// to highlight it in an accent color (the backticks themselves are not
@@ -214,6 +217,66 @@ fn capitalize(s: &str) -> String {
 }
 
 impl App {
+    fn render_overlay_checkbox(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        label: &str,
+        checked: bool,
+        state: CheckboxState,
+        hint: Option<Line<'static>>,
+    ) -> (Rect, u16) {
+        let checkbox = Checkbox::new(label).checked(checked).state(state);
+        let marker_style = checkbox.marker_style(match state {
+            CheckboxState::Focused => Style::default().fg(self.theme.button_active_fg),
+            CheckboxState::Hovered => Style::default().fg(self.theme.button_active_fg),
+            CheckboxState::Disabled => Style::default().fg(self.theme.hint_desc_fg),
+            CheckboxState::Normal => Style::default().fg(self.theme.hint_key_fg),
+        });
+        let label_style = checkbox.label_style(match state {
+            CheckboxState::Focused => Style::default().fg(self.theme.button_active_fg),
+            CheckboxState::Hovered => Style::default().fg(self.theme.button_active_fg),
+            CheckboxState::Disabled => Style::default().fg(self.theme.hint_desc_fg),
+            CheckboxState::Normal => Style::default().fg(self.theme.input_label_fg),
+        });
+        let layout = checkbox.layout(area.width, marker_style, label_style);
+        let checkbox_height = layout.height;
+        let hint_height = u16::from(hint.is_some());
+        let total_height = checkbox_height.saturating_add(hint_height);
+
+        layout.render(
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: checkbox_height,
+            },
+            frame.buffer_mut(),
+        );
+
+        if let Some(hint_line) = hint {
+            Paragraph::new(hint_line).render(
+                Rect {
+                    x: area.x,
+                    y: area.y.saturating_add(checkbox_height),
+                    width: area.width,
+                    height: 1,
+                },
+                frame.buffer_mut(),
+            );
+        }
+
+        (
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: total_height,
+            },
+            total_height,
+        )
+    }
+
     pub(crate) fn render(&mut self, frame: &mut Frame) {
         let term_w = frame.area().width as usize;
         let status_text_len = self.status.text().len() + 3; // " ● " prefix
@@ -2883,23 +2946,37 @@ impl App {
                 ..
             } => {
                 self.render_dim_overlay(frame);
-                // Outer dialog: border + title.
-                let area = centered_rect(56, 30, frame.area());
+                let checkbox_height = if *worktree_shared {
+                    0
+                } else {
+                    let state = if *focus == DeleteAgentFocus::Checkbox {
+                        CheckboxState::Focused
+                    } else {
+                        CheckboxState::Normal
+                    };
+                    let checkbox = Checkbox::new("Also delete the worktree and branch")
+                        .checked(*delete_worktree)
+                        .state(state);
+                    checkbox
+                        .layout(
+                            54,
+                            checkbox.marker_style(Style::default()),
+                            checkbox.label_style(Style::default()),
+                        )
+                        .height
+                };
+                let area = centered_rect_exact(56, 11 + checkbox_height, frame.area());
                 Clear.render(area, frame.buffer_mut());
                 let outer = self.themed_overlay_block("Delete Agent");
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                // Layout: body (flexible) / checkbox (1 row) / spacer / buttons.
-                // The warning text and hint live in the flexible body area so
-                // long lines can wrap safely without truncation. The checkbox
-                // is a single fixed-height row below the body.
-                let [body_area, checkbox_area, _, buttons_area] = Layout::default()
+                let body_height = if *delete_worktree { 5 } else { 4 };
+                let [body_area, checkbox_area, buttons_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
-                        Constraint::Min(1),
-                        Constraint::Length(1),
-                        Constraint::Length(1),
+                        Constraint::Length(body_height),
+                        Constraint::Length(checkbox_height),
                         Constraint::Length(3),
                     ])
                     .areas(inner);
@@ -2943,33 +3020,27 @@ impl App {
                     .wrap(Wrap { trim: false })
                     .render(body_area, frame.buffer_mut());
 
-                // Checkbox row (1 line). When the worktree is shared, the
-                // checkbox is hidden and the line is left empty — the shared
-                // note above already explains the situation.
-                if !*worktree_shared {
-                    let check = if *delete_worktree { "x" } else { " " };
-                    let checkbox_focused = *focus == DeleteAgentFocus::Checkbox;
-                    let label_style = if checkbox_focused {
-                        Style::default()
-                            .fg(self.theme.button_active_fg)
-                            .add_modifier(Modifier::BOLD)
+                let checkbox_rect = if !*worktree_shared {
+                    let checkbox_state = if *focus == DeleteAgentFocus::Checkbox {
+                        CheckboxState::Focused
                     } else {
-                        Style::default().fg(self.theme.input_label_fg)
+                        CheckboxState::Normal
                     };
-                    let bracket_style = if checkbox_focused {
-                        Style::default()
-                            .fg(self.theme.button_active_fg)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(self.theme.hint_key_fg)
-                    };
-                    Paragraph::new(Line::from(vec![
-                        Span::raw(" "),
-                        Span::styled(format!("[{check}]"), bracket_style),
-                        Span::styled(" Also delete the worktree and branch", label_style),
-                    ]))
-                    .render(checkbox_area, frame.buffer_mut());
-                }
+                    let (rect, _) = self.render_overlay_checkbox(
+                        frame,
+                        checkbox_area,
+                        "Also delete the worktree and branch",
+                        *delete_worktree,
+                        checkbox_state,
+                        None,
+                    );
+                    Some(OverlayCheckbox {
+                        id: OverlayCheckboxId::DeleteAgentWorktree,
+                        rect,
+                    })
+                } else {
+                    None
+                };
 
                 // Button area: two bordered panels side by side.
                 let btn_width = 16u16;
@@ -3032,6 +3103,7 @@ impl App {
                 self.overlay_layout.active = OverlayMouseLayout::ConfirmDeleteAgent {
                     cancel_button: cancel_area,
                     delete_button: delete_area,
+                    checkbox: checkbox_rect,
                 };
             }
             PromptState::ConfirmDeleteTerminal {
@@ -3596,7 +3668,18 @@ impl App {
                 ..
             } => {
                 self.render_dim_overlay(frame);
-                let area = centered_rect_exact(62, 12, frame.area());
+                let checkbox = Checkbox::new("Also rename the git branch")
+                    .checked(*rename_branch)
+                    .state(CheckboxState::Normal);
+                let checkbox_height = checkbox
+                    .layout(
+                        60,
+                        checkbox.marker_style(Style::default()),
+                        checkbox.label_style(Style::default()),
+                    )
+                    .height
+                    .saturating_add(1);
+                let area = centered_rect_exact(62, 9 + checkbox_height, frame.area());
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
@@ -3608,7 +3691,7 @@ impl App {
                     .constraints([
                         Constraint::Length(1),
                         Constraint::Length(3),
-                        Constraint::Length(3),
+                        Constraint::Length(checkbox_height),
                         Constraint::Min(1),
                     ])
                     .areas(inner);
@@ -3653,25 +3736,20 @@ impl App {
                     .block(input_block)
                     .render(input_area, frame.buffer_mut());
 
-                // Checkbox for optional branch rename.
-                let check = if *rename_branch { "x" } else { " " };
-                let checkbox_line = Line::from(vec![
-                    Span::raw(" "),
-                    Span::styled(
-                        format!("[{check}]"),
-                        Style::default().fg(self.theme.hint_key_fg),
-                    ),
-                    Span::styled(
-                        " Also rename the git branch",
-                        Style::default().fg(self.theme.input_label_fg),
-                    ),
-                ]);
-                let checkbox_hint = Line::from(Span::styled(
-                    "     Open PRs will still reference the old branch name",
-                    Style::default().fg(self.theme.hint_desc_fg),
-                ));
-                Paragraph::new(vec![checkbox_line, checkbox_hint])
-                    .render(checkbox_area, frame.buffer_mut());
+                let (checkbox_rect, _) = self.render_overlay_checkbox(
+                    frame,
+                    checkbox_area,
+                    "Also rename the git branch",
+                    *rename_branch,
+                    CheckboxState::Normal,
+                    Some(Line::from(Span::styled(
+                        format!(
+                            "{}Open PRs will still reference the old branch name",
+                            " ".repeat(usize::from(CHECKBOX_PREFIX_WIDTH))
+                        ),
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ))),
+                );
 
                 let confirm_key = self.bindings.label_for(Action::Confirm);
                 let close_key = self.bindings.label_for(Action::CloseOverlay);
@@ -3693,8 +3771,13 @@ impl App {
                     Style::default().fg(self.theme.hint_desc_fg),
                 ));
                 Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
-                self.overlay_layout.active =
-                    OverlayMouseLayout::RenameSession { input: input_inner };
+                self.overlay_layout.active = OverlayMouseLayout::RenameSession {
+                    input: input_inner,
+                    checkbox: Some(OverlayCheckbox {
+                        id: OverlayCheckboxId::RenameSessionBranch,
+                        rect: checkbox_rect,
+                    }),
+                };
             }
             PromptState::EditMacros { .. } => {
                 // Full rendering implemented in Task #5.

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3046,9 +3046,10 @@ impl App {
                     )));
                 }
                 let body_height = wrapped_line_count(&body_lines, inner_width, false);
+                let checkbox_spacing = u16::from(!*worktree_shared);
                 let area = centered_rect_exact(
                     dialog_width,
-                    2 + body_height + checkbox_height + 3,
+                    2 + body_height + checkbox_spacing + checkbox_height + 3,
                     frame.area(),
                 );
                 Clear.render(area, frame.buffer_mut());
@@ -3056,10 +3057,11 @@ impl App {
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                let [body_area, checkbox_area, buttons_area] = Layout::default()
+                let [body_area, _, checkbox_area, buttons_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Length(body_height),
+                        Constraint::Length(checkbox_spacing),
                         Constraint::Length(checkbox_height),
                         Constraint::Length(3),
                     ])
@@ -3730,18 +3732,24 @@ impl App {
                     )
                     .height
                     .saturating_add(1);
-                let area = centered_rect_exact(dialog_width, 9 + checkbox_height, frame.area());
+                let checkbox_spacing = 1;
+                let area = centered_rect_exact(
+                    dialog_width,
+                    9 + checkbox_spacing + checkbox_height,
+                    frame.area(),
+                );
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                let [label_area, input_area, checkbox_area, hint_area] = Layout::default()
+                let [label_area, input_area, _, checkbox_area, hint_area] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Length(1),
                         Constraint::Length(3),
+                        Constraint::Length(checkbox_spacing),
                         Constraint::Length(checkbox_height),
                         Constraint::Min(1),
                     ])

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -46,8 +46,6 @@ const TIP_GAP: u16 = 2;
 /// Maximum number of wrapped lines a tip may occupy.
 const TIP_MAX_LINES: u16 = 3;
 
-const CHECKBOX_PREFIX_WIDTH: u16 = 5;
-
 /// Welcome-screen tips shown beneath the ASCII logo. Wrap text in backticks
 /// to highlight it in an accent color (the backticks themselves are not
 /// rendered). Each function receives `&RuntimeBindings` so keybinding labels
@@ -214,6 +212,54 @@ fn capitalize(s: &str) -> String {
         Some(first) => format!("{}{}", first.to_uppercase(), c.as_str()),
         None => String::new(),
     }
+}
+
+fn wrapped_line_count(lines: &[Line<'_>], width: u16, trim: bool) -> u16 {
+    if width == 0 {
+        return 0;
+    }
+
+    let max_width = usize::from(width);
+    let mut total = 0u16;
+    for line in lines {
+        let mut current_width = 0usize;
+        let mut line_count = 1u16;
+        for span in &line.spans {
+            let content = if trim {
+                span.content.trim_end_matches(' ')
+            } else {
+                span.content.as_ref()
+            };
+            for segment in content.split('\n') {
+                let segment_width = segment.chars().count();
+                if segment_width == 0 {
+                    continue;
+                }
+
+                let remaining = if current_width == 0 {
+                    max_width
+                } else {
+                    max_width.saturating_sub(current_width)
+                };
+                if segment_width <= remaining {
+                    current_width += segment_width;
+                } else {
+                    let needed = if current_width == 0 {
+                        segment_width
+                    } else {
+                        segment_width - remaining
+                    };
+                    line_count = line_count.saturating_add(((needed - 1) / max_width) as u16 + 1);
+                    current_width = needed % max_width;
+                    if current_width == 0 {
+                        current_width = max_width;
+                    }
+                }
+            }
+        }
+        total = total.saturating_add(line_count);
+    }
+    total
 }
 
 impl App {
@@ -2942,6 +2988,8 @@ impl App {
                 ..
             } => {
                 self.render_dim_overlay(frame);
+                let dialog_width = 56.min(frame.area().width.max(1));
+                let inner_width = dialog_width.saturating_sub(2);
                 let checkbox_height = if *worktree_shared {
                     0
                 } else {
@@ -2955,27 +3003,12 @@ impl App {
                         .state(state);
                     checkbox
                         .layout(
-                            54,
+                            inner_width,
                             checkbox.marker_style(Style::default()),
                             checkbox.label_style(Style::default()),
                         )
                         .height
                 };
-                let area = centered_rect_exact(56, 11 + checkbox_height, frame.area());
-                Clear.render(area, frame.buffer_mut());
-                let outer = self.themed_overlay_block("Delete Agent");
-                let inner = outer.inner(area);
-                outer.render(area, frame.buffer_mut());
-
-                let body_height = if *delete_worktree { 5 } else { 4 };
-                let [body_area, checkbox_area, buttons_area] = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Length(body_height),
-                        Constraint::Length(checkbox_height),
-                        Constraint::Length(3),
-                    ])
-                    .areas(inner);
 
                 // Body: question text + conditional warning/hint/shared note.
                 // Long warning text is split into two explicit Lines so it
@@ -3012,6 +3045,26 @@ impl App {
                         Style::default().fg(self.theme.hint_desc_fg),
                     )));
                 }
+                let body_height = wrapped_line_count(&body_lines, inner_width, false);
+                let area = centered_rect_exact(
+                    dialog_width,
+                    2 + body_height + checkbox_height + 3,
+                    frame.area(),
+                );
+                Clear.render(area, frame.buffer_mut());
+                let outer = self.themed_overlay_block("Delete Agent");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, checkbox_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(body_height),
+                        Constraint::Length(checkbox_height),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
                 Paragraph::new(body_lines)
                     .wrap(Wrap { trim: false })
                     .render(body_area, frame.buffer_mut());
@@ -3667,15 +3720,17 @@ impl App {
                 let checkbox = Checkbox::new("Also rename the git branch")
                     .checked(*rename_branch)
                     .state(CheckboxState::Normal);
+                let dialog_width = 62.min(frame.area().width.max(1));
+                let inner_width = dialog_width.saturating_sub(2);
                 let checkbox_height = checkbox
                     .layout(
-                        60,
+                        inner_width,
                         checkbox.marker_style(Style::default()),
                         checkbox.label_style(Style::default()),
                     )
                     .height
                     .saturating_add(1);
-                let area = centered_rect_exact(62, 9 + checkbox_height, frame.area());
+                let area = centered_rect_exact(dialog_width, 9 + checkbox_height, frame.area());
                 Clear.render(area, frame.buffer_mut());
 
                 let outer = self.themed_overlay_block("Rename Agent");
@@ -3741,7 +3796,7 @@ impl App {
                     Some(Line::from(Span::styled(
                         format!(
                             "{}Open PRs will still reference the old branch name",
-                            " ".repeat(usize::from(CHECKBOX_PREFIX_WIDTH))
+                            Checkbox::indent()
                         ),
                         Style::default().fg(self.theme.hint_desc_fg),
                     ))),
@@ -5176,6 +5231,27 @@ mod tests {
     fn centered_rect_exact_clamps_to_available_area() {
         let area = Rect::new(0, 0, 40, 6);
         assert_eq!(centered_rect_exact(56, 9, area), area);
+    }
+
+    #[test]
+    fn wrapped_line_count_counts_unwrapped_lines() {
+        let lines = vec![Line::from(" short line"), Line::from(" another short line")];
+
+        assert_eq!(wrapped_line_count(&lines, 40, false), 2);
+    }
+
+    #[test]
+    fn wrapped_line_count_grows_for_narrow_widths() {
+        let lines = vec![Line::from(vec![
+            Span::raw(" Are you sure you want to delete "),
+            Span::styled(
+                "very-long-branch-name",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("?"),
+        ])];
+
+        assert!(wrapped_line_count(&lines, 20, false) > 1);
     }
 
     // ── Unit tests for capitalize ─────────────────────────────────


### PR DESCRIPTION
This makes the standalone modal checkboxes in the delete-agent and rename-agent dialogs behave like real mouse targets instead of inert `[ ]` text. Clicking anywhere on the checkbox label now toggles the setting, which restores the expected mouse interaction in these dialogs.

- add a shared checkbox component with ASCII rendering, wrapping, and focus/hover state support
- register overlay checkbox hitboxes through a generic prompt mouse target path instead of one-off dialog logic
- resize the affected dialogs so wrapped checkbox labels and hints render cleanly

`cargo fmt` and `cargo test` both pass (`597` tests).