### PR TITLE
Clarify global and project provider defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Set `resume_args` and dux can reconnect to detached or crashed sessions. Omit it
 Switch providers from the command palette. dux sticks to one agent per worktree, so provider changes happen in place:
 
 - **`change-agent-provider`** swaps the *selected* worktree's provider on next launch. If the agent is still running, dux records your choice and warns you — the running agent keeps going until you exit and relaunch it, at which point it spawns with the new provider. If you've used that provider on this worktree before, dux passes its `resume_args` so you pick up the previous conversation instead of starting fresh.
-- **`change-default-provider`** picks which provider *new* agent sessions should spawn with. Existing agents keep their current provider; to move a running one, use `change-agent-provider` after stopping it.
+- **`change-default-provider`** picks the global fallback provider for *new* agent sessions in projects without a project-specific override. Existing agents keep their current provider; to move a running one, use `change-agent-provider` after stopping it.
+- **`change-project-default-provider`** picks the provider future agents should use for the selected project only, or lets that project inherit the global fallback again.
 
-The header shows `default provider: …` for the project and adds `current provider: …` when the selected agent is using a different one, so you always know which CLI you're talking to.
+The header shows `default provider: …` when the selected project inherits the global fallback. If a project has its own override, the header shows `project provider: …` plus `global default: …`. It also adds `current provider: …` when the selected agent is using a different one, so you always know which CLI you're talking to.
 
 You can also set a default per-project in the config file, which wins over the global default for that one project.
 

