### PR TITLE
Disable session resume for Copilot CLI provider

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1327,7 +1327,12 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 5] {
             ProviderCommandConfig {
                 command: "copilot".to_string(),
                 args: Vec::new(),
-                resume_args: Some(vec!["--continue".to_string()]),
+                // Copilot's --continue resumes the most recent session
+                // globally, not scoped to the current working directory.
+                // Unlike claude/codex/gemini/opencode, there is no flag
+                // to limit resume to the CWD, so we disable it.
+                resume_args: None,
+                resume_wait_timeout_ms: None,
                 oneshot_args: vec![
                     "-p".to_string(),
                     "{prompt}".to_string(),
@@ -2192,11 +2197,8 @@ oneshot_output = "stdout"
             vec!["-p", "{prompt}", "--allow-all-tools"]
         );
         assert!(matches!(cfg.oneshot_output, OneshotOutput::Stdout));
-        assert_eq!(
-            cfg.resume_args.clone(),
-            Some(vec!["--continue".to_string()])
-        );
-        assert!(cfg.supports_session_resume());
+        assert_eq!(cfg.resume_args, None);
+        assert!(!cfg.supports_session_resume());
     }
 
     #[test]


### PR DESCRIPTION
Copilot CLI's `--continue` flag resumes the **most recently closed session globally**, not the most recent session in the current working directory. This differs from every other built-in provider — Claude, Codex, Gemini, and OpenCode all scope their resume flags to the CWD. When dux used `--continue` for Copilot, it would resume a session from an unrelated worktree, which is incorrect and confusing.

After reviewing the [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference), [config directory reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference), and [programmatic reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-programmatic-reference), there is no flag, environment variable, or configuration option to scope `--continue` to the current working directory. The `--resume=SESSION-ID` flag can target a specific session, but would require dux to track Copilot session IDs per worktree — a much larger change with no upstream support for discovering the "most recent session in directory X."

This PR sets `resume_args` to `None` for the Copilot provider, disabling session resume entirely rather than resuming the wrong session. The corresponding test is updated to assert that `supports_session_resume()` returns `false`. If Copilot CLI adds CWD-scoped resume in the future, this can be revisited.