### PR TITLE
Close diff view when switching agents in the left pane

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -394,16 +394,19 @@ impl App {
                 Action::MoveDown => {
                     if self.selected_left + 1 < item_count {
                         self.selected_left += 1;
+                        self.close_diff_view();
                         self.reload_changed_files();
                         self.update_missing_project_warning();
                     } else if self.has_terminal_items() {
                         // Jump to terminals section.
                         self.left_section = LeftSection::Terminals;
                         self.selected_terminal_index = 0;
+                        self.close_diff_view();
                     }
                 }
                 Action::MoveUp if self.selected_left > 0 => {
                     self.selected_left -= 1;
+                    self.close_diff_view();
                     self.reload_changed_files();
                     self.update_missing_project_warning();
                 }
@@ -469,6 +472,7 @@ impl App {
                         let item_count = self.left_items().len();
                         if item_count > 0 {
                             self.selected_left = item_count - 1;
+                            self.close_diff_view();
                         }
                     }
                 }
@@ -3074,6 +3078,7 @@ impl App {
         self.fullscreen_overlay = FullscreenOverlay::None;
         if self.selected_left != index {
             self.selected_left = index;
+            self.close_diff_view();
             self.reload_changed_files();
         }
     }
@@ -6200,6 +6205,87 @@ mod tests {
             CenterMode::Diff { scroll, .. } => assert_eq!(scroll, 3),
             _ => panic!("expected diff mode"),
         }
+    }
+
+    fn open_fake_diff(app: &mut App) {
+        app.center_mode = CenterMode::Diff {
+            lines: Arc::new(vec![Line::from("diff")]),
+            scroll: 0,
+            gutter_width: 0,
+            worktree_path: String::new(),
+            rel_path: String::new(),
+        };
+    }
+
+    #[test]
+    fn left_move_down_closes_open_diff_when_moving_between_agents() {
+        let mut app = test_app(default_bindings());
+        let now = Utc::now();
+        app.sessions.push(AgentSession {
+            id: "session-2".to_string(),
+            project_id: app.projects[0].id.clone(),
+            project_path: Some(app.projects[0].path.clone()),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "agent-branch-2".to_string(),
+            worktree_path: app.paths.worktrees_root.to_string_lossy().to_string(),
+            title: None,
+            started_providers: Vec::new(),
+            status: SessionStatus::Detached,
+            created_at: now,
+            updated_at: now,
+        });
+        app.rebuild_left_items();
+        app.selected_left = 1;
+        app.focus = FocusPane::Left;
+        open_fake_diff(&mut app);
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.selected_left, 2);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+    }
+
+    #[test]
+    fn left_move_up_closes_open_diff() {
+        let mut app = test_app(default_bindings());
+        app.selected_left = 1;
+        app.focus = FocusPane::Left;
+        open_fake_diff(&mut app);
+
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.selected_left, 0);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+    }
+
+    #[test]
+    fn mouse_click_different_left_row_closes_open_diff() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        open_fake_diff(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 1));
+
+        assert_eq!(app.selected_left, 0);
+        assert!(matches!(app.center_mode, CenterMode::Agent));
+    }
+
+    #[test]
+    fn mouse_click_same_left_row_preserves_open_diff() {
+        let mut app = test_app(default_bindings());
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+        app.focus = FocusPane::Left;
+        open_fake_diff(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 2));
+
+        assert_eq!(app.selected_left, 1);
+        assert!(matches!(app.center_mode, CenterMode::Diff { .. }));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1374,6 +1374,17 @@ impl App {
         false
     }
 
+    /// Closes the diff overlay if one is open, leaving other state (focus,
+    /// input target, status line) untouched. Called when the left-pane
+    /// selection moves to a different item so the middle pane falls back
+    /// to the newly-selected agent's terminal. Silent by design: the user
+    /// moved a cursor, they did not dismiss a dialog.
+    pub(crate) fn close_diff_view(&mut self) {
+        if matches!(self.center_mode, CenterMode::Diff { .. }) {
+            self.center_mode = CenterMode::Agent;
+        }
+    }
+
     /// Returns the current braille spinner frame index based on wall-clock
     /// time (80ms per frame). Unlike `tick_count`, this stays constant-speed
     /// regardless of event loop frequency.


### PR DESCRIPTION
When the diff overlay is open for one agent and the user moves the left-pane selection to a different item, the diff stays on screen showing the previous session's file. The right pane dutifully reloads its changed-files list for the new selection, but the middle pane goes stale until the user presses `Esc` manually. That mismatch is the bug this PR fixes — the diff is tied to a specific worktree + file, and moving to another agent invalidates both.

The change adds a small `close_diff_view()` helper on `App` that flips `CenterMode::Diff` back to `CenterMode::Agent` without touching focus, input target, or status line. It's invoked at every left-pane selection-change site: `MoveDown` and `MoveUp` in `handle_left_key`, the terminal-section `MoveUp` that wraps back into the Projects section, and `set_left_selection()` for mouse clicks. The existing `selected_left != index` guard in the mouse path ensures a repeat click on the already-selected row leaves the diff open — only a *different* row closes it. Activation (Enter) wasn't touched because `activate_selected_left_item()` already sets `CenterMode::Agent` directly.

The helper is deliberately separate from the existing `close_top_overlay()`: that one narrates the dismissal via the status line and jumps focus to the Files pane, which is the right behavior for an `Esc` press but wrong for cursor navigation. Four unit tests cover the arrow-key and mouse paths, including the no-op mouse click that must preserve the open diff.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (654 passing)
- [ ] Manual: open diff on session A, `j`/`k` to session B — middle pane flips to agent output
- [ ] Manual: open diff on session A, mouse-click a different left row — middle pane flips to agent output
- [ ] Manual: open diff, click the same row again — diff stays open
