### PR TITLE
Add command palette provider switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ resume_args = ["--continue"]
 
 Set `resume_args` and dux can reconnect to detached or crashed sessions. Omit it if your CLI doesn't support resuming; dux will just relaunch it.
 
-Cycle through providers on the fly with a single keypress, or set a default per-project.
+Switch providers from the command palette while keeping each provider's session history on the same worktree, or set a default per-project.
 
 ### Macros
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ resume_args = ["--continue"]
 
 Set `resume_args` and dux can reconnect to detached or crashed sessions. Omit it if your CLI doesn't support resuming; dux will just relaunch it.
 
-Switch providers from the command palette while keeping each provider's session history on the same worktree, or set a default per-project.
+Switch providers from the command palette. dux sticks to one agent per worktree, so provider changes happen in place:
+
+- **`change-agent-provider`** swaps the *selected* worktree's provider on next launch. If the agent is still running, dux records your choice and warns you — the running agent keeps going until you exit and relaunch it, at which point it spawns with the new provider. If you've used that provider on this worktree before, dux passes its `resume_args` so you pick up the previous conversation instead of starting fresh.
+- **`change-default-provider`** picks which provider *new* agent sessions should spawn with. Existing agents keep their current provider; to move a running one, use `change-agent-provider` after stopping it.
+
+The header shows `default provider: …` for the project and adds `current provider: …` when the selected agent is using a different one, so you always know which CLI you're talking to.
+
+You can also set a default per-project in the config file, which wins over the global default for that one project.
 
 ### Macros
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -57,6 +57,9 @@ enum PromptMouseTarget {
     ChangeAgentProviderItem(usize),
     ChangeAgentProviderCancel,
     ChangeAgentProviderApply,
+    ChangeDefaultProviderItem(usize),
+    ChangeDefaultProviderCancel,
+    ChangeDefaultProviderApply,
     RuntimeKillInput,
     RuntimeKillItem(usize),
     RuntimeKillCancel,
@@ -412,7 +415,6 @@ impl App {
                 }
                 Action::NewAgent => self.create_agent_for_selected_project()?,
                 Action::ForkAgent => self.fork_selected_session()?,
-                Action::NewProviderSession => self.create_provider_session_on_worktree()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
                 Action::ShowTerminal => self.show_or_open_first_terminal()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
@@ -2026,6 +2028,59 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ChangeDefaultProvider(prompt) = &mut self.prompt {
+            let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
+            let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let is_space = key.code == KeyCode::Char(' ');
+            let reverse_tab = key.code == KeyCode::BackTab;
+
+            if matches!(palette_action.or(dialog_action), Some(Action::CloseOverlay)) {
+                self.prompt = PromptState::None;
+                return Ok(false);
+            }
+
+            if reverse_tab {
+                prompt.focus = Self::next_change_default_provider_focus(prompt.focus, false);
+                return Ok(false);
+            }
+
+            match prompt.focus {
+                ChangeDefaultProviderFocus::List => match palette_action.or(dialog_action) {
+                    Some(Action::MoveDown) if prompt.selected + 1 < prompt.options.len() => {
+                        prompt.selected += 1;
+                    }
+                    Some(Action::MoveUp) if prompt.selected > 0 => {
+                        prompt.selected -= 1;
+                    }
+                    Some(Action::Confirm) => {
+                        self.apply_change_default_provider()?;
+                    }
+                    Some(Action::ToggleSelection) => {
+                        prompt.focus = Self::next_change_default_provider_focus(prompt.focus, true);
+                    }
+                    _ => {}
+                },
+                ChangeDefaultProviderFocus::Cancel | ChangeDefaultProviderFocus::Apply => {
+                    if matches!(dialog_action, Some(Action::ToggleSelection)) {
+                        prompt.focus = Self::next_change_default_provider_focus(prompt.focus, true);
+                        return Ok(false);
+                    }
+                    if matches!(dialog_action, Some(Action::Confirm)) || is_space {
+                        match prompt.focus {
+                            ChangeDefaultProviderFocus::Cancel => {
+                                self.prompt = PromptState::None;
+                            }
+                            ChangeDefaultProviderFocus::Apply => {
+                                self.apply_change_default_provider()?;
+                            }
+                            ChangeDefaultProviderFocus::List => {}
+                        }
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ConfirmKillRunning(confirm_prompt) = &mut self.prompt {
             match self.bindings.lookup(&key, BindingScope::Dialog) {
                 Some(Action::CloseOverlay) => {
@@ -2701,6 +2756,23 @@ impl App {
                     None
                 }
             }
+            OverlayMouseLayout::ChangeDefaultProvider {
+                list,
+                items,
+                offset,
+                cancel_button,
+                apply_button,
+            } => {
+                if let Some(index) = Self::overlay_row_at(list, offset, items, column, row) {
+                    Some(PromptMouseTarget::ChangeDefaultProviderItem(index))
+                } else if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ChangeDefaultProviderCancel)
+                } else if contains_point(apply_button, column, row) {
+                    Some(PromptMouseTarget::ChangeDefaultProviderApply)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::KillRunning {
                 input,
                 list,
@@ -3368,6 +3440,34 @@ impl App {
         }
     }
 
+    fn next_change_default_provider_focus(
+        current: ChangeDefaultProviderFocus,
+        forward: bool,
+    ) -> ChangeDefaultProviderFocus {
+        match (current, forward) {
+            (ChangeDefaultProviderFocus::List, true) => ChangeDefaultProviderFocus::Cancel,
+            (ChangeDefaultProviderFocus::Cancel, true) => ChangeDefaultProviderFocus::Apply,
+            (ChangeDefaultProviderFocus::Apply, true) => ChangeDefaultProviderFocus::List,
+            (ChangeDefaultProviderFocus::List, false) => ChangeDefaultProviderFocus::Apply,
+            (ChangeDefaultProviderFocus::Apply, false) => ChangeDefaultProviderFocus::Cancel,
+            (ChangeDefaultProviderFocus::Cancel, false) => ChangeDefaultProviderFocus::List,
+        }
+    }
+
+    fn set_change_default_provider_selection(&mut self, index: usize) {
+        let count = match &self.prompt {
+            PromptState::ChangeDefaultProvider(prompt) => prompt.options.len(),
+            _ => 0,
+        };
+        if count == 0 {
+            return;
+        }
+        if let PromptState::ChangeDefaultProvider(prompt) = &mut self.prompt {
+            prompt.selected = index.min(count.saturating_sub(1));
+            prompt.focus = ChangeDefaultProviderFocus::List;
+        }
+    }
+
     fn resolve_confirm_delete_agent(&mut self, confirm: bool) -> bool {
         let (session_id, delete_worktree) = match &self.prompt {
             PromptState::ConfirmDeleteAgent {
@@ -3701,6 +3801,22 @@ impl App {
             }
             PromptMouseTarget::ChangeAgentProviderApply => {
                 if let Err(err) = self.apply_change_agent_provider() {
+                    self.set_error(format!("{err:#}"));
+                }
+            }
+            PromptMouseTarget::ChangeDefaultProviderItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
+                self.set_change_default_provider_selection(index);
+                if double_click && let Err(err) = self.apply_change_default_provider() {
+                    self.set_error(format!("{err:#}"));
+                }
+            }
+            PromptMouseTarget::ChangeDefaultProviderCancel => {
+                self.prompt = PromptState::None;
+            }
+            PromptMouseTarget::ChangeDefaultProviderApply => {
+                if let Err(err) = self.apply_change_default_provider() {
                     self.set_error(format!("{err:#}"));
                 }
             }
@@ -4590,6 +4706,7 @@ mod tests {
             worker_tx,
             worker_rx,
             providers: std::collections::HashMap::new(),
+            running_provider_pins: std::collections::HashMap::new(),
             companion_terminals: std::collections::HashMap::new(),
             active_terminal_id: None,
             terminal_return_to_list: false,
@@ -6687,146 +6804,173 @@ mod tests {
     }
 
     #[test]
-    fn change_agent_provider_switches_to_existing_sibling_session() {
+    fn change_agent_provider_swaps_in_place_when_stopped() {
         let mut app = test_app(default_bindings());
-        let root = PathBuf::from(&app.projects[0].path);
-        let now = Utc::now();
-
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: Some(app.projects[0].default_provider.as_str().to_string()),
-            commit_prompt: None,
-        });
-
+        let original_session_id = app.sessions[0].id.clone();
+        let original_worktree = app.sessions[0].worktree_path.clone();
         app.sessions[0].provider = ProviderKind::from_str("codex");
-        app.sessions[0].status = SessionStatus::Active;
+        app.sessions[0].status = SessionStatus::Detached;
         app.session_store
             .upsert_session(&app.sessions[0])
-            .expect("persist active session");
-
-        let detached = AgentSession {
-            id: "session-2".to_string(),
-            project_id: app.projects[0].id.clone(),
-            project_path: Some(app.projects[0].path.clone()),
-            provider: ProviderKind::from_str("codex"),
-            source_branch: "main".to_string(),
-            branch_name: "detached-branch".to_string(),
-            worktree_path: app
-                .paths
-                .worktrees_root
-                .join("detached")
-                .display()
-                .to_string(),
-            title: None,
-            started_providers: vec!["codex".to_string()],
-            status: SessionStatus::Detached,
-            created_at: now,
-            updated_at: now,
-        };
-        let exited = AgentSession {
-            id: "session-3".to_string(),
-            project_id: app.projects[0].id.clone(),
-            project_path: Some(app.projects[0].path.clone()),
-            provider: ProviderKind::from_str("gemini"),
-            source_branch: "main".to_string(),
-            branch_name: "exited-branch".to_string(),
-            worktree_path: app.sessions[0].worktree_path.clone(),
-            title: None,
-            started_providers: vec!["codex".to_string()],
-            status: SessionStatus::Exited,
-            created_at: now,
-            updated_at: now,
-        };
-        let other_project = Project {
-            id: "project-2".to_string(),
-            name: "other".to_string(),
-            path: root.join("other-project").display().to_string(),
-            default_provider: ProviderKind::from_str("codex"),
-            current_branch: "main".to_string(),
-            path_missing: false,
-        };
-        let other_session = AgentSession {
-            id: "session-4".to_string(),
-            project_id: other_project.id.clone(),
-            project_path: Some(other_project.path.clone()),
-            provider: ProviderKind::from_str("codex"),
-            source_branch: "main".to_string(),
-            branch_name: "other-branch".to_string(),
-            worktree_path: app.paths.worktrees_root.join("other").display().to_string(),
-            title: None,
-            started_providers: vec!["codex".to_string()],
-            status: SessionStatus::Detached,
-            created_at: now,
-            updated_at: now,
-        };
-
-        app.config.projects.push(ProjectConfig {
-            id: other_project.id.clone(),
-            path: other_project.path.clone(),
-            name: Some(other_project.name.clone()),
-            default_provider: Some(other_project.default_provider.as_str().to_string()),
-            commit_prompt: None,
-        });
-        app.projects.push(other_project);
-        app.sessions.push(detached);
-        app.sessions.push(exited);
-        app.sessions.push(other_session);
-        for session in &app.sessions[1..] {
-            app.session_store
-                .upsert_session(session)
-                .expect("persist session");
-        }
+            .expect("persist session");
 
         app.rebuild_left_items();
         app.selected_left = app
             .left_items()
             .iter()
-            .position(|item| {
-                matches!(item, LeftItem::Session(index) if app.sessions.get(*index).map(|session| session.id.as_str()) == Some("session-1"))
-            })
-            .expect("selected session");
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the seeded session");
 
         app.open_change_agent_provider_prompt()
             .expect("open provider picker");
-        if let PromptState::ChangeAgentProvider(prompt) = &mut app.prompt {
-            prompt.selected = prompt
-                .options
-                .iter()
-                .position(|option| option.provider.as_str() == "gemini")
-                .expect("gemini option");
-        } else {
-            panic!("expected change-agent-provider prompt");
+        match &mut app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.as_str() == "gemini")
+                    .expect("gemini option");
+            }
+            other => panic!("expected change-agent-provider prompt, got {other:?}"),
         }
 
         app.apply_change_agent_provider()
-            .expect("apply provider switch");
+            .expect("apply provider swap");
 
-        assert_eq!(
-            app.selected_session().map(|session| session.id.as_str()),
-            Some("session-3")
-        );
-        // The current session keeps its original provider-specific history.
-        assert_eq!(app.sessions[0].provider.as_str(), "codex");
-        // Existing sibling session is reused instead of being overwritten.
-        assert_eq!(app.sessions[2].provider.as_str(), "gemini");
+        // Exactly one session still exists; its provider was mutated in place.
+        assert_eq!(app.sessions.len(), 1);
+        assert_eq!(app.sessions[0].id, original_session_id);
+        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        assert_eq!(app.sessions[0].worktree_path, original_worktree);
+        assert!(matches!(app.prompt, PromptState::None));
 
         let persisted = app.session_store.load_sessions().expect("load sessions");
-        let started_providers_for = |id: &str| {
-            persisted
-                .iter()
-                .find(|session| session.id == id)
-                .map(|session| session.started_providers.clone())
-        };
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].provider.as_str(), "gemini");
+
+        assert!(app.status.text().contains("will use gemini next launch"));
+    }
+
+    #[test]
+    fn change_agent_provider_swaps_but_warns_when_agent_is_running() {
+        let mut app = test_app(default_bindings());
+        app.sessions[0].provider = ProviderKind::from_str("codex");
+        app.sessions[0].status = SessionStatus::Active;
+        let session_id = app.sessions[0].id.clone();
+
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let provider = PtyClient::spawn(
+            "/bin/sh",
+            &["-c".to_string(), "sleep 5".to_string()],
+            worktree,
+            24,
+            80,
+            1_000,
+        )
+        .expect("spawn test agent");
+        app.providers.insert(session_id.clone(), provider);
+
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the running session");
+
+        app.open_change_agent_provider_prompt()
+            .expect("open provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.as_str() == "gemini")
+                    .expect("gemini option");
+            }
+            other => panic!("expected change-agent-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_agent_provider()
+            .expect("apply provider swap");
+
+        // Provider is swapped now; the warning just tells the user the running
+        // PTY hasn't caught up yet.
+        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        let persisted = app.session_store.load_sessions().expect("load sessions");
+        assert_eq!(persisted[0].provider.as_str(), "gemini");
+        assert!(
+            app.providers.contains_key(&session_id),
+            "the old PTY keeps running until the user exits it"
+        );
         assert_eq!(
-            started_providers_for("session-3"),
-            Some(vec!["codex".to_string()])
+            app.status.tone(),
+            crate::statusline::StatusTone::Warning,
+            "status should be a warning, not an error"
+        );
+        let message = app.status.message().to_string();
+        assert!(
+            message.contains("still running") && message.contains("gemini"),
+            "status should explain the agent still runs the old provider, got: {message}"
+        );
+        assert!(matches!(app.prompt, PromptState::None));
+
+        // Clean up so the PTY doesn't outlive the test.
+        app.providers.remove(&session_id);
+    }
+
+    #[test]
+    fn change_agent_provider_preserves_resume_for_previously_started_provider() {
+        let mut app = test_app(default_bindings());
+        app.sessions[0].provider = ProviderKind::from_str("claude");
+        app.sessions[0].status = SessionStatus::Detached;
+        app.sessions[0].started_providers = vec!["codex".to_string(), "claude".to_string()];
+        app.session_store
+            .upsert_session(&app.sessions[0])
+            .expect("persist session with history");
+
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the seeded session");
+
+        app.open_change_agent_provider_prompt()
+            .expect("open provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                let codex_option = prompt
+                    .options
+                    .iter()
+                    .find(|option| option.provider.as_str() == "codex")
+                    .expect("codex option present");
+                assert!(
+                    codex_option.resume_available,
+                    "codex was started earlier — picker should advertise resume"
+                );
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.as_str() == "codex")
+                    .expect("codex option");
+            }
+            other => panic!("expected change-agent-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_agent_provider()
+            .expect("swap back to codex");
+
+        assert_eq!(app.sessions[0].provider.as_str(), "codex");
+        // should_resume_session uses started_providers + config's resume_args.
+        let session = app.sessions[0].clone();
+        assert!(
+            app.should_resume_session(&session),
+            "codex was launched on this worktree earlier, so resume must be active"
         );
         assert!(
-            app.status
-                .text()
-                .contains("Switched to the existing gemini session")
+            app.status.text().contains("resume its prior session"),
+            "status should note resume is happening, got: {}",
+            app.status.text()
         );
     }
 
@@ -8831,5 +8975,274 @@ mod tests {
 
         assert!(pending_delete_state(&app).is_none());
         assert!(!app.config.macros.entries.contains_key("greet"));
+    }
+
+    #[test]
+    fn change_default_provider_updates_config_and_refreshes_projects() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "codex".to_string();
+
+        // project-1 inherits the global default (no explicit override).
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: None,
+            commit_prompt: None,
+        });
+
+        // project-2 pins itself to "gemini" and must not be touched.
+        let pinned = Project {
+            id: "project-2".to_string(),
+            name: "pinned".to_string(),
+            path: app.paths.root.join("pinned").display().to_string(),
+            default_provider: ProviderKind::from_str("gemini"),
+            current_branch: "main".to_string(),
+            path_missing: false,
+        };
+        app.config.projects.push(ProjectConfig {
+            id: pinned.id.clone(),
+            path: pinned.path.clone(),
+            name: Some(pinned.name.clone()),
+            default_provider: Some("gemini".to_string()),
+            commit_prompt: None,
+        });
+        app.projects.push(pinned);
+
+        let original_session_provider = app.sessions[0].provider.clone();
+
+        app.open_change_default_provider_prompt()
+            .expect("open default provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeDefaultProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.as_str() == "claude")
+                    .expect("claude option present");
+            }
+            other => panic!("expected change-default-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_default_provider()
+            .expect("apply default provider");
+
+        // Config was updated in memory and on disk.
+        assert_eq!(app.config.defaults.provider, "claude");
+        let persisted = crate::config::ensure_config(&app.paths).expect("reload config");
+        assert_eq!(persisted.defaults.provider, "claude");
+
+        // Inherited project picks up the new default.
+        let inherited = app
+            .projects
+            .iter()
+            .find(|project| project.id == "project-1")
+            .expect("inherited project present");
+        assert_eq!(inherited.default_provider.as_str(), "claude");
+
+        // Pinned project keeps its explicit override.
+        let pinned = app
+            .projects
+            .iter()
+            .find(|project| project.id == "project-2")
+            .expect("pinned project present");
+        assert_eq!(pinned.default_provider.as_str(), "gemini");
+
+        // Existing sessions are untouched — provider is frozen at creation.
+        assert_eq!(app.sessions[0].provider, original_session_provider);
+
+        assert!(matches!(app.prompt, PromptState::None));
+        assert!(
+            app.status
+                .text()
+                .contains("Default provider changed to claude")
+        );
+    }
+
+    #[test]
+    fn change_default_provider_rejects_current_selection_without_mutating_config() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "codex".to_string();
+
+        app.open_change_default_provider_prompt()
+            .expect("open default provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeDefaultProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.is_current)
+                    .expect("current option present");
+            }
+            other => panic!("expected change-default-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_default_provider()
+            .expect("apply no-op selection");
+
+        assert_eq!(app.config.defaults.provider, "codex");
+        assert!(matches!(app.prompt, PromptState::None));
+        assert!(
+            app.status
+                .text()
+                .contains("is already the default provider")
+        );
+    }
+
+    #[test]
+    fn header_shows_current_provider_when_it_differs_from_project_default() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.projects[0].default_provider = ProviderKind::from_str("codex");
+        app.sessions[0].provider = ProviderKind::from_str("gemini");
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the seeded session");
+
+        let backend = TestBackend::new(200, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains("default provider: codex"),
+            "expected default provider label, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("current provider: gemini"),
+            "expected current provider label, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn header_omits_current_provider_when_session_matches_project_default() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.projects[0].default_provider = ProviderKind::from_str("codex");
+        app.sessions[0].provider = ProviderKind::from_str("codex");
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the seeded session");
+
+        let backend = TestBackend::new(200, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains("default provider: codex"),
+            "expected default provider label, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("current provider:"),
+            "current provider label should be hidden when identical, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn agent_pane_title_keeps_running_provider_after_swap_while_running() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.projects[0].default_provider = ProviderKind::from_str("codex");
+        app.sessions[0].provider = ProviderKind::from_str("codex");
+        app.sessions[0].status = SessionStatus::Active;
+        let session_id = app.sessions[0].id.clone();
+
+        // Spawn a real PTY so the session looks live.
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let pty = PtyClient::spawn(
+            "/bin/sh",
+            &["-c".to_string(), "sleep 5".to_string()],
+            worktree,
+            24,
+            80,
+            1_000,
+        )
+        .expect("spawn test agent");
+        app.providers.insert(session_id.clone(), pty);
+
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the running session");
+
+        // Swap provider while the agent is still running.
+        app.open_change_agent_provider_prompt()
+            .expect("open picker");
+        match &mut app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.as_str() == "gemini")
+                    .expect("gemini option");
+            }
+            other => panic!("expected picker, got {other:?}"),
+        }
+        app.apply_change_agent_provider().expect("apply swap");
+
+        // session.provider is now gemini, but the PTY is still running codex;
+        // running_provider_for should reflect that.
+        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        assert_eq!(app.running_provider_for(&app.sessions[0]).as_str(), "codex");
+
+        let backend = TestBackend::new(200, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            rendered.contains("Codex agent"),
+            "pane title should still say Codex (running) after the swap, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Gemini agent"),
+            "pane title should NOT claim Gemini is running yet, got: {rendered}"
+        );
+
+        // Tearing down the PTY clears the pin — the next launch will be gemini.
+        app.providers.remove(&session_id);
+        app.running_provider_pins.remove(&session_id);
+        assert_eq!(
+            app.running_provider_for(&app.sessions[0]).as_str(),
+            "gemini"
+        );
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -6975,6 +6975,54 @@ mod tests {
     }
 
     #[test]
+    fn change_agent_provider_marks_providers_without_resume_support() {
+        let mut app = test_app(default_bindings());
+        app.sessions[0].provider = ProviderKind::from_str("codex");
+        app.sessions[0].status = SessionStatus::Detached;
+        // Pretend copilot was launched earlier — it still shouldn't advertise
+        // resume because copilot's config has `resume_args: None`.
+        app.sessions[0].started_providers = vec!["copilot".to_string()];
+
+        app.rebuild_left_items();
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| matches!(item, LeftItem::Session(index) if *index == 0))
+            .expect("select the seeded session");
+
+        app.open_change_agent_provider_prompt()
+            .expect("open picker");
+        match &app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                let copilot = prompt
+                    .options
+                    .iter()
+                    .find(|option| option.provider.as_str() == "copilot")
+                    .expect("copilot option present");
+                assert!(
+                    !copilot.supports_resume,
+                    "copilot is configured without resume_args, so supports_resume must be false"
+                );
+                assert!(
+                    !copilot.resume_available,
+                    "even with prior launches, copilot cannot resume"
+                );
+
+                let codex = prompt
+                    .options
+                    .iter()
+                    .find(|option| option.provider.as_str() == "codex")
+                    .expect("codex option present");
+                assert!(
+                    codex.supports_resume,
+                    "codex supports resume via resume_args"
+                );
+            }
+            other => panic!("expected change-agent-provider prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn launch_companion_terminal_sets_runtime_state_and_overlay() {
         let mut app = test_app(default_bindings());
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -9237,12 +9237,40 @@ mod tests {
             "pane title should NOT claim Gemini is running yet, got: {rendered}"
         );
 
+        // Sidebar entry should show the running → queued transition.
+        assert!(
+            rendered.contains("(codex → gemini)"),
+            "sidebar should show running provider → next provider, got: {rendered}"
+        );
+
         // Tearing down the PTY clears the pin — the next launch will be gemini.
         app.providers.remove(&session_id);
         app.running_provider_pins.remove(&session_id);
         assert_eq!(
             app.running_provider_for(&app.sessions[0]).as_str(),
             "gemini"
+        );
+
+        // After the PTY is gone, the sidebar collapses back to a single label.
+        let backend = TestBackend::new(200, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+        assert!(
+            rendered.contains("(gemini)"),
+            "sidebar should collapse to plain (gemini) after the PTY exits, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("→"),
+            "arrow should disappear once no swap is pending, got: {rendered}"
         );
     }
 }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -54,6 +54,9 @@ enum PromptMouseTarget {
     BrowseProjectInput,
     BrowseProjectItem(usize),
     PickEditorItem(usize),
+    ChangeAgentProviderItem(usize),
+    ChangeAgentProviderCancel,
+    ChangeAgentProviderApply,
     RuntimeKillInput,
     RuntimeKillItem(usize),
     RuntimeKillCancel,
@@ -415,7 +418,6 @@ impl App {
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
                 Action::RenameSession => self.open_rename_session()?,
                 Action::EditMacros => self.open_edit_macros(),
-                Action::CycleProvider => self.cycle_selected_project_provider()?,
                 Action::CopyPath => self.copy_selected_path()?,
                 Action::OpenWorktreeInEditor => self.open_selected_worktree_in_default_editor()?,
                 Action::ChooseWorktreeEditor => self.open_worktree_editor_picker()?,
@@ -1971,6 +1973,59 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ChangeAgentProvider(prompt) = &mut self.prompt {
+            let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
+            let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let is_space = key.code == KeyCode::Char(' ');
+            let reverse_tab = key.code == KeyCode::BackTab;
+
+            if matches!(palette_action.or(dialog_action), Some(Action::CloseOverlay)) {
+                self.prompt = PromptState::None;
+                return Ok(false);
+            }
+
+            if reverse_tab {
+                prompt.focus = Self::next_change_agent_provider_focus(prompt.focus, false);
+                return Ok(false);
+            }
+
+            match prompt.focus {
+                ChangeAgentProviderFocus::List => match palette_action.or(dialog_action) {
+                    Some(Action::MoveDown) if prompt.selected + 1 < prompt.options.len() => {
+                        prompt.selected += 1;
+                    }
+                    Some(Action::MoveUp) if prompt.selected > 0 => {
+                        prompt.selected -= 1;
+                    }
+                    Some(Action::Confirm) => {
+                        self.apply_change_agent_provider()?;
+                    }
+                    Some(Action::ToggleSelection) => {
+                        prompt.focus = Self::next_change_agent_provider_focus(prompt.focus, true);
+                    }
+                    _ => {}
+                },
+                ChangeAgentProviderFocus::Cancel | ChangeAgentProviderFocus::Apply => {
+                    if matches!(dialog_action, Some(Action::ToggleSelection)) {
+                        prompt.focus = Self::next_change_agent_provider_focus(prompt.focus, true);
+                        return Ok(false);
+                    }
+                    if matches!(dialog_action, Some(Action::Confirm)) || is_space {
+                        match prompt.focus {
+                            ChangeAgentProviderFocus::Cancel => {
+                                self.prompt = PromptState::None;
+                            }
+                            ChangeAgentProviderFocus::Apply => {
+                                self.apply_change_agent_provider()?;
+                            }
+                            ChangeAgentProviderFocus::List => {}
+                        }
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ConfirmKillRunning(confirm_prompt) = &mut self.prompt {
             match self.bindings.lookup(&key, BindingScope::Dialog) {
                 Some(Action::CloseOverlay) => {
@@ -2237,16 +2292,12 @@ impl App {
                                 "Forking agent \"{source_label}\" as \"{name}\" by cloning its current worktree contents into a fresh session...",
                             )
                         }
-                        CreateAgentRequest::NewProviderSession { .. } => {
-                            unreachable!("NewProviderSession does not use the naming prompt")
-                        }
                     };
                     match &mut request {
                         CreateAgentRequest::NewProject { custom_name, .. }
                         | CreateAgentRequest::ForkSession { custom_name, .. } => {
                             *custom_name = Some(name);
                         }
-                        CreateAgentRequest::NewProviderSession { .. } => {}
                     }
                     self.dispatch_create_agent_request(request, msg)?;
                 }
@@ -2633,6 +2684,23 @@ impl App {
                 ..
             } => Self::overlay_row_at(list, offset, items, column, row)
                 .map(PromptMouseTarget::PickEditorItem),
+            OverlayMouseLayout::ChangeAgentProvider {
+                list,
+                items,
+                offset,
+                cancel_button,
+                apply_button,
+            } => {
+                if let Some(index) = Self::overlay_row_at(list, offset, items, column, row) {
+                    Some(PromptMouseTarget::ChangeAgentProviderItem(index))
+                } else if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ChangeAgentProviderCancel)
+                } else if contains_point(apply_button, column, row) {
+                    Some(PromptMouseTarget::ChangeAgentProviderApply)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::KillRunning {
                 input,
                 list,
@@ -3272,6 +3340,34 @@ impl App {
         }
     }
 
+    fn next_change_agent_provider_focus(
+        current: ChangeAgentProviderFocus,
+        forward: bool,
+    ) -> ChangeAgentProviderFocus {
+        match (current, forward) {
+            (ChangeAgentProviderFocus::List, true) => ChangeAgentProviderFocus::Cancel,
+            (ChangeAgentProviderFocus::Cancel, true) => ChangeAgentProviderFocus::Apply,
+            (ChangeAgentProviderFocus::Apply, true) => ChangeAgentProviderFocus::List,
+            (ChangeAgentProviderFocus::List, false) => ChangeAgentProviderFocus::Apply,
+            (ChangeAgentProviderFocus::Apply, false) => ChangeAgentProviderFocus::Cancel,
+            (ChangeAgentProviderFocus::Cancel, false) => ChangeAgentProviderFocus::List,
+        }
+    }
+
+    fn set_change_agent_provider_selection(&mut self, index: usize) {
+        let count = match &self.prompt {
+            PromptState::ChangeAgentProvider(prompt) => prompt.options.len(),
+            _ => 0,
+        };
+        if count == 0 {
+            return;
+        }
+        if let PromptState::ChangeAgentProvider(prompt) = &mut self.prompt {
+            prompt.selected = index.min(count.saturating_sub(1));
+            prompt.focus = ChangeAgentProviderFocus::List;
+        }
+    }
+
     fn resolve_confirm_delete_agent(&mut self, confirm: bool) -> bool {
         let (session_id, delete_worktree) = match &self.prompt {
             PromptState::ConfirmDeleteAgent {
@@ -3590,6 +3686,22 @@ impl App {
                 self.set_pick_editor_selection(index);
                 if double_click {
                     self.open_selected_pick_editor();
+                }
+            }
+            PromptMouseTarget::ChangeAgentProviderItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
+                self.set_change_agent_provider_selection(index);
+                if double_click && let Err(err) = self.apply_change_agent_provider() {
+                    self.set_error(format!("{err:#}"));
+                }
+            }
+            PromptMouseTarget::ChangeAgentProviderCancel => {
+                self.prompt = PromptState::None;
+            }
+            PromptMouseTarget::ChangeAgentProviderApply => {
+                if let Err(err) = self.apply_change_agent_provider() {
+                    self.set_error(format!("{err:#}"));
                 }
             }
             PromptMouseTarget::RuntimeKillInput => {
@@ -4336,8 +4448,8 @@ mod tests {
     use crate::app::{
         App, CenterMode, ConfirmKillRunningPrompt, DeleteAgentFocus, FocusPane, FullscreenOverlay,
         InputTarget, KillRunningAction, KillRunningFocus, KillRunningFooterAction,
-        KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftSection, MouseClickTarget,
-        MouseLayoutState, OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout,
+        KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftItem, LeftSection,
+        MouseClickTarget, MouseLayoutState, OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout,
         OverlayMouseLayoutState, PromptState, PullTarget, RightSection, RuntimeTargetId, TextInput,
         WorkerEvent,
     };
@@ -6575,7 +6687,7 @@ mod tests {
     }
 
     #[test]
-    fn cycle_provider_only_updates_new_and_stopped_agents() {
+    fn change_agent_provider_switches_to_existing_sibling_session() {
         let mut app = test_app(default_bindings());
         let root = PathBuf::from(&app.projects[0].path);
         let now = Utc::now();
@@ -6617,15 +6729,10 @@ mod tests {
             id: "session-3".to_string(),
             project_id: app.projects[0].id.clone(),
             project_path: Some(app.projects[0].path.clone()),
-            provider: ProviderKind::from_str("codex"),
+            provider: ProviderKind::from_str("gemini"),
             source_branch: "main".to_string(),
             branch_name: "exited-branch".to_string(),
-            worktree_path: app
-                .paths
-                .worktrees_root
-                .join("exited")
-                .display()
-                .to_string(),
+            worktree_path: app.sessions[0].worktree_path.clone(),
             title: None,
             started_providers: vec!["codex".to_string()],
             status: SessionStatus::Exited,
@@ -6673,38 +6780,39 @@ mod tests {
         }
 
         app.rebuild_left_items();
-        app.selected_left = 0;
+        app.selected_left = app
+            .left_items()
+            .iter()
+            .position(|item| {
+                matches!(item, LeftItem::Session(index) if app.sessions.get(*index).map(|session| session.id.as_str()) == Some("session-1"))
+            })
+            .expect("selected session");
 
-        app.cycle_selected_project_provider()
-            .expect("cycle provider");
+        app.open_change_agent_provider_prompt()
+            .expect("open provider picker");
+        if let PromptState::ChangeAgentProvider(prompt) = &mut app.prompt {
+            prompt.selected = prompt
+                .options
+                .iter()
+                .position(|option| option.provider.as_str() == "gemini")
+                .expect("gemini option");
+        } else {
+            panic!("expected change-agent-provider prompt");
+        }
 
-        // With providers [claude, codex, gemini, opencode], cycling from codex
-        // advances to the next provider: gemini.
-        assert_eq!(app.projects[0].default_provider.as_str(), "gemini");
+        app.apply_change_agent_provider()
+            .expect("apply provider switch");
+
         assert_eq!(
-            app.config.projects[0].default_provider.as_deref(),
-            Some("gemini")
+            app.selected_session().map(|session| session.id.as_str()),
+            Some("session-3")
         );
-        // Active session keeps its original provider.
+        // The current session keeps its original provider-specific history.
         assert_eq!(app.sessions[0].provider.as_str(), "codex");
-        // Non-active sessions are updated to the new default.
-        assert_eq!(app.sessions[1].provider.as_str(), "gemini");
+        // Existing sibling session is reused instead of being overwritten.
         assert_eq!(app.sessions[2].provider.as_str(), "gemini");
-        // Session belonging to a different project is untouched.
-        assert_eq!(app.sessions[3].provider.as_str(), "codex");
 
         let persisted = app.session_store.load_sessions().expect("load sessions");
-        let provider_for = |id: &str| {
-            persisted
-                .iter()
-                .find(|session| session.id == id)
-                .map(|session| session.provider.as_str())
-        };
-        assert_eq!(provider_for("session-1"), Some("codex"));
-        assert_eq!(provider_for("session-2"), Some("gemini"));
-        assert_eq!(provider_for("session-3"), Some("gemini"));
-        assert_eq!(provider_for("session-4"), Some("codex"));
-
         let started_providers_for = |id: &str| {
             persisted
                 .iter()
@@ -6712,18 +6820,13 @@ mod tests {
                 .map(|session| session.started_providers.clone())
         };
         assert_eq!(
-            started_providers_for("session-2"),
-            Some(vec!["codex".to_string()])
-        );
-        assert_eq!(
             started_providers_for("session-3"),
             Some(vec!["codex".to_string()])
         );
-
         assert!(
             app.status
                 .text()
-                .contains("Changed default CLI agent to \"gemini\"")
+                .contains("Switched to the existing gemini session")
         );
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -413,6 +413,11 @@ pub(crate) struct KillRunningPrompt {
 #[derive(Clone, Debug)]
 pub(crate) struct ChangeAgentProviderOption {
     pub(crate) provider: ProviderKind,
+    /// True when this provider's config has `resume_args`. Providers
+    /// without resume support (e.g. Copilot CLI) always start fresh.
+    pub(crate) supports_resume: bool,
+    /// True when `supports_resume` AND this provider has been launched on
+    /// this worktree before, so the next launch will actually resume.
     pub(crate) resume_available: bool,
     pub(crate) is_current: bool,
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -91,6 +91,11 @@ pub struct App {
     pub(crate) worker_tx: Sender<WorkerEvent>,
     pub(crate) worker_rx: Receiver<WorkerEvent>,
     pub(crate) providers: HashMap<String, PtyClient>,
+    /// When a provider swap happens while the agent's PTY is still running,
+    /// the currently-spawned provider is pinned here so UI labels keep
+    /// showing what's actually running until the user exits and relaunches
+    /// the agent. Cleared whenever the PTY is torn down.
+    pub(crate) running_provider_pins: HashMap<String, ProviderKind>,
     pub(crate) companion_terminals: HashMap<String, CompanionTerminal>,
     pub(crate) active_terminal_id: Option<String>,
     pub(crate) terminal_return_to_list: bool,
@@ -408,7 +413,6 @@ pub(crate) struct KillRunningPrompt {
 #[derive(Clone, Debug)]
 pub(crate) struct ChangeAgentProviderOption {
     pub(crate) provider: ProviderKind,
-    pub(crate) session_id: Option<String>,
     pub(crate) resume_available: bool,
     pub(crate) is_current: bool,
 }
@@ -421,6 +425,27 @@ pub(crate) struct ChangeAgentProviderPrompt {
     pub(crate) options: Vec<ChangeAgentProviderOption>,
     pub(crate) selected: usize,
     pub(crate) focus: ChangeAgentProviderFocus,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChangeDefaultProviderFocus {
+    List,
+    Cancel,
+    Apply,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChangeDefaultProviderOption {
+    pub(crate) provider: ProviderKind,
+    pub(crate) is_current: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChangeDefaultProviderPrompt {
+    pub(crate) current: ProviderKind,
+    pub(crate) options: Vec<ChangeDefaultProviderOption>,
+    pub(crate) selected: usize,
+    pub(crate) focus: ChangeDefaultProviderFocus,
 }
 
 #[derive(Clone, Debug)]
@@ -460,6 +485,7 @@ pub(crate) enum PromptState {
         tab_index: usize,
     },
     ChangeAgentProvider(ChangeAgentProviderPrompt),
+    ChangeDefaultProvider(ChangeDefaultProviderPrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
     ConfirmDeleteAgent {
@@ -761,6 +787,13 @@ pub(crate) enum OverlayMouseLayout {
         cancel_button: Rect,
         apply_button: Rect,
     },
+    ChangeDefaultProvider {
+        list: Rect,
+        items: usize,
+        offset: usize,
+        cancel_button: Rect,
+        apply_button: Rect,
+    },
     PickEditor {
         list: Rect,
         items: usize,
@@ -1034,6 +1067,7 @@ impl App {
             worker_tx,
             worker_rx,
             providers: HashMap::new(),
+            running_provider_pins: HashMap::new(),
             companion_terminals: HashMap::new(),
             active_terminal_id: None,
             terminal_return_to_list: false,
@@ -1469,8 +1503,8 @@ impl App {
         match command {
             "new-agent" => self.create_agent_for_selected_project(),
             "fork-agent" => self.fork_selected_session(),
-            "new-provider-session" => self.create_provider_session_on_worktree(),
             "change-agent-provider" => self.open_change_agent_provider_prompt(),
+            "change-default-provider" => self.open_change_default_provider_prompt(),
             "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),
@@ -1786,6 +1820,17 @@ impl App {
             .find(|p| p.id == session.project_id)
             .map(|p| p.name.clone())
             .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    /// Provider currently driving the session's live PTY, if any. After an
+    /// in-place provider swap while the agent is still running, this returns
+    /// the *original* provider until the user exits and relaunches — so the
+    /// pane title doesn't lie about what's actually on screen.
+    pub(crate) fn running_provider_for(&self, session: &AgentSession) -> ProviderKind {
+        self.running_provider_pins
+            .get(&session.id)
+            .cloned()
+            .unwrap_or_else(|| session.provider.clone())
     }
 
     pub(crate) fn reload_changed_files(&mut self) {
@@ -2162,6 +2207,22 @@ impl App {
         } else {
             false
         }
+    }
+}
+
+/// Re-resolve the in-memory `default_provider` for each project against the
+/// current config. Projects with an explicit `default_provider` keep their
+/// override; projects without one pick up the new global default.
+pub(crate) fn refresh_project_defaults(projects: &mut [Project], config: &Config) {
+    let fallback = config.default_provider();
+    for project in projects.iter_mut() {
+        let explicit = config
+            .projects
+            .iter()
+            .find(|cfg| cfg.id == project.id)
+            .and_then(|cfg| cfg.default_provider.as_deref())
+            .map(ProviderKind::from_str);
+        project.default_provider = explicit.unwrap_or_else(|| fallback.clone());
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -388,6 +388,13 @@ pub(crate) enum KillRunningFocus {
     Footer(KillRunningFooterAction),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ChangeAgentProviderFocus {
+    List,
+    Cancel,
+    Apply,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct KillRunningPrompt {
     pub(crate) runtimes: Vec<KillableRuntime>,
@@ -396,6 +403,24 @@ pub(crate) struct KillRunningPrompt {
     pub(crate) hovered_visible_index: usize,
     pub(crate) selected_ids: HashSet<RuntimeTargetId>,
     pub(crate) focus: KillRunningFocus,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChangeAgentProviderOption {
+    pub(crate) provider: ProviderKind,
+    pub(crate) session_id: Option<String>,
+    pub(crate) resume_available: bool,
+    pub(crate) is_current: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChangeAgentProviderPrompt {
+    pub(crate) session_id: String,
+    pub(crate) session_label: String,
+    pub(crate) worktree_path: String,
+    pub(crate) options: Vec<ChangeAgentProviderOption>,
+    pub(crate) selected: usize,
+    pub(crate) focus: ChangeAgentProviderFocus,
 }
 
 #[derive(Clone, Debug)]
@@ -434,6 +459,7 @@ pub(crate) enum PromptState {
         tab_completions: Vec<String>,
         tab_index: usize,
     },
+    ChangeAgentProvider(ChangeAgentProviderPrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
     ConfirmDeleteAgent {
@@ -728,6 +754,13 @@ pub(crate) enum OverlayMouseLayout {
         items: usize,
         offset: usize,
     },
+    ChangeAgentProvider {
+        list: Rect,
+        items: usize,
+        offset: usize,
+        cancel_button: Rect,
+        apply_button: Rect,
+    },
     PickEditor {
         list: Rect,
         items: usize,
@@ -849,11 +882,6 @@ pub(crate) enum CreateAgentRequest {
         source_session: Box<AgentSession>,
         source_label: String,
         custom_name: Option<String>,
-    },
-    NewProviderSession {
-        project: Project,
-        source_session: Box<AgentSession>,
-        provider: ProviderKind,
     },
 }
 
@@ -1442,7 +1470,7 @@ impl App {
             "new-agent" => self.create_agent_for_selected_project(),
             "fork-agent" => self.fork_selected_session(),
             "new-provider-session" => self.create_provider_session_on_worktree(),
-            "provider" => self.cycle_selected_project_provider(),
+            "change-agent-provider" => self.open_change_agent_provider_prompt(),
             "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -106,8 +106,8 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
     },
     |b| {
         format!(
-            "`{}` cycles through providers. Claude today, Codex tomorrow; your call.",
-            b.label_for(Action::CycleProvider)
+            "`{}` opens the command palette so you can switch a worktree between provider sessions. Memory stays with the provider.",
+            b.label_for(Action::OpenPalette)
         )
     },
     // --- new tips ---
@@ -2448,6 +2448,213 @@ impl App {
                         offset: state.offset(),
                     };
                 }
+            }
+            PromptState::ChangeAgentProvider(prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(72, 42, frame.area());
+                Clear.render(area, frame.buffer_mut());
+
+                let move_down = self.bindings.label_for(Action::MoveDown);
+                let move_up = self.bindings.label_for(Action::MoveUp);
+                let toggle_key = self.bindings.label_for(Action::ToggleSelection);
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+
+                let mut bottom_spans = vec![Span::raw(" ")];
+                bottom_spans.extend(self.theme.key_badge_default(&move_down));
+                bottom_spans.push(Span::styled(
+                    " down  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&move_up));
+                bottom_spans.push(Span::styled(
+                    " up  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&toggle_key));
+                bottom_spans.push(Span::styled(
+                    " buttons  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
+                bottom_spans.push(Span::styled(
+                    " choose  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let [details_area, list_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(4),
+                        Constraint::Min(6),
+                        Constraint::Length(3),
+                    ])
+                    .areas(area);
+
+                let detail_lines = vec![
+                    Line::from(vec![
+                        Span::styled(" Agent: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::styled(
+                            prompt.session_label.as_str(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled(" Path: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::raw(prompt.worktree_path.as_str()),
+                    ]),
+                ];
+                Paragraph::new(detail_lines)
+                    .block(
+                        self.themed_overlay_block("Change Agent Provider")
+                            .title_bottom(Line::from(bottom_spans)),
+                    )
+                    .render(details_area, frame.buffer_mut());
+
+                let provider_col = prompt
+                    .options
+                    .iter()
+                    .map(|option| option.provider.as_str().chars().count())
+                    .max()
+                    .unwrap_or(0)
+                    .max(8);
+                let items = prompt
+                    .options
+                    .iter()
+                    .map(|option| {
+                        let status = if option.is_current {
+                            "current session"
+                        } else if option.session_id.is_some() && option.resume_available {
+                            "existing session, resume available"
+                        } else if option.session_id.is_some() {
+                            "existing session"
+                        } else {
+                            "new session"
+                        };
+                        let name =
+                            format!("{:width$}", option.provider.as_str(), width = provider_col);
+                        ListItem::new(Line::from(vec![
+                            Span::styled(
+                                name,
+                                Style::default()
+                                    .fg(self.theme.help_section_header_fg)
+                                    .add_modifier(Modifier::BOLD),
+                            ),
+                            Span::styled(
+                                format!("  {status}"),
+                                Style::default().fg(self.theme.hint_desc_fg),
+                            ),
+                        ]))
+                    })
+                    .collect::<Vec<_>>();
+                let mut state = ListState::default().with_selected(Some(
+                    prompt.selected.min(prompt.options.len().saturating_sub(1)),
+                ));
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let list_inner = list_block.inner(list_area);
+                let highlight_style = if matches!(prompt.focus, ChangeAgentProviderFocus::List) {
+                    self.theme.selection_style()
+                } else {
+                    Style::default()
+                        .fg(self.theme.help_section_header_fg)
+                        .add_modifier(Modifier::BOLD)
+                };
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(list_block)
+                        .highlight_style(highlight_style),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+
+                let btn_width = 18u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let apply_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) =
+                    if matches!(prompt.focus, ChangeAgentProviderFocus::Cancel) {
+                        (
+                            self.theme.button_confirm_border,
+                            self.theme.button_active_fg,
+                        )
+                    } else {
+                        (self.theme.border_normal, self.theme.hint_desc_fg)
+                    };
+                let apply_enabled = prompt
+                    .options
+                    .get(prompt.selected)
+                    .map(|option| !option.is_current)
+                    .unwrap_or(false);
+                let (apply_border, apply_fg) =
+                    if matches!(prompt.focus, ChangeAgentProviderFocus::Apply) && apply_enabled {
+                        (
+                            self.theme.button_confirm_border,
+                            self.theme.button_active_fg,
+                        )
+                    } else if !apply_enabled {
+                        (self.theme.border_normal, self.theme.hint_dim_desc_fg)
+                    } else {
+                        (self.theme.border_normal, self.theme.hint_desc_fg)
+                    };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Use Provider",
+                    if apply_enabled {
+                        Style::default().fg(apply_fg).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(apply_fg)
+                    },
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(apply_border)),
+                )
+                .render(apply_area, frame.buffer_mut());
+
+                self.overlay_layout.active = OverlayMouseLayout::ChangeAgentProvider {
+                    list: list_inner,
+                    items: prompt.options.len(),
+                    offset: state.offset(),
+                    cancel_button: cancel_area,
+                    apply_button: apply_area,
+                };
             }
             PromptState::PickEditor {
                 session_label,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2557,6 +2557,8 @@ impl App {
                             "current"
                         } else if option.resume_available {
                             "a previous session was found; it'll be continued"
+                        } else if !option.supports_resume {
+                            "this provider doesn't support resume; it'll start fresh every time"
                         } else {
                             "no prior session; will start fresh"
                         };

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -426,13 +426,26 @@ impl App {
             }
             spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
             spans.push(Span::styled(
-                "provider: ",
+                "default provider: ",
                 Style::default().fg(label_fg).bg(bg),
             ));
             spans.push(Span::styled(
                 project.default_provider.as_str().to_string(),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
+            if let Some(session) = self.selected_session()
+                && session.provider != project.default_provider
+            {
+                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                spans.push(Span::styled(
+                    "current provider: ",
+                    Style::default().fg(label_fg).bg(bg),
+                ));
+                spans.push(Span::styled(
+                    session.provider.as_str().to_string(),
+                    Style::default().fg(self.theme.branch_fg).bg(bg),
+                ));
+            }
             let running_terminals = self.running_companion_terminal_count();
             if running_terminals > 0 {
                 spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
@@ -1065,7 +1078,7 @@ impl App {
         let session_provider_name = match active_surface {
             SessionSurface::Agent => self
                 .selected_session()
-                .map(|s| s.provider.as_str().to_owned()),
+                .map(|s| self.running_provider_for(s).as_str().to_owned()),
             SessionSurface::Terminal => Some(
                 self.config
                     .terminal
@@ -2528,13 +2541,11 @@ impl App {
                     .iter()
                     .map(|option| {
                         let status = if option.is_current {
-                            "current session"
-                        } else if option.session_id.is_some() && option.resume_available {
-                            "existing session, resume available"
-                        } else if option.session_id.is_some() {
-                            "existing session"
+                            "current"
+                        } else if option.resume_available {
+                            "resume available"
                         } else {
-                            "new session"
+                            "available"
                         };
                         let name =
                             format!("{:width$}", option.provider.as_str(), width = provider_col);
@@ -2649,6 +2660,212 @@ impl App {
                 .render(apply_area, frame.buffer_mut());
 
                 self.overlay_layout.active = OverlayMouseLayout::ChangeAgentProvider {
+                    list: list_inner,
+                    items: prompt.options.len(),
+                    offset: state.offset(),
+                    cancel_button: cancel_area,
+                    apply_button: apply_area,
+                };
+            }
+            PromptState::ChangeDefaultProvider(prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(72, 42, frame.area());
+                Clear.render(area, frame.buffer_mut());
+
+                let move_down = self.bindings.label_for(Action::MoveDown);
+                let move_up = self.bindings.label_for(Action::MoveUp);
+                let toggle_key = self.bindings.label_for(Action::ToggleSelection);
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+
+                let mut bottom_spans = vec![Span::raw(" ")];
+                bottom_spans.extend(self.theme.key_badge_default(&move_down));
+                bottom_spans.push(Span::styled(
+                    " down  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&move_up));
+                bottom_spans.push(Span::styled(
+                    " up  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&toggle_key));
+                bottom_spans.push(Span::styled(
+                    " buttons  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
+                bottom_spans.push(Span::styled(
+                    " choose  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let [details_area, list_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(4),
+                        Constraint::Min(6),
+                        Constraint::Length(3),
+                    ])
+                    .areas(area);
+
+                let detail_lines = vec![
+                    Line::from(vec![
+                        Span::styled(
+                            " Current default: ",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ),
+                        Span::styled(
+                            prompt.current.as_str().to_string(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![Span::styled(
+                        " New sessions will use the chosen provider. Existing agents keep their current provider.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )]),
+                ];
+                Paragraph::new(detail_lines)
+                    .block(
+                        self.themed_overlay_block("Change Default Provider")
+                            .title_bottom(Line::from(bottom_spans)),
+                    )
+                    .render(details_area, frame.buffer_mut());
+
+                let provider_col = prompt
+                    .options
+                    .iter()
+                    .map(|option| option.provider.as_str().chars().count())
+                    .max()
+                    .unwrap_or(0)
+                    .max(8);
+                let items = prompt
+                    .options
+                    .iter()
+                    .map(|option| {
+                        let status = if option.is_current {
+                            "current default"
+                        } else {
+                            "available"
+                        };
+                        let name =
+                            format!("{:width$}", option.provider.as_str(), width = provider_col);
+                        ListItem::new(Line::from(vec![
+                            Span::styled(
+                                name,
+                                Style::default()
+                                    .fg(self.theme.help_section_header_fg)
+                                    .add_modifier(Modifier::BOLD),
+                            ),
+                            Span::styled(
+                                format!("  {status}"),
+                                Style::default().fg(self.theme.hint_desc_fg),
+                            ),
+                        ]))
+                    })
+                    .collect::<Vec<_>>();
+                let mut state = ListState::default().with_selected(Some(
+                    prompt.selected.min(prompt.options.len().saturating_sub(1)),
+                ));
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let list_inner = list_block.inner(list_area);
+                let highlight_style = if matches!(prompt.focus, ChangeDefaultProviderFocus::List) {
+                    self.theme.selection_style()
+                } else {
+                    Style::default()
+                        .fg(self.theme.help_section_header_fg)
+                        .add_modifier(Modifier::BOLD)
+                };
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(list_block)
+                        .highlight_style(highlight_style),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+
+                let btn_width = 18u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let apply_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let (cancel_border, cancel_fg) =
+                    if matches!(prompt.focus, ChangeDefaultProviderFocus::Cancel) {
+                        (
+                            self.theme.button_confirm_border,
+                            self.theme.button_active_fg,
+                        )
+                    } else {
+                        (self.theme.border_normal, self.theme.hint_desc_fg)
+                    };
+                let apply_enabled = prompt
+                    .options
+                    .get(prompt.selected)
+                    .map(|option| !option.is_current)
+                    .unwrap_or(false);
+                let (apply_border, apply_fg) =
+                    if matches!(prompt.focus, ChangeDefaultProviderFocus::Apply) && apply_enabled {
+                        (
+                            self.theme.button_confirm_border,
+                            self.theme.button_active_fg,
+                        )
+                    } else if !apply_enabled {
+                        (self.theme.border_normal, self.theme.hint_dim_desc_fg)
+                    } else {
+                        (self.theme.border_normal, self.theme.hint_desc_fg)
+                    };
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Cancel",
+                    Style::default().fg(cancel_fg).add_modifier(Modifier::BOLD),
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(cancel_border)),
+                )
+                .render(cancel_area, frame.buffer_mut());
+
+                Paragraph::new(Line::from(Span::styled(
+                    "Set Default",
+                    if apply_enabled {
+                        Style::default().fg(apply_fg).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(apply_fg)
+                    },
+                )))
+                .alignment(ratatui::layout::Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(apply_border)),
+                )
+                .render(apply_area, frame.buffer_mut());
+
+                self.overlay_layout.active = OverlayMouseLayout::ChangeDefaultProvider {
                     list: list_inner,
                     items: prompt.options.len(),
                     offset: state.offset(),
@@ -4660,7 +4877,7 @@ impl App {
         Clear.render(area, frame.buffer_mut());
         let title = match self.selected_session() {
             Some(session) => {
-                let provider = capitalize(session.provider.as_str());
+                let provider = capitalize(self.running_provider_for(session).as_str());
                 let name = session.title.as_deref().unwrap_or(&session.branch_name);
                 let pr_suffix = self
                     .pr_statuses
@@ -4855,7 +5072,7 @@ impl App {
 
     fn center_pane_agent_title(&self) -> String {
         if let Some(session) = self.selected_session() {
-            let provider = capitalize(session.provider.as_str());
+            let provider = capitalize(self.running_provider_for(session).as_str());
             let base = format!("{provider} agent");
             let count = self.session_terminal_count(&session.id);
             if count == 1 {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -106,9 +106,18 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
     },
     |b| {
         format!(
-            "`{}` opens the command palette so you can switch a worktree between provider sessions. Memory stays with the provider.",
+            "Open the palette with `{}` and run `change-agent-provider` to swap a worktree's CLI. Been here before? dux resumes that provider's last session automatically.",
             b.label_for(Action::OpenPalette)
         )
+    },
+    |_b| {
+        "dux remembers which providers you've run on each worktree. Swap away and back, and each one picks up right where you left it.".into()
+    },
+    |_b| {
+        "New agents spawning with the wrong CLI? Run `change-default-provider` in the palette to swap the default. Existing agents stay on their current brain.".into()
+    },
+    |_b| {
+        "Swapped providers while an agent was still running? The sidebar shows `(old → new)` until you exit and relaunch. dux queues the swap, you run the show.".into()
     },
     // --- new tips ---
     |_b| {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -644,13 +644,26 @@ impl App {
                     } else {
                         Style::default().fg(label_color)
                     };
+                    let running_provider = self.running_provider_for(session);
+                    let provider_label = if running_provider != session.provider {
+                        // Swap is pending: agent is still running the old
+                        // provider but will spawn with session.provider on
+                        // next launch. Show both so the sidebar doesn't lie.
+                        format!(
+                            " ({} → {})",
+                            running_provider.as_str(),
+                            session.provider.as_str(),
+                        )
+                    } else {
+                        format!(" ({})", session.provider.as_str())
+                    };
                     ListItem::new(Line::from(
                         vec![
                             Span::styled(connector, Style::default().fg(self.theme.project_icon)),
                             Span::styled(format!("{dot} "), label_style),
                             Span::styled(label, label_style),
                             Span::styled(
-                                format!(" ({})", session.provider.as_str()),
+                                provider_label,
                                 if deleting {
                                     label_style
                                 } else {
@@ -2543,9 +2556,9 @@ impl App {
                         let status = if option.is_current {
                             "current"
                         } else if option.resume_available {
-                            "resume available"
+                            "a previous session was found; it'll be continued"
                         } else {
-                            "available"
+                            "no prior session; will start fresh"
                         };
                         let name =
                             format!("{:width$}", option.provider.as_str(), width = provider_col);

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -707,6 +707,7 @@ impl App {
         self.session_store.delete_session(&session.id)?;
 
         self.providers.remove(&session.id);
+        self.running_provider_pins.remove(&session.id);
         self.last_pty_activity.remove(&session.id);
         self.resume_fallback_candidates.remove(&session.id);
         self.clear_companion_terminals_for_session(&session.id);
@@ -810,32 +811,6 @@ impl App {
         }
     }
 
-    fn select_session_in_left_pane(&mut self, session_id: &str) -> bool {
-        let Some(position) = self.left_items().iter().position(|item| {
-            matches!(item, LeftItem::Session(index) if self.sessions.get(*index).map(|session| session.id.as_str()) == Some(session_id))
-        }) else {
-            return false;
-        };
-        self.left_section = LeftSection::Projects;
-        self.selected_left = position;
-        self.reload_changed_files();
-        self.show_agent_surface();
-        self.input_target = InputTarget::None;
-        true
-    }
-
-    fn same_worktree_provider_session(
-        &self,
-        session: &AgentSession,
-        provider: &ProviderKind,
-    ) -> Option<&AgentSession> {
-        self.sessions.iter().find(|candidate| {
-            candidate.id != session.id
-                && candidate.worktree_path == session.worktree_path
-                && candidate.provider == *provider
-        })
-    }
-
     fn change_agent_provider_options(
         &self,
         session: &AgentSession,
@@ -846,15 +821,12 @@ impl App {
             .keys()
             .map(|name| {
                 let provider = ProviderKind::new(name.clone());
-                let existing = self.same_worktree_provider_session(session, &provider);
-                let existing_session = existing.map(|candidate| candidate.id.clone());
-                let resume_available = existing
-                    .map(|candidate| self.should_resume_session(candidate))
-                    .unwrap_or(false);
+                let cfg = provider_config(&self.config, &provider);
+                let resume_available =
+                    cfg.supports_session_resume() && session.has_started_provider(&provider);
                 ChangeAgentProviderOption {
                     is_current: provider == session.provider,
                     provider,
-                    session_id: existing_session,
                     resume_available,
                 }
             })
@@ -881,53 +853,9 @@ impl App {
             focus: ChangeAgentProviderFocus::List,
         });
         self.set_info(
-            "Choose a provider for the selected worktree. Existing provider sessions keep their own resume history.",
+            "Choose a provider for this worktree. The change takes effect on the next launch; dux resumes each provider's prior session on this worktree when available.",
         );
         Ok(())
-    }
-
-    fn create_provider_session_record(
-        &mut self,
-        source_session: &AgentSession,
-        provider: ProviderKind,
-    ) -> Result<AgentSession> {
-        if let Some(existing) = self.same_worktree_provider_session(source_session, &provider) {
-            return Ok(existing.clone());
-        }
-        let Some(project) = self
-            .projects
-            .iter()
-            .find(|project| project.id == source_session.project_id)
-            .cloned()
-        else {
-            anyhow::bail!("Project not found for the selected agent.");
-        };
-        if !Path::new(&source_session.worktree_path).exists() {
-            anyhow::bail!(
-                "Worktree for agent \"{}\" no longer exists.",
-                source_session.branch_name
-            );
-        }
-        let session = AgentSession {
-            id: Uuid::new_v4().to_string(),
-            project_id: source_session.project_id.clone(),
-            project_path: Some(project.path),
-            provider,
-            source_branch: source_session.source_branch.clone(),
-            branch_name: source_session.branch_name.clone(),
-            worktree_path: source_session.worktree_path.clone(),
-            title: source_session.title.clone(),
-            started_providers: Vec::new(),
-            status: SessionStatus::Exited,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        self.session_store.upsert_session(&session)?;
-        self.sessions.insert(0, session.clone());
-        self.update_branch_sync_sessions();
-        self.update_pr_sync_sessions();
-        self.rebuild_left_items();
-        Ok(session)
     }
 
     pub(crate) fn apply_change_agent_provider(&mut self) -> Result<()> {
@@ -935,15 +863,125 @@ impl App {
             PromptState::ChangeAgentProvider(prompt) => prompt.clone(),
             _ => return Ok(()),
         };
-        let Some(source_session) = self
+        let Some(selected) = prompt.options.get(prompt.selected).cloned() else {
+            self.prompt = PromptState::None;
+            self.set_error("Select a provider first.");
+            return Ok(());
+        };
+        let Some(session_index) = self
             .sessions
             .iter()
-            .find(|session| session.id == prompt.session_id)
-            .cloned()
+            .position(|session| session.id == prompt.session_id)
         else {
             self.prompt = PromptState::None;
             self.set_error("The selected agent is no longer available.");
             return Ok(());
+        };
+
+        if selected.is_current {
+            self.prompt = PromptState::None;
+            self.set_info(format!(
+                "Agent \"{}\" already uses {}. Pick another provider to swap.",
+                prompt.session_label,
+                selected.provider.as_str(),
+            ));
+            return Ok(());
+        }
+
+        self.prompt = PromptState::None;
+
+        let session_id = self.sessions[session_index].id.clone();
+        let running = self.providers.contains_key(&session_id);
+        let previous_provider = self.sessions[session_index].provider.clone();
+
+        let session = &mut self.sessions[session_index];
+        session.provider = selected.provider.clone();
+        session.updated_at = Utc::now();
+        let updated = session.clone();
+        self.session_store.upsert_session(&updated)?;
+
+        // Pin the still-running provider so UI labels stay truthful until
+        // the user exits and relaunches the agent. Only set on the first
+        // swap-while-running — later swaps don't change what's spawned.
+        if running {
+            self.running_provider_pins
+                .entry(session_id.clone())
+                .or_insert(previous_provider.clone());
+        }
+        self.rebuild_left_items();
+
+        let reconnect_key = self.bindings.label_for(Action::ReconnectAgent);
+        if running {
+            self.set_warning(format!(
+                "Worktree \"{}\" is set to {}, but the {} agent is still running. Exit it and press {} to relaunch with {}.",
+                prompt.session_label,
+                selected.provider.as_str(),
+                previous_provider.as_str(),
+                reconnect_key,
+                selected.provider.as_str(),
+            ));
+        } else {
+            let resume_note = if selected.resume_available {
+                " dux will resume its prior session on this worktree."
+            } else {
+                " This provider hasn't run on this worktree yet, so it'll start a fresh session."
+            };
+            self.set_info(format!(
+                "Worktree \"{}\" will use {} next launch. Press {} to start it.{}",
+                prompt.session_label,
+                selected.provider.as_str(),
+                reconnect_key,
+                resume_note,
+            ));
+        }
+        Ok(())
+    }
+
+    fn change_default_provider_options(&self) -> Vec<ChangeDefaultProviderOption> {
+        let current = self.config.default_provider();
+        self.config
+            .providers
+            .commands
+            .keys()
+            .map(|name| {
+                let provider = ProviderKind::new(name.clone());
+                ChangeDefaultProviderOption {
+                    is_current: provider == current,
+                    provider,
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn open_change_default_provider_prompt(&mut self) -> Result<()> {
+        if self.config.providers.commands.is_empty() {
+            self.set_error("No providers are configured.");
+            return Ok(());
+        }
+        let options = self.change_default_provider_options();
+        let selected = options
+            .iter()
+            .position(|option| option.is_current)
+            .unwrap_or(0);
+        let current = self.config.default_provider();
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::ChangeDefaultProvider(ChangeDefaultProviderPrompt {
+            current,
+            options,
+            selected,
+            focus: ChangeDefaultProviderFocus::List,
+        });
+        self.set_info(
+            "Choose the default provider for newly created agent sessions. Existing agents keep their current provider.",
+        );
+        Ok(())
+    }
+
+    pub(crate) fn apply_change_default_provider(&mut self) -> Result<()> {
+        let prompt = match &self.prompt {
+            PromptState::ChangeDefaultProvider(prompt) => prompt.clone(),
+            _ => return Ok(()),
         };
         let Some(selected) = prompt.options.get(prompt.selected).cloned() else {
             self.prompt = PromptState::None;
@@ -953,33 +991,25 @@ impl App {
         self.prompt = PromptState::None;
         if selected.is_current {
             self.set_info(format!(
-                "Agent \"{}\" already uses {}. Pick another provider to switch worktree sessions.",
-                prompt.session_label,
-                selected.provider.as_str()
-            ));
-            return Ok(());
-        }
-        if let Some(existing_session_id) = selected.session_id.as_deref() {
-            let _ = self.select_session_in_left_pane(existing_session_id);
-            let resume_note = if selected.resume_available {
-                " Resume is available when you reconnect it."
-            } else {
-                ""
-            };
-            self.set_info(format!(
-                "Switched to the existing {} session for worktree \"{}\". Reconnect it when you want to continue with that provider.{resume_note}",
+                "{} is already the default provider. Pick a different one to change it.",
                 selected.provider.as_str(),
-                prompt.session_label,
             ));
             return Ok(());
         }
-        let session =
-            self.create_provider_session_record(&source_session, selected.provider.clone())?;
-        let _ = self.select_session_in_left_pane(&session.id);
+        let previous = self.config.defaults.provider.clone();
+        self.config.defaults.provider = selected.provider.as_str().to_string();
+        if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings) {
+            self.config.defaults.provider = previous;
+            self.set_error(format!(
+                "Couldn't persist the default provider change: {err:#}"
+            ));
+            return Ok(());
+        }
+        refresh_project_defaults(&mut self.projects, &self.config);
+        self.rebuild_left_items();
         self.set_info(format!(
-            "Created a stopped {} session for worktree \"{}\". Reconnect it when you want to start using that provider.",
+            "Default provider changed to {}. New agent sessions will use it; existing agents keep their current provider. Use \"change-agent-provider\" on a session to switch providers for an existing worktree.",
             selected.provider.as_str(),
-            prompt.session_label,
         ));
         Ok(())
     }
@@ -1085,6 +1115,7 @@ impl App {
         }
         // Kill existing PTY if the agent is still active.
         self.providers.remove(&session.id);
+        self.running_provider_pins.remove(&session.id);
         self.last_pty_activity.remove(&session.id);
         self.resume_fallback_candidates.remove(&session.id);
 
@@ -1591,6 +1622,7 @@ impl App {
             match target_id {
                 RuntimeTargetId::Agent(session_id) => {
                     if self.providers.remove(session_id).is_some() {
+                        self.running_provider_pins.remove(session_id);
                         self.last_pty_activity.remove(session_id);
                         self.mark_session_status(session_id, SessionStatus::Detached);
                         killed_agents += 1;
@@ -1639,51 +1671,6 @@ impl App {
             .unwrap_or_else(|| session.branch_name.clone())
     }
 
-    /// Creates a new session on the same worktree as the selected session but
-    /// using the project's current default provider.
-    pub(crate) fn create_provider_session_on_worktree(&mut self) -> Result<()> {
-        let Some(session) = self.selected_session().cloned() else {
-            self.set_error("Select an agent first.");
-            return Ok(());
-        };
-        let Some(project) = self
-            .projects
-            .iter()
-            .find(|p| p.id == session.project_id)
-            .cloned()
-        else {
-            self.set_error("Project not found for the selected agent.");
-            return Ok(());
-        };
-        if project.default_provider == session.provider {
-            self.set_error(format!(
-                "The selected agent already uses {}. Choose a different default provider in config or use change-agent-provider from the command palette.",
-                session.provider.as_str(),
-            ));
-            return Ok(());
-        }
-        let target_provider = project.default_provider.clone();
-        if let Some(existing_id) = self
-            .same_worktree_provider_session(&session, &target_provider)
-            .map(|existing| existing.id.clone())
-        {
-            let _ = self.select_session_in_left_pane(&existing_id);
-            self.set_error(format!(
-                "A {} session already exists on this worktree. It has been selected in the session list.",
-                target_provider.as_str(),
-            ));
-            return Ok(());
-        }
-        let created = self.create_provider_session_record(&session, target_provider.clone())?;
-        let _ = self.select_session_in_left_pane(&created.id);
-        self.set_info(format!(
-            "Created a stopped {} session on worktree \"{}\". Reconnect it when you want to start using that provider.",
-            target_provider.as_str(),
-            self.session_label(&session),
-        ));
-        Ok(())
-    }
-
     /// If another session on the same worktree has a running PTY, detach it
     /// (kill the PTY and mark the session as `Detached`).  Returns the
     /// human-readable label of the detached session, if any.
@@ -1705,6 +1692,7 @@ impl App {
         let label = self.session_label(&conflicting);
         let provider = conflicting.provider.as_str().to_string();
         self.providers.remove(&conflicting.id);
+        self.running_provider_pins.remove(&conflicting.id);
         self.last_pty_activity.remove(&conflicting.id);
         self.resume_fallback_candidates.remove(&conflicting.id);
         self.mark_session_status(&conflicting.id, SessionStatus::Detached);
@@ -1804,6 +1792,7 @@ mod tests {
             worker_tx,
             worker_rx,
             providers: std::collections::HashMap::new(),
+            running_provider_pins: std::collections::HashMap::new(),
             companion_terminals: std::collections::HashMap::new(),
             active_terminal_id: None,
             terminal_return_to_list: false,
@@ -1954,71 +1943,6 @@ mod tests {
         assert!(!app.providers.contains_key("s1"));
         let s1_session = app.sessions.iter().find(|s| s.id == "s1").unwrap();
         assert_eq!(s1_session.status, SessionStatus::Detached);
-    }
-
-    #[test]
-    fn create_provider_session_allows_running_agent_without_reconnect() {
-        let s1 = make_session("s1", "claude", "/tmp/wt/a");
-        let project = make_project("project-1", "codex");
-        let mut app = test_app_with_sessions(vec![s1], vec![project]);
-        std::fs::create_dir_all("/tmp/wt/a").expect("create worktree");
-        app.selected_left = app
-            .left_items()
-            .iter()
-            .position(|item| matches!(item, LeftItem::Session(_)))
-            .unwrap_or(0);
-        mark_active(&mut app, "s1");
-
-        app.create_provider_session_on_worktree().unwrap();
-        assert_eq!(app.sessions.len(), 2);
-        let created = app
-            .sessions
-            .iter()
-            .find(|session| session.id != "s1")
-            .expect("new sibling session");
-        assert_eq!(created.provider.as_str(), "codex");
-        assert_eq!(created.status, SessionStatus::Exited);
-        assert!(!app.providers.contains_key(&created.id));
-    }
-
-    #[test]
-    fn create_provider_session_rejects_same_provider() {
-        let s1 = make_session("s1", "claude", "/tmp/wt/a");
-        let project = make_project("project-1", "claude");
-        let mut app = test_app_with_sessions(vec![s1], vec![project]);
-        // Select the session in the left pane.
-        app.selected_left = app
-            .left_items()
-            .iter()
-            .position(|item| matches!(item, LeftItem::Session(_)))
-            .unwrap_or(0);
-
-        app.create_provider_session_on_worktree().unwrap();
-        // Should have set an error because the session already uses claude.
-        assert!(app.status.text().contains("already uses"));
-    }
-
-    #[test]
-    fn create_provider_session_selects_existing_duplicate() {
-        let s1 = make_session("s1", "claude", "/tmp/wt/a");
-        let s2 = make_session("s2", "codex", "/tmp/wt/a");
-        let project = make_project("project-1", "codex");
-        let mut app = test_app_with_sessions(vec![s1, s2], vec![project]);
-        // Select s1 (the claude session).
-        app.selected_left = app
-            .left_items()
-            .iter()
-            .position(|item| {
-                matches!(item, LeftItem::Session(i) if app.sessions.get(*i).map(|s| s.id.as_str()) == Some("s1"))
-            })
-            .unwrap_or(0);
-
-        app.create_provider_session_on_worktree().unwrap();
-        assert_eq!(
-            app.selected_session().map(|session| session.id.as_str()),
-            Some("s2")
-        );
-        assert!(app.status.text().contains("has been selected"));
     }
 
     #[test]

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -822,11 +822,12 @@ impl App {
             .map(|name| {
                 let provider = ProviderKind::new(name.clone());
                 let cfg = provider_config(&self.config, &provider);
-                let resume_available =
-                    cfg.supports_session_resume() && session.has_started_provider(&provider);
+                let supports_resume = cfg.supports_session_resume();
+                let resume_available = supports_resume && session.has_started_provider(&provider);
                 ChangeAgentProviderOption {
                     is_current: provider == session.provider,
                     provider,
+                    supports_resume,
                     resume_available,
                 }
             })

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -810,53 +810,176 @@ impl App {
         }
     }
 
-    pub(crate) fn cycle_selected_project_provider(&mut self) -> Result<()> {
-        let Some(project) = self.selected_project().cloned() else {
-            self.set_error("Select a project first.");
+    fn select_session_in_left_pane(&mut self, session_id: &str) -> bool {
+        let Some(position) = self.left_items().iter().position(|item| {
+            matches!(item, LeftItem::Session(index) if self.sessions.get(*index).map(|session| session.id.as_str()) == Some(session_id))
+        }) else {
+            return false;
+        };
+        self.left_section = LeftSection::Projects;
+        self.selected_left = position;
+        self.reload_changed_files();
+        self.show_agent_surface();
+        self.input_target = InputTarget::None;
+        true
+    }
+
+    fn same_worktree_provider_session(
+        &self,
+        session: &AgentSession,
+        provider: &ProviderKind,
+    ) -> Option<&AgentSession> {
+        self.sessions.iter().find(|candidate| {
+            candidate.id != session.id
+                && candidate.worktree_path == session.worktree_path
+                && candidate.provider == *provider
+        })
+    }
+
+    fn change_agent_provider_options(
+        &self,
+        session: &AgentSession,
+    ) -> Vec<ChangeAgentProviderOption> {
+        self.config
+            .providers
+            .commands
+            .keys()
+            .map(|name| {
+                let provider = ProviderKind::new(name.clone());
+                let existing = self.same_worktree_provider_session(session, &provider);
+                let existing_session = existing.map(|candidate| candidate.id.clone());
+                let resume_available = existing
+                    .map(|candidate| self.should_resume_session(candidate))
+                    .unwrap_or(false);
+                ChangeAgentProviderOption {
+                    is_current: provider == session.provider,
+                    provider,
+                    session_id: existing_session,
+                    resume_available,
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn open_change_agent_provider_prompt(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent session first.");
             return Ok(());
         };
-        let provider_names: Vec<&String> = self.config.providers.commands.keys().collect();
-        if provider_names.is_empty() {
-            self.set_error("No providers configured.");
+        if self.config.providers.commands.is_empty() {
+            self.set_error("No providers are configured.");
             return Ok(());
         }
-        let current = project.default_provider.as_str();
-        let current_idx = provider_names
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::ChangeAgentProvider(ChangeAgentProviderPrompt {
+            session_id: session.id.clone(),
+            session_label: self.session_label(&session),
+            worktree_path: session.worktree_path.clone(),
+            options: self.change_agent_provider_options(&session),
+            selected: 0,
+            focus: ChangeAgentProviderFocus::List,
+        });
+        self.set_info(
+            "Choose a provider for the selected worktree. Existing provider sessions keep their own resume history.",
+        );
+        Ok(())
+    }
+
+    fn create_provider_session_record(
+        &mut self,
+        source_session: &AgentSession,
+        provider: ProviderKind,
+    ) -> Result<AgentSession> {
+        if let Some(existing) = self.same_worktree_provider_session(source_session, &provider) {
+            return Ok(existing.clone());
+        }
+        let Some(project) = self
+            .projects
             .iter()
-            .position(|n| n.as_str() == current)
-            .unwrap_or(0);
-        let next_idx = (current_idx + 1) % provider_names.len();
-        let next = ProviderKind::new(provider_names[next_idx].clone());
-        if let Some(existing) = self
-            .projects
-            .iter_mut()
-            .find(|candidate| candidate.id == project.id)
-        {
-            existing.default_provider = next.clone();
+            .find(|project| project.id == source_session.project_id)
+            .cloned()
+        else {
+            anyhow::bail!("Project not found for the selected agent.");
+        };
+        if !Path::new(&source_session.worktree_path).exists() {
+            anyhow::bail!(
+                "Worktree for agent \"{}\" no longer exists.",
+                source_session.branch_name
+            );
         }
-        if let Some(project_config) = self
-            .config
-            .projects
-            .iter_mut()
-            .find(|candidate| Path::new(&candidate.path) == Path::new(&project.path))
-        {
-            project_config.default_provider = Some(next.as_str().to_string());
-        }
-        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
-        for session in self
+        let session = AgentSession {
+            id: Uuid::new_v4().to_string(),
+            project_id: source_session.project_id.clone(),
+            project_path: Some(project.path),
+            provider,
+            source_branch: source_session.source_branch.clone(),
+            branch_name: source_session.branch_name.clone(),
+            worktree_path: source_session.worktree_path.clone(),
+            title: source_session.title.clone(),
+            started_providers: Vec::new(),
+            status: SessionStatus::Exited,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        self.session_store.upsert_session(&session)?;
+        self.sessions.insert(0, session.clone());
+        self.update_branch_sync_sessions();
+        self.update_pr_sync_sessions();
+        self.rebuild_left_items();
+        Ok(session)
+    }
+
+    pub(crate) fn apply_change_agent_provider(&mut self) -> Result<()> {
+        let prompt = match &self.prompt {
+            PromptState::ChangeAgentProvider(prompt) => prompt.clone(),
+            _ => return Ok(()),
+        };
+        let Some(source_session) = self
             .sessions
-            .iter_mut()
-            // Active is currently the only running session state. If SessionStatus
-            // gains additional running variants, update this filter to keep
-            // provider cycling limited to new and non-running agents.
-            .filter(|s| s.project_id == project.id && !matches!(s.status, SessionStatus::Active))
-        {
-            session.provider = next.clone();
-            self.session_store.upsert_session(session)?;
+            .iter()
+            .find(|session| session.id == prompt.session_id)
+            .cloned()
+        else {
+            self.prompt = PromptState::None;
+            self.set_error("The selected agent is no longer available.");
+            return Ok(());
+        };
+        let Some(selected) = prompt.options.get(prompt.selected).cloned() else {
+            self.prompt = PromptState::None;
+            self.set_error("Select a provider first.");
+            return Ok(());
+        };
+        self.prompt = PromptState::None;
+        if selected.is_current {
+            self.set_info(format!(
+                "Agent \"{}\" already uses {}. Pick another provider to switch worktree sessions.",
+                prompt.session_label,
+                selected.provider.as_str()
+            ));
+            return Ok(());
         }
+        if let Some(existing_session_id) = selected.session_id.as_deref() {
+            let _ = self.select_session_in_left_pane(existing_session_id);
+            let resume_note = if selected.resume_available {
+                " Resume is available when you reconnect it."
+            } else {
+                ""
+            };
+            self.set_info(format!(
+                "Switched to the existing {} session for worktree \"{}\". Reconnect it when you want to continue with that provider.{resume_note}",
+                selected.provider.as_str(),
+                prompt.session_label,
+            ));
+            return Ok(());
+        }
+        let session =
+            self.create_provider_session_record(&source_session, selected.provider.clone())?;
+        let _ = self.select_session_in_left_pane(&session.id);
         self.set_info(format!(
-            "Changed default CLI agent to \"{}\" for new and stopped agents",
-            next.as_str()
+            "Created a stopped {} session for worktree \"{}\". Reconnect it when you want to start using that provider.",
+            selected.provider.as_str(),
+            prompt.session_label,
         ));
         Ok(())
     }
@@ -1532,51 +1655,32 @@ impl App {
             self.set_error("Project not found for the selected agent.");
             return Ok(());
         };
-        if self.providers.contains_key(&session.id) {
-            self.set_error(
-                "The selected agent is still running. Stop it before creating a new provider session.",
-            );
-            return Ok(());
-        }
         if project.default_provider == session.provider {
             self.set_error(format!(
-                "The selected agent already uses {}. Change the default provider first with the \"provider\" command.",
+                "The selected agent already uses {}. Choose a different default provider in config or use change-agent-provider from the command palette.",
                 session.provider.as_str(),
             ));
             return Ok(());
         }
-        // Prevent creating a duplicate session with the same provider on
-        // the same worktree.
         let target_provider = project.default_provider.clone();
-        let duplicate = self.sessions.iter().any(|s| {
-            s.id != session.id
-                && s.worktree_path == session.worktree_path
-                && s.provider == target_provider
-        });
-        if duplicate {
+        if let Some(existing_id) = self
+            .same_worktree_provider_session(&session, &target_provider)
+            .map(|existing| existing.id.clone())
+        {
+            let _ = self.select_session_in_left_pane(&existing_id);
             self.set_error(format!(
-                "A {} session already exists on this worktree. Select it from the session list instead.",
+                "A {} session already exists on this worktree. It has been selected in the session list.",
                 target_provider.as_str(),
             ));
             return Ok(());
         }
-        if self.create_agent_in_flight {
-            self.set_error("Another agent is being created. Wait for it to finish.");
-            return Ok(());
-        }
-        self.create_agent_in_flight = true;
-        let request = CreateAgentRequest::NewProviderSession {
-            project,
-            source_session: Box::new(session),
-            provider: target_provider,
-        };
-        let paths = self.paths.clone();
-        let config = self.config.clone();
-        let tx = self.worker_tx.clone();
-        let term_size = self.last_pty_size;
-        std::thread::spawn(move || {
-            super::workers::run_create_agent_job(request, paths, config, tx, term_size);
-        });
+        let created = self.create_provider_session_record(&session, target_provider.clone())?;
+        let _ = self.select_session_in_left_pane(&created.id);
+        self.set_info(format!(
+            "Created a stopped {} session on worktree \"{}\". Reconnect it when you want to start using that provider.",
+            target_provider.as_str(),
+            self.session_label(&session),
+        ));
         Ok(())
     }
 
@@ -1853,10 +1957,11 @@ mod tests {
     }
 
     #[test]
-    fn create_provider_session_rejects_running_agent() {
+    fn create_provider_session_allows_running_agent_without_reconnect() {
         let s1 = make_session("s1", "claude", "/tmp/wt/a");
         let project = make_project("project-1", "codex");
         let mut app = test_app_with_sessions(vec![s1], vec![project]);
+        std::fs::create_dir_all("/tmp/wt/a").expect("create worktree");
         app.selected_left = app
             .left_items()
             .iter()
@@ -1865,7 +1970,15 @@ mod tests {
         mark_active(&mut app, "s1");
 
         app.create_provider_session_on_worktree().unwrap();
-        assert!(app.status.text().contains("still running"));
+        assert_eq!(app.sessions.len(), 2);
+        let created = app
+            .sessions
+            .iter()
+            .find(|session| session.id != "s1")
+            .expect("new sibling session");
+        assert_eq!(created.provider.as_str(), "codex");
+        assert_eq!(created.status, SessionStatus::Exited);
+        assert!(!app.providers.contains_key(&created.id));
     }
 
     #[test]
@@ -1886,7 +1999,7 @@ mod tests {
     }
 
     #[test]
-    fn create_provider_session_rejects_duplicate() {
+    fn create_provider_session_selects_existing_duplicate() {
         let s1 = make_session("s1", "claude", "/tmp/wt/a");
         let s2 = make_session("s2", "codex", "/tmp/wt/a");
         let project = make_project("project-1", "codex");
@@ -1901,8 +2014,11 @@ mod tests {
             .unwrap_or(0);
 
         app.create_provider_session_on_worktree().unwrap();
-        // Should reject because s2 already uses codex on the same worktree.
-        assert!(app.status.text().contains("already exists"));
+        assert_eq!(
+            app.selected_session().map(|session| session.id.as_str()),
+            Some("s2")
+        );
+        assert!(app.status.text().contains("has been selected"));
     }
 
     #[test]

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -1055,40 +1055,6 @@ pub(crate) fn run_create_agent_job(
                 true,
             )
         }
-        CreateAgentRequest::NewProviderSession {
-            project,
-            source_session,
-            provider,
-        } => {
-            let worktree_path = PathBuf::from(&source_session.worktree_path);
-            if !worktree_path.exists() {
-                let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
-                    "Worktree for agent \"{}\" no longer exists.",
-                    source_session.branch_name
-                )));
-                return;
-            }
-            let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-                "Creating {} session on existing worktree \"{}\"...",
-                provider.as_str(),
-                source_session.branch_name
-            )));
-            let status_message = format!(
-                "Created {} session on worktree \"{}\" in project \"{}\". The worktree is shared with existing agents.",
-                provider.as_str(),
-                source_session.branch_name,
-                project.name
-            );
-            (
-                project,
-                provider,
-                source_session.source_branch.clone(),
-                status_message,
-                source_session.branch_name.clone(),
-                worktree_path,
-                false,
-            )
-        }
     };
     let repo_path = PathBuf::from(&project.path);
     if owns_worktree {

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -386,6 +386,7 @@ impl App {
                 continue;
             };
             self.providers.remove(session_id);
+            self.running_provider_pins.remove(session_id);
             self.last_pty_activity.remove(session_id);
             logger::info(&format!(
                 "resume args exited without output for agent \"{}\", retrying with regular args",
@@ -420,6 +421,7 @@ impl App {
                 continue;
             }
             self.providers.remove(session_id);
+            self.running_provider_pins.remove(session_id);
             self.last_pty_activity.remove(session_id);
             self.mark_session_status(session_id, SessionStatus::Detached);
         }
@@ -838,6 +840,7 @@ impl App {
                 continue;
             };
             self.providers.remove(&session_id);
+            self.running_provider_pins.remove(&session_id);
             self.last_pty_activity.remove(&session_id);
             logger::info(&format!(
                 "resume args produced no visible output for agent \"{}\" within timeout, retrying with regular args",

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -12,12 +12,12 @@ pub enum Action {
     NewAgent,
     ForkAgent,
     NewProviderSession,
+    ChangeAgentProvider,
     FocusAgent,
     OpenProjectBrowser,
     CopyPath,
     OpenWorktreeInEditor,
     ChooseWorktreeEditor,
-    CycleProvider,
     RefreshProject,
     ReconnectAgent,
     DeleteSession,
@@ -186,12 +186,12 @@ impl Action {
             Action::NewAgent => "new_agent",
             Action::ForkAgent => "fork_agent",
             Action::NewProviderSession => "new_provider_session",
+            Action::ChangeAgentProvider => "change_agent_provider",
             Action::FocusAgent => "focus_agent",
             Action::OpenProjectBrowser => "open_project_browser",
             Action::CopyPath => "copy_path",
             Action::OpenWorktreeInEditor => "open_worktree_in_editor",
             Action::ChooseWorktreeEditor => "choose_worktree_editor",
-            Action::CycleProvider => "cycle_provider",
             Action::RefreshProject => "refresh_project",
             Action::ReconnectAgent => "reconnect_agent",
             Action::DeleteSession => "delete_session",
@@ -268,6 +268,9 @@ impl Action {
             Action::NewProviderSession => {
                 "Create a new session with a different provider on the selected agent's worktree."
             }
+            Action::ChangeAgentProvider => {
+                "Switch the selected agent worktree to a different provider session."
+            }
             Action::FocusAgent => "Focus the selected agent's output pane.",
             Action::OpenProjectBrowser => "Open the project browser.",
             Action::CopyPath => "Copy the selected agent's worktree path.",
@@ -277,7 +280,6 @@ impl Action {
             Action::ChooseWorktreeEditor => {
                 "Open a picker and choose which editor should open the selected agent worktree."
             }
-            Action::CycleProvider => "Cycle the default provider for the selected project.",
             Action::RefreshProject => "Git pull the selected project checkout.",
             Action::ReconnectAgent => "Restart the CLI for the selected agent.",
             Action::DeleteSession => "Delete the selected session and worktree.",
@@ -358,12 +360,12 @@ impl Action {
             | Action::NewAgent
             | Action::ForkAgent
             | Action::NewProviderSession
+            | Action::ChangeAgentProvider
             | Action::FocusAgent
             | Action::OpenProjectBrowser
             | Action::CopyPath
             | Action::OpenWorktreeInEditor
             | Action::ChooseWorktreeEditor
-            | Action::CycleProvider
             | Action::RefreshProject
             | Action::InteractAgent
             | Action::ReconnectAgent
@@ -554,6 +556,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
     },
     BindingDef {
+        action: Action::ChangeAgentProvider,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "change-agent-provider",
+            description: "Switch this worktree to a different provider session",
+        }),
+    },
+    BindingDef {
         action: Action::FocusAgent,
         default_keys: &[key!(enter)],
         scopes: &[BindingScope::Left, BindingScope::Center],
@@ -631,20 +644,6 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "open-worktree-with",
             description: "Choose which editor should open the selected agent worktree",
-        }),
-    },
-    BindingDef {
-        action: Action::CycleProvider,
-        default_keys: &[key!(d)],
-        scopes: &[BindingScope::Left],
-        help: Some(HelpEntry {
-            section: "Projects pane",
-            description: "Cycle default provider",
-        }),
-        hint_contexts: &[(HintContext::LeftProject, "Provider")],
-        palette: Some(PaletteEntry {
-            name: "provider",
-            description: "Toggle the selected project's default provider",
         }),
     },
     BindingDef {
@@ -2145,14 +2144,14 @@ mod tests {
     }
 
     #[test]
-    fn filtered_palette_includes_new_provider_session_command() {
+    fn filtered_palette_includes_change_agent_provider_command() {
         let bindings = default_bindings();
         let results = bindings.filtered_palette("provider");
         let names = results
             .iter()
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
-        assert!(names.contains(&"new-provider-session"));
+        assert!(names.contains(&"change-agent-provider"));
     }
 
     #[test]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -11,8 +11,8 @@ pub enum Action {
     ToggleProject,
     NewAgent,
     ForkAgent,
-    NewProviderSession,
     ChangeAgentProvider,
+    ChangeDefaultProvider,
     FocusAgent,
     OpenProjectBrowser,
     CopyPath,
@@ -185,8 +185,8 @@ impl Action {
             Action::ToggleProject => "toggle_project",
             Action::NewAgent => "new_agent",
             Action::ForkAgent => "fork_agent",
-            Action::NewProviderSession => "new_provider_session",
             Action::ChangeAgentProvider => "change_agent_provider",
+            Action::ChangeDefaultProvider => "change_default_provider",
             Action::FocusAgent => "focus_agent",
             Action::OpenProjectBrowser => "open_project_browser",
             Action::CopyPath => "copy_path",
@@ -265,11 +265,11 @@ impl Action {
             Action::ToggleProject => "Collapse or expand the selected project.",
             Action::NewAgent => "Create a new agent session (worktree).",
             Action::ForkAgent => "Fork the selected agent into a fresh worktree and session.",
-            Action::NewProviderSession => {
-                "Create a new session with a different provider on the selected agent's worktree."
-            }
             Action::ChangeAgentProvider => {
-                "Switch the selected agent worktree to a different provider session."
+                "Swap the selected agent worktree to a different provider."
+            }
+            Action::ChangeDefaultProvider => {
+                "Change the default provider used when creating new agent sessions."
             }
             Action::FocusAgent => "Focus the selected agent's output pane.",
             Action::OpenProjectBrowser => "Open the project browser.",
@@ -359,7 +359,6 @@ impl Action {
             | Action::ToggleProject
             | Action::NewAgent
             | Action::ForkAgent
-            | Action::NewProviderSession
             | Action::ChangeAgentProvider
             | Action::FocusAgent
             | Action::OpenProjectBrowser
@@ -426,7 +425,8 @@ impl Action {
             | Action::ToggleGithubIntegration
             | Action::TogglePromptForName
             | Action::TogglePrBannerPosition
-            | Action::ForceReconnectAgent => None,
+            | Action::ForceReconnectAgent
+            | Action::ChangeDefaultProvider => None,
         }
     }
 }
@@ -545,17 +545,6 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
     },
     BindingDef {
-        action: Action::NewProviderSession,
-        default_keys: &[],
-        scopes: &[BindingScope::Left],
-        help: None,
-        hint_contexts: &[],
-        palette: Some(PaletteEntry {
-            name: "new-provider-session",
-            description: "Create a new session with a different provider on this worktree",
-        }),
-    },
-    BindingDef {
         action: Action::ChangeAgentProvider,
         default_keys: &[],
         scopes: &[],
@@ -563,7 +552,18 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[],
         palette: Some(PaletteEntry {
             name: "change-agent-provider",
-            description: "Switch this worktree to a different provider session",
+            description: "Swap this worktree's provider",
+        }),
+    },
+    BindingDef {
+        action: Action::ChangeDefaultProvider,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "change-default-provider",
+            description: "Change the default provider used when creating new sessions",
         }),
     },
     BindingDef {

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -50,9 +50,7 @@ impl StatusLine {
     pub fn text(&self) -> String {
         match self.tone {
             StatusTone::Busy => format!("{} {}", self.spinner_frame(), self.message),
-            StatusTone::Warning => format!("[warning] {}", self.message),
-            StatusTone::Error => format!("[error] {}", self.message),
-            StatusTone::Info => self.message.clone(),
+            StatusTone::Info | StatusTone::Warning | StatusTone::Error => self.message.clone(),
         }
     }
 
@@ -77,10 +75,11 @@ mod tests {
     use super::{StatusLine, StatusTone};
 
     #[test]
-    fn warning_tone_formats_with_warning_prefix() {
+    fn warning_tone_keeps_message_plain() {
         let mut status = StatusLine::new("ready");
         status.warning("something changed");
         assert_eq!(status.tone(), StatusTone::Warning);
-        assert_eq!(status.text(), "[warning] something changed");
+        // The warning colour carries the meaning — no "[warning]" prefix.
+        assert_eq!(status.text(), "something changed");
     }
 }


### PR DESCRIPTION
Replaces per-provider sibling sessions with an in-place provider swap, keeping dux's one-agent-per-worktree invariant.

`change-agent-provider` now updates the selected session's provider in place. The swap is always recorded; if the agent is still running, dux additionally warns the user that the running PTY hasn't caught up yet, and the new provider takes effect once the agent is exited and relaunched. Per-provider resume is preserved via the existing `started_providers` tracking, so flipping back to a provider that was used earlier on the same worktree reconnects with its `resume_args` instead of starting fresh.

Also adds `change-default-provider` (palette-only) for changing the global default provider used by newly created sessions, and a `default provider: X / current provider: Y` header label that surfaces the swap at a glance. Removes the now-redundant `new-provider-session` palette action; `fork-agent` still handles the "branch off this worktree" case.

README updated to document the new flow.