--- a/src/app/components/button.rs
+++ b/src/app/components/button.rs
@@ -74,6 +74,8 @@ pub(crate) enum ButtonPressedTarget {
     ChangeAgentProviderApply,
     ChangeDefaultProviderCancel,
     ChangeDefaultProviderApply,
+    ChangeProjectDefaultProviderCancel,
+    ChangeProjectDefaultProviderApply,
     RuntimeKillCancel,
     RuntimeKillHovered,
     RuntimeKillSelected,

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -90,6 +90,9 @@ enum PromptMouseTarget {
     ChangeDefaultProviderItem(usize),
     ChangeDefaultProviderCancel,
     ChangeDefaultProviderApply,
+    ChangeProjectDefaultProviderItem(usize),
+    ChangeProjectDefaultProviderCancel,
+    ChangeProjectDefaultProviderApply,
     RuntimeKillInput,
     RuntimeKillItem(usize),
     RuntimeKillCancel,
@@ -135,6 +138,12 @@ impl ButtonPressedTarget {
             }
             PromptMouseTarget::ChangeDefaultProviderApply => {
                 Some(ButtonPressedTarget::ChangeDefaultProviderApply)
+            }
+            PromptMouseTarget::ChangeProjectDefaultProviderCancel => {
+                Some(ButtonPressedTarget::ChangeProjectDefaultProviderCancel)
+            }
+            PromptMouseTarget::ChangeProjectDefaultProviderApply => {
+                Some(ButtonPressedTarget::ChangeProjectDefaultProviderApply)
             }
             PromptMouseTarget::RuntimeKillCancel => Some(ButtonPressedTarget::RuntimeKillCancel),
             PromptMouseTarget::RuntimeKillHovered => Some(ButtonPressedTarget::RuntimeKillHovered),
@@ -190,6 +199,7 @@ impl ButtonPressedTarget {
             | PromptMouseTarget::ChangeThemeItem(_)
             | PromptMouseTarget::ChangeAgentProviderItem(_)
             | PromptMouseTarget::ChangeDefaultProviderItem(_)
+            | PromptMouseTarget::ChangeProjectDefaultProviderItem(_)
             | PromptMouseTarget::RuntimeKillInput
             | PromptMouseTarget::RuntimeKillItem(_)
             | PromptMouseTarget::Checkbox(_)
@@ -2199,6 +2209,59 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ChangeProjectDefaultProvider(prompt) = &mut self.prompt {
+            let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
+            let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let is_space = key.code == KeyCode::Char(' ');
+            let reverse_tab = key.code == KeyCode::BackTab;
+
+            if matches!(palette_action.or(dialog_action), Some(Action::CloseOverlay)) {
+                self.prompt = PromptState::None;
+                return Ok(false);
+            }
+
+            if reverse_tab {
+                prompt.focus = Self::next_change_default_provider_focus(prompt.focus, false);
+                return Ok(false);
+            }
+
+            match prompt.focus {
+                ChangeDefaultProviderFocus::List => match palette_action.or(dialog_action) {
+                    Some(Action::MoveDown) if prompt.selected + 1 < prompt.options.len() => {
+                        prompt.selected += 1;
+                    }
+                    Some(Action::MoveUp) if prompt.selected > 0 => {
+                        prompt.selected -= 1;
+                    }
+                    Some(Action::Confirm) => {
+                        self.apply_change_project_default_provider()?;
+                    }
+                    Some(Action::ToggleSelection) => {
+                        prompt.focus = Self::next_change_default_provider_focus(prompt.focus, true);
+                    }
+                    _ => {}
+                },
+                ChangeDefaultProviderFocus::Cancel | ChangeDefaultProviderFocus::Apply => {
+                    if matches!(dialog_action, Some(Action::ToggleSelection)) {
+                        prompt.focus = Self::next_change_default_provider_focus(prompt.focus, true);
+                        return Ok(false);
+                    }
+                    if matches!(dialog_action, Some(Action::Confirm)) || is_space {
+                        match prompt.focus {
+                            ChangeDefaultProviderFocus::Cancel => {
+                                self.prompt = PromptState::None;
+                            }
+                            ChangeDefaultProviderFocus::Apply => {
+                                self.apply_change_project_default_provider()?;
+                            }
+                            ChangeDefaultProviderFocus::List => {}
+                        }
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ChangeTheme(prompt) = &mut self.prompt {
             let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
             let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
@@ -2993,6 +3056,23 @@ impl App {
                     None
                 }
             }
+            OverlayMouseLayout::ChangeProjectDefaultProvider {
+                list,
+                items,
+                offset,
+                cancel_button,
+                apply_button,
+            } => {
+                if let Some(index) = Self::overlay_row_at(list, offset, items, column, row) {
+                    Some(PromptMouseTarget::ChangeProjectDefaultProviderItem(index))
+                } else if contains_point(cancel_button, column, row) {
+                    Some(PromptMouseTarget::ChangeProjectDefaultProviderCancel)
+                } else if contains_point(apply_button, column, row) {
+                    Some(PromptMouseTarget::ChangeProjectDefaultProviderApply)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::KillRunning {
                 input,
                 list,
@@ -3699,6 +3779,20 @@ impl App {
         }
     }
 
+    fn set_change_project_default_provider_selection(&mut self, index: usize) {
+        let count = match &self.prompt {
+            PromptState::ChangeProjectDefaultProvider(prompt) => prompt.options.len(),
+            _ => 0,
+        };
+        if count == 0 {
+            return;
+        }
+        if let PromptState::ChangeProjectDefaultProvider(prompt) = &mut self.prompt {
+            prompt.selected = index.min(count.saturating_sub(1));
+            prompt.focus = ChangeDefaultProviderFocus::List;
+        }
+    }
+
     fn resolve_confirm_delete_agent(&mut self, confirm: bool) -> bool {
         let (session_id, delete_worktree) = match &self.prompt {
             PromptState::ConfirmDeleteAgent {
@@ -4197,6 +4291,14 @@ impl App {
                     self.set_error(format!("{err:#}"));
                 }
             }
+            PromptMouseTarget::ChangeProjectDefaultProviderItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
+                self.set_change_project_default_provider_selection(index);
+                if double_click && let Err(err) = self.apply_change_project_default_provider() {
+                    self.set_error(format!("{err:#}"));
+                }
+            }
             PromptMouseTarget::RuntimeKillInput => {
                 self.set_kill_running_search_cursor_from_mouse(mouse.column);
             }
@@ -4221,6 +4323,8 @@ impl App {
             | PromptMouseTarget::ChangeAgentProviderApply
             | PromptMouseTarget::ChangeDefaultProviderCancel
             | PromptMouseTarget::ChangeDefaultProviderApply
+            | PromptMouseTarget::ChangeProjectDefaultProviderCancel
+            | PromptMouseTarget::ChangeProjectDefaultProviderApply
             | PromptMouseTarget::RuntimeKillCancel
             | PromptMouseTarget::RuntimeKillHovered
             | PromptMouseTarget::RuntimeKillSelected
@@ -4274,6 +4378,16 @@ impl App {
             }
             ButtonPressedTarget::ChangeDefaultProviderApply => {
                 if let Err(err) = self.apply_change_default_provider() {
+                    self.set_error(format!("{err:#}"));
+                }
+                false
+            }
+            ButtonPressedTarget::ChangeProjectDefaultProviderCancel => {
+                self.prompt = PromptState::None;
+                false
+            }
+            ButtonPressedTarget::ChangeProjectDefaultProviderApply => {
+                if let Err(err) = self.apply_change_project_default_provider() {
                     self.set_error(format!("{err:#}"));
                 }
                 false
@@ -10285,7 +10399,7 @@ cyan = "#00ffff"
         assert!(
             app.status
                 .text()
-                .contains("Default provider changed to claude")
+                .contains("Global default provider changed to claude")
         );
     }
 
@@ -10293,6 +10407,13 @@ cyan = "#00ffff"
     fn change_default_provider_rejects_current_selection_without_mutating_config() {
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: None,
+            commit_prompt: None,
+        });
 
         app.open_change_default_provider_prompt()
             .expect("open default provider picker");
@@ -10315,16 +10436,149 @@ cyan = "#00ffff"
         assert!(
             app.status
                 .text()
-                .contains("is already the default provider")
+                .contains("is already the global default provider")
         );
     }
 
     #[test]
-    fn header_shows_current_provider_when_it_differs_from_project_default() {
+    fn change_project_default_provider_updates_selected_project_only() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "codex".to_string();
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: None,
+            commit_prompt: None,
+        });
+
+        let pinned = Project {
+            id: "project-2".to_string(),
+            name: "pinned".to_string(),
+            path: app.paths.root.join("pinned").display().to_string(),
+            default_provider: ProviderKind::from_str("gemini"),
+            current_branch: "main".to_string(),
+            path_missing: false,
+        };
+        app.config.projects.push(ProjectConfig {
+            id: pinned.id.clone(),
+            path: pinned.path.clone(),
+            name: Some(pinned.name.clone()),
+            default_provider: Some("gemini".to_string()),
+            commit_prompt: None,
+        });
+        app.projects.push(pinned);
+
+        app.open_change_project_default_provider_prompt()
+            .expect("open project provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeProjectDefaultProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| {
+                        option
+                            .provider
+                            .as_ref()
+                            .map(|provider| provider.as_str() == "claude")
+                            .unwrap_or(false)
+                    })
+                    .expect("claude option present");
+            }
+            other => panic!("expected change-project-default-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_project_default_provider()
+            .expect("apply project provider");
+
+        assert_eq!(app.config.defaults.provider, "codex");
+        let persisted = crate::config::ensure_config(&app.paths).expect("reload config");
+        let inherited_cfg = persisted
+            .projects
+            .iter()
+            .find(|project| project.id == "project-1")
+            .expect("project-1 config");
+        assert_eq!(inherited_cfg.default_provider.as_deref(), Some("claude"));
+
+        let pinned_cfg = persisted
+            .projects
+            .iter()
+            .find(|project| project.id == "project-2")
+            .expect("project-2 config");
+        assert_eq!(pinned_cfg.default_provider.as_deref(), Some("gemini"));
+
+        let project = app
+            .projects
+            .iter()
+            .find(|project| project.id == "project-1")
+            .expect("updated project");
+        assert_eq!(project.default_provider.as_str(), "claude");
+
+        assert!(
+            app.status
+                .text()
+                .contains("Project provider for \"demo\" changed to claude")
+        );
+    }
+
+    #[test]
+    fn change_project_default_provider_can_revert_to_global_default() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "codex".to_string();
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: Some("gemini".to_string()),
+            commit_prompt: None,
+        });
+        app.projects[0].default_provider = ProviderKind::from_str("gemini");
+
+        app.open_change_project_default_provider_prompt()
+            .expect("open project provider picker");
+        match &mut app.prompt {
+            PromptState::ChangeProjectDefaultProvider(prompt) => {
+                prompt.selected = prompt
+                    .options
+                    .iter()
+                    .position(|option| option.provider.is_none())
+                    .expect("inherit option present");
+            }
+            other => panic!("expected change-project-default-provider prompt, got {other:?}"),
+        }
+
+        app.apply_change_project_default_provider()
+            .expect("apply inherit global");
+
+        let persisted = crate::config::ensure_config(&app.paths).expect("reload config");
+        let config = persisted
+            .projects
+            .iter()
+            .find(|project| project.id == "project-1")
+            .expect("project-1 config");
+        assert_eq!(config.default_provider, None);
+        assert_eq!(app.projects[0].default_provider.as_str(), "codex");
+        assert!(
+            app.status
+                .text()
+                .contains("\"demo\" now inherits the global default provider (codex)")
+        );
+    }
+
+    #[test]
+    fn header_shows_project_and_global_provider_when_project_is_overridden() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
         let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "claude".to_string();
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: Some("codex".to_string()),
+            commit_prompt: None,
+        });
         app.projects[0].default_provider = ProviderKind::from_str("codex");
         app.sessions[0].provider = ProviderKind::from_str("gemini");
         app.rebuild_left_items();
@@ -10348,8 +10602,12 @@ cyan = "#00ffff"
             .collect();
 
         assert!(
-            rendered.contains("default provider: codex"),
-            "expected default provider label, got: {rendered}"
+            rendered.contains("project provider: codex"),
+            "expected project provider label, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("global default: claude"),
+            "expected global default label, got: {rendered}"
         );
         assert!(
             rendered.contains("current provider: gemini"),
@@ -10358,11 +10616,19 @@ cyan = "#00ffff"
     }
 
     #[test]
-    fn header_omits_current_provider_when_session_matches_project_default() {
+    fn header_uses_default_provider_label_when_project_inherits_global_default() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
         let mut app = test_app(default_bindings());
+        app.config.defaults.provider = "codex".to_string();
+        app.config.projects.push(ProjectConfig {
+            id: app.projects[0].id.clone(),
+            path: app.projects[0].path.clone(),
+            name: Some(app.projects[0].name.clone()),
+            default_provider: None,
+            commit_prompt: None,
+        });
         app.projects[0].default_provider = ProviderKind::from_str("codex");
         app.sessions[0].provider = ProviderKind::from_str("codex");
         app.rebuild_left_items();
@@ -10388,6 +10654,14 @@ cyan = "#00ffff"
         assert!(
             rendered.contains("default provider: codex"),
             "expected default provider label, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("project provider:"),
+            "project provider label should be hidden when inheriting global default, got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("global default:"),
+            "global default label should be hidden when the project inherits it, got: {rendered}"
         );
         assert!(
             !rendered.contains("current provider:"),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -460,6 +460,24 @@ pub(crate) struct ChangeDefaultProviderPrompt {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct ChangeProjectDefaultProviderOption {
+    pub(crate) provider: Option<ProviderKind>,
+    pub(crate) is_current: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChangeProjectDefaultProviderPrompt {
+    pub(crate) project_id: String,
+    pub(crate) project_name: String,
+    pub(crate) current: ProviderKind,
+    pub(crate) global_default: ProviderKind,
+    pub(crate) inherits_global_default: bool,
+    pub(crate) options: Vec<ChangeProjectDefaultProviderOption>,
+    pub(crate) selected: usize,
+    pub(crate) focus: ChangeDefaultProviderFocus,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ChangeThemePrompt {
     pub(crate) options: Vec<crate::theme::ThemeListing>,
     pub(crate) selected: usize,
@@ -520,6 +538,7 @@ pub(crate) enum PromptState {
     },
     ChangeAgentProvider(ChangeAgentProviderPrompt),
     ChangeDefaultProvider(ChangeDefaultProviderPrompt),
+    ChangeProjectDefaultProvider(ChangeProjectDefaultProviderPrompt),
     ChangeTheme(ChangeThemePrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
@@ -833,6 +852,13 @@ pub(crate) enum OverlayMouseLayout {
         apply_button: Rect,
     },
     ChangeDefaultProvider {
+        list: Rect,
+        items: usize,
+        offset: usize,
+        cancel_button: Rect,
+        apply_button: Rect,
+    },
+    ChangeProjectDefaultProvider {
         list: Rect,
         items: usize,
         offset: usize,
@@ -1589,6 +1615,7 @@ impl App {
             "fork-agent" => self.fork_selected_session(),
             "change-agent-provider" => self.open_change_agent_provider_prompt(),
             "change-default-provider" => self.open_change_default_provider_prompt(),
+            "change-project-default-provider" => self.open_change_project_default_provider_prompt(),
             "change-theme" => self.open_change_theme_prompt(),
             "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
@@ -1891,6 +1918,33 @@ impl App {
             }),
             None => None,
         }
+    }
+
+    pub(crate) fn project_config(&self, project_id: &str) -> Option<&ProjectConfig> {
+        self.config
+            .projects
+            .iter()
+            .find(|project| project.id == project_id)
+    }
+
+    pub(crate) fn project_config_mut(&mut self, project_id: &str) -> Option<&mut ProjectConfig> {
+        self.config
+            .projects
+            .iter_mut()
+            .find(|project| project.id == project_id)
+    }
+
+    pub(crate) fn project_explicit_default_provider(
+        &self,
+        project_id: &str,
+    ) -> Option<ProviderKind> {
+        self.project_config(project_id)
+            .and_then(|project| project.default_provider.as_deref())
+            .map(ProviderKind::from_str)
+    }
+
+    pub(crate) fn project_uses_explicit_default_provider(&self, project_id: &str) -> bool {
+        self.project_explicit_default_provider(project_id).is_some()
     }
 
     pub(crate) fn selected_session(&self) -> Option<&AgentSession> {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -117,7 +117,7 @@ const WELCOME_TIPS: &[fn(&RuntimeBindings) -> String] = &[
         "dux remembers which providers you've run on each worktree. Swap away and back, and each one picks up right where you left it.".into()
     },
     |_b| {
-        "New agents spawning with the wrong CLI? Run `change-default-provider` in the palette to swap the default. Existing agents stay on their current brain.".into()
+        "Need to change which CLI new agents use? `change-default-provider` updates the global fallback. `change-project-default-provider` overrides just one project.".into()
     },
     |_b| {
         "Swapped providers while an agent was still running? The sidebar shows `(old → new)` until you exit and relaunch. dux queues the swap, you run the show.".into()
@@ -474,14 +474,31 @@ impl App {
                 ));
             }
             spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+            let has_project_override = self.project_uses_explicit_default_provider(&project.id);
+            let provider_label = if has_project_override {
+                "project provider: "
+            } else {
+                "default provider: "
+            };
             spans.push(Span::styled(
-                "default provider: ",
+                provider_label,
                 Style::default().fg(label_fg).bg(bg),
             ));
             spans.push(Span::styled(
                 project.default_provider.as_str().to_string(),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ));
+            if has_project_override {
+                spans.push(Span::styled(" ╱ ", Style::default().fg(sep_fg).bg(bg)));
+                spans.push(Span::styled(
+                    "global default: ",
+                    Style::default().fg(label_fg).bg(bg),
+                ));
+                spans.push(Span::styled(
+                    self.config.default_provider().as_str().to_string(),
+                    Style::default().fg(self.theme.branch_fg).bg(bg),
+                ));
+            }
             if let Some(session) = self.selected_session()
                 && session.provider != project.default_provider
             {
@@ -2777,7 +2794,7 @@ impl App {
                 let detail_lines = vec![
                     Line::from(vec![
                         Span::styled(
-                            " Current default: ",
+                            " Current global default: ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ),
                         Span::styled(
@@ -2788,7 +2805,7 @@ impl App {
                         ),
                     ]),
                     Line::from(vec![Span::styled(
-                        " New sessions will use the chosen provider. Existing agents keep their current provider.",
+                        " Projects with an explicit project provider keep their override. Existing agents keep their current provider.",
                         Style::default().fg(self.theme.hint_desc_fg),
                     )]),
                 ];
@@ -2811,7 +2828,7 @@ impl App {
                     .iter()
                     .map(|option| {
                         let status = if option.is_current {
-                            "current default"
+                            "current global default"
                         } else {
                             "available"
                         };
@@ -2888,7 +2905,7 @@ impl App {
                     ))
                     .render(frame, cancel_area, &self.theme);
 
-                Button::new("Set Default")
+                Button::new("Set Global")
                     .kind(ButtonKind::Confirm)
                     .state(button_state_for(
                         ButtonPressedTarget::ChangeDefaultProviderApply,
@@ -2899,6 +2916,223 @@ impl App {
                     .render(frame, apply_area, &self.theme);
 
                 self.overlay_layout.active = OverlayMouseLayout::ChangeDefaultProvider {
+                    list: list_inner,
+                    items: prompt.options.len(),
+                    offset: state.offset(),
+                    cancel_button: cancel_area,
+                    apply_button: apply_area,
+                };
+            }
+            PromptState::ChangeProjectDefaultProvider(prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(64, 60, frame.area());
+                self.clear_overlay_area(frame, area);
+
+                let move_down = self.bindings.label_for(Action::MoveDown);
+                let move_up = self.bindings.label_for(Action::MoveUp);
+                let toggle = self.bindings.label_for(Action::ToggleSelection);
+                let confirm = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+
+                let mut bottom_spans = vec![Span::raw(" ")];
+                bottom_spans.extend(self.theme.key_badge_default(&move_down));
+                bottom_spans.push(Span::styled(
+                    "/",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&move_up));
+                bottom_spans.push(Span::styled(
+                    " move  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&toggle));
+                bottom_spans.push(Span::styled(
+                    " buttons  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&confirm));
+                bottom_spans.push(Span::styled(
+                    " choose  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let [details_area, list_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(5),
+                        Constraint::Min(6),
+                        Constraint::Length(3),
+                    ])
+                    .areas(area);
+
+                let project_mode = if prompt.inherits_global_default {
+                    "inherits global default"
+                } else {
+                    "project override"
+                };
+                let detail_lines = vec![
+                    Line::from(vec![
+                        Span::styled(" Project: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::styled(
+                            prompt.project_name.clone(),
+                            Style::default()
+                                .fg(self.theme.text_fg)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled(
+                            " Current provider: ",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ),
+                        Span::styled(
+                            format!("{} ({project_mode})", prompt.current.as_str()),
+                            Style::default()
+                                .fg(self.theme.text_fg)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled(
+                            " Global default: ",
+                            Style::default().fg(self.theme.hint_desc_fg),
+                        ),
+                        Span::styled(
+                            prompt.global_default.as_str().to_string(),
+                            Style::default()
+                                .fg(self.theme.text_fg)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![Span::styled(
+                        " Choose \"inherit global default\" to remove the project-specific override. Existing agents keep their current provider.",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )]),
+                ];
+                Paragraph::new(detail_lines)
+                    .block(
+                        self.themed_overlay_block("Change Project Provider")
+                            .title_bottom(Line::from(bottom_spans)),
+                    )
+                    .render(details_area, frame.buffer_mut());
+
+                let provider_col = prompt
+                    .options
+                    .iter()
+                    .map(|option| match &option.provider {
+                        Some(provider) => provider.as_str().chars().count(),
+                        None => "inherit global default".chars().count(),
+                    })
+                    .max()
+                    .unwrap_or(0)
+                    .max(8);
+                let items = prompt
+                    .options
+                    .iter()
+                    .map(|option| {
+                        let name = match &option.provider {
+                            Some(provider) => provider.as_str().to_string(),
+                            None => "inherit global default".to_string(),
+                        };
+                        let status = match (&option.provider, option.is_current) {
+                            (None, true) => "current setting",
+                            (None, false) => "remove project override",
+                            (Some(_), true) => "current project override",
+                            (Some(provider), false)
+                                if provider.as_str() == prompt.global_default.as_str() =>
+                            {
+                                "matches global default"
+                            }
+                            _ => "available",
+                        };
+                        let name = format!("{name:width$}", width = provider_col);
+                        ListItem::new(Line::from(vec![
+                            Span::styled(
+                                name,
+                                Style::default()
+                                    .fg(self.theme.help_section_header_fg)
+                                    .add_modifier(Modifier::BOLD),
+                            ),
+                            Span::styled(
+                                format!("  {status}"),
+                                Style::default().fg(self.theme.hint_desc_fg),
+                            ),
+                        ]))
+                    })
+                    .collect::<Vec<_>>();
+                let mut state = ListState::default().with_selected(Some(
+                    prompt.selected.min(prompt.options.len().saturating_sub(1)),
+                ));
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_style(Style::default().fg(self.theme.overlay_border))
+                    .style(Style::default().bg(self.theme.overlay_bg));
+                let list_inner = list_block.inner(list_area);
+                let highlight_style = if matches!(prompt.focus, ChangeDefaultProviderFocus::List) {
+                    self.theme.selection_style()
+                } else {
+                    Style::default()
+                        .fg(self.theme.help_section_header_fg)
+                        .add_modifier(Modifier::BOLD)
+                };
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(list_block)
+                        .highlight_style(highlight_style),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+
+                let btn_width = 18u16;
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+                let cancel_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let apply_area = Rect {
+                    x: cancel_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                let apply_enabled = prompt
+                    .options
+                    .get(prompt.selected)
+                    .map(|option| !option.is_current)
+                    .unwrap_or(false);
+
+                Button::new("Cancel")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::ChangeProjectDefaultProviderCancel,
+                        self.pressed_button,
+                        matches!(prompt.focus, ChangeDefaultProviderFocus::Cancel),
+                        true,
+                    ))
+                    .render(frame, cancel_area, &self.theme);
+
+                Button::new("Set Project")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::ChangeProjectDefaultProviderApply,
+                        self.pressed_button,
+                        matches!(prompt.focus, ChangeDefaultProviderFocus::Apply),
+                        apply_enabled,
+                    ))
+                    .render(frame, apply_area, &self.theme);
+
+                self.overlay_layout.active = OverlayMouseLayout::ChangeProjectDefaultProvider {
                     list: list_inner,
                     items: prompt.options.len(),
                     offset: state.offset(),

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -956,6 +956,36 @@ impl App {
             .collect()
     }
 
+    fn change_project_default_provider_options(
+        &self,
+        project_id: &str,
+    ) -> Vec<ChangeProjectDefaultProviderOption> {
+        let global_default = self.config.default_provider();
+        let explicit = self.project_explicit_default_provider(project_id);
+        let mut options = vec![ChangeProjectDefaultProviderOption {
+            provider: None,
+            is_current: explicit.is_none(),
+        }];
+        options.extend(self.config.providers.commands.keys().map(|name| {
+            let provider = ProviderKind::new(name.clone());
+            ChangeProjectDefaultProviderOption {
+                is_current: explicit.as_ref() == Some(&provider),
+                provider: Some(provider),
+            }
+        }));
+        if explicit.is_none()
+            && !options
+                .iter()
+                .any(|option| option.provider.as_ref() == Some(&global_default))
+        {
+            options.push(ChangeProjectDefaultProviderOption {
+                provider: Some(global_default),
+                is_current: false,
+            });
+        }
+        options
+    }
+
     pub(crate) fn open_change_default_provider_prompt(&mut self) -> Result<()> {
         if self.config.providers.commands.is_empty() {
             self.set_error("No providers are configured.");
@@ -976,7 +1006,42 @@ impl App {
             focus: ChangeDefaultProviderFocus::List,
         });
         self.set_info(
-            "Choose the default provider for newly created agent sessions. Existing agents keep their current provider.",
+            "Choose the global default provider for newly created agent sessions. Projects with an explicit project provider keep their override, and existing agents keep their current provider.",
+        );
+        Ok(())
+    }
+
+    pub(crate) fn open_change_project_default_provider_prompt(&mut self) -> Result<()> {
+        if self.config.providers.commands.is_empty() {
+            self.set_error("No providers are configured.");
+            return Ok(());
+        }
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+        let options = self.change_project_default_provider_options(&project.id);
+        let selected = options
+            .iter()
+            .position(|option| option.is_current)
+            .unwrap_or(0);
+        let global_default = self.config.default_provider();
+        let inherits_global_default = !self.project_uses_explicit_default_provider(&project.id);
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt =
+            PromptState::ChangeProjectDefaultProvider(ChangeProjectDefaultProviderPrompt {
+                project_id: project.id,
+                project_name: project.name,
+                current: project.default_provider,
+                global_default,
+                inherits_global_default,
+                options,
+                selected,
+                focus: ChangeDefaultProviderFocus::List,
+            });
+        self.set_info(
+            "Choose the selected project's default provider for future agents. Choose \"inherit global default\" to remove a project-specific override. Existing agents keep their current provider.",
         );
         Ok(())
     }
@@ -994,7 +1059,7 @@ impl App {
         self.prompt = PromptState::None;
         if selected.is_current {
             self.set_info(format!(
-                "{} is already the default provider. Pick a different one to change it.",
+                "{} is already the global default provider. Pick a different one to change it.",
                 selected.provider.as_str(),
             ));
             return Ok(());
@@ -1004,16 +1069,84 @@ impl App {
         if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings) {
             self.config.defaults.provider = previous;
             self.set_error(format!(
-                "Couldn't persist the default provider change: {err:#}"
+                "Couldn't persist the global default provider change: {err:#}"
             ));
             return Ok(());
         }
         refresh_project_defaults(&mut self.projects, &self.config);
         self.rebuild_left_items();
         self.set_info(format!(
-            "Default provider changed to {}. New agent sessions will use it; existing agents keep their current provider. Use \"change-agent-provider\" on a session to switch providers for an existing worktree.",
+            "Global default provider changed to {}. New agents in projects without a project-specific override will use it; existing agents keep their current provider. Use \"change-project-default-provider\" to override one project or \"change-agent-provider\" to switch an existing worktree.",
             selected.provider.as_str(),
         ));
+        Ok(())
+    }
+
+    pub(crate) fn apply_change_project_default_provider(&mut self) -> Result<()> {
+        let prompt = match &self.prompt {
+            PromptState::ChangeProjectDefaultProvider(prompt) => prompt.clone(),
+            _ => return Ok(()),
+        };
+        let Some(selected) = prompt.options.get(prompt.selected).cloned() else {
+            self.prompt = PromptState::None;
+            self.set_error("Select a provider first.");
+            return Ok(());
+        };
+        self.prompt = PromptState::None;
+        let previous = self
+            .project_config(&prompt.project_id)
+            .and_then(|project| project.default_provider.clone());
+        if selected.is_current {
+            let message = match selected.provider {
+                Some(provider) => format!(
+                    "{} is already the project provider for \"{}\". Pick a different option to change it.",
+                    provider.as_str(),
+                    prompt.project_name,
+                ),
+                None => format!(
+                    "\"{}\" is already inheriting the global default provider ({}).",
+                    prompt.project_name,
+                    prompt.global_default.as_str(),
+                ),
+            };
+            self.set_info(message);
+            return Ok(());
+        }
+
+        let Some(project_config) = self.project_config_mut(&prompt.project_id) else {
+            self.set_error(format!(
+                "Could not find config for project \"{}\".",
+                prompt.project_name
+            ));
+            return Ok(());
+        };
+        project_config.default_provider =
+            selected.provider.as_ref().map(|p| p.as_str().to_string());
+        if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings) {
+            if let Some(project_config) = self.project_config_mut(&prompt.project_id) {
+                project_config.default_provider = previous;
+            }
+            self.set_error(format!(
+                "Couldn't persist the project provider change: {err:#}"
+            ));
+            return Ok(());
+        }
+
+        refresh_project_defaults(&mut self.projects, &self.config);
+        self.rebuild_left_items();
+        let message = match selected.provider {
+            Some(provider) => format!(
+                "Project provider for \"{}\" changed to {}. Future agents in this project will use it; existing agents keep their current provider.",
+                prompt.project_name,
+                provider.as_str(),
+            ),
+            None => format!(
+                "\"{}\" now inherits the global default provider ({}). Future agents in this project will use it unless you add a project override again.",
+                prompt.project_name,
+                prompt.global_default.as_str(),
+            ),
+        };
+        self.set_info(message);
         Ok(())
     }
 
@@ -1261,8 +1394,14 @@ impl App {
                 if let Some(project) = self.projects.iter().find(|p| p.id == session.project_id)
                     && project.default_provider != session.provider
                 {
+                    let provider_label = if self.project_uses_explicit_default_provider(&project.id)
+                    {
+                        "current project provider"
+                    } else {
+                        "current global default provider"
+                    };
                     msg.push_str(&format!(
-                        " Note: this agent uses {}. Your current default provider is {}.",
+                        " Note: this agent uses {}. Your {provider_label} is {}.",
                         session.provider.as_str(),
                         project.default_provider.as_str(),
                     ));
@@ -1340,8 +1479,14 @@ impl App {
                 if let Some(project) = self.projects.iter().find(|p| p.id == session.project_id)
                     && project.default_provider != session.provider
                 {
+                    let provider_label = if self.project_uses_explicit_default_provider(&project.id)
+                    {
+                        "current project provider"
+                    } else {
+                        "current global default provider"
+                    };
                     msg.push_str(&format!(
-                        " Note: this agent uses {}. Your current default provider is {}.",
+                        " Note: this agent uses {}. Your {provider_label} is {}.",
                         session.provider.as_str(),
                         project.default_provider.as_str(),
                     ));

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -13,6 +13,7 @@ pub enum Action {
     ForkAgent,
     ChangeAgentProvider,
     ChangeDefaultProvider,
+    ChangeProjectDefaultProvider,
     FocusAgent,
     OpenProjectBrowser,
     CopyPath,
@@ -188,6 +189,7 @@ impl Action {
             Action::ForkAgent => "fork_agent",
             Action::ChangeAgentProvider => "change_agent_provider",
             Action::ChangeDefaultProvider => "change_default_provider",
+            Action::ChangeProjectDefaultProvider => "change_project_default_provider",
             Action::FocusAgent => "focus_agent",
             Action::OpenProjectBrowser => "open_project_browser",
             Action::CopyPath => "copy_path",
@@ -271,7 +273,10 @@ impl Action {
                 "Swap the selected agent worktree to a different provider."
             }
             Action::ChangeDefaultProvider => {
-                "Change the default provider used when creating new agent sessions."
+                "Change the global default provider used for new agent sessions in projects without an explicit project override."
+            }
+            Action::ChangeProjectDefaultProvider => {
+                "Change the selected project's default provider used for new agent sessions in that project only."
             }
             Action::FocusAgent => "Focus the selected agent's output pane.",
             Action::OpenProjectBrowser => "Open the project browser.",
@@ -432,6 +437,7 @@ impl Action {
             | Action::TogglePrBannerPosition
             | Action::ForceReconnectAgent
             | Action::ChangeDefaultProvider
+            | Action::ChangeProjectDefaultProvider
             | Action::ChangeTheme => None,
         }
     }
@@ -569,7 +575,18 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         hint_contexts: &[],
         palette: Some(PaletteEntry {
             name: "change-default-provider",
-            description: "Change the default provider used when creating new sessions",
+            description: "Change the global default provider for new agents in projects without a project-specific override",
+        }),
+    },
+    BindingDef {
+        action: Action::ChangeProjectDefaultProvider,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "change-project-default-provider",
+            description: "Change the selected project's default provider for future agents in that project only",
         }),
     },
     BindingDef {
@@ -2169,6 +2186,36 @@ mod tests {
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
         assert!(names.contains(&"change-agent-provider"));
+        assert!(names.contains(&"change-default-provider"));
+        assert!(names.contains(&"change-project-default-provider"));
+    }
+
+    #[test]
+    fn provider_palette_descriptions_clarify_scope() {
+        let bindings = default_bindings();
+        let global = bindings
+            .filtered_palette("change-default-provider")
+            .into_iter()
+            .find(|binding| binding.palette_name == Some("change-default-provider"))
+            .expect("global provider palette entry");
+        assert_eq!(
+            global.palette_description,
+            Some(
+                "Change the global default provider for new agents in projects without a project-specific override"
+            )
+        );
+
+        let project = bindings
+            .filtered_palette("change-project-default-provider")
+            .into_iter()
+            .find(|binding| binding.palette_name == Some("change-project-default-provider"))
+            .expect("project provider palette entry");
+        assert_eq!(
+            project.palette_description,
+            Some(
+                "Change the selected project's default provider for future agents in that project only"
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
This changes the provider-default UX so the global fallback and project-specific overrides are treated as separate concepts. It adds a project-level provider command, clarifies the command palette descriptions, and updates the header and prompt copy so it is clear when a project is inheriting the global fallback versus using its own override.

The behavior for new agents stays precise: changing the global default only affects projects without explicit overrides, and changing a project provider affects only that selected project. Existing sessions keep their current provider.