### PR TITLE
Publish dux through npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,38 @@ permissions:
   contents: write
 
 jobs:
+  prepare-release:
+    name: Prepare release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release_version.outputs.value }}
+      npm_tag: ${{ steps.npm_dist_tag.outputs.value }}
+    steps:
+      - name: Determine release version
+        id: release_version
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            echo "Failed to extract version from ${{ github.event.release.tag_name }}"
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Determine npm dist tag
+        id: npm_dist_tag
+        env:
+          VERSION: ${{ steps.release_version.outputs.value }}
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            echo "value=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build ${{ matrix.archive }}
+    needs: prepare-release
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -47,10 +77,7 @@ jobs:
         run: cargo install cargo-edit --locked
 
       - name: Set version from tag
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
-          cargo set-version "$VERSION"
+        run: cargo set-version "${{ needs.prepare-release.outputs.version }}"
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
@@ -65,6 +92,91 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload ${{ github.event.release.tag_name }} ${{ matrix.archive }}
+
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+          retention-days: 1
+          if-no-files-found: error
+
+  build-npm-package:
+    name: Build npm package
+    needs: [prepare-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Download release archive artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist/artifacts
+          merge-multiple: true
+
+      - name: Build npm package
+        env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+          ARTIFACTS_DIR: dist/artifacts
+        run: node npm/scripts/build_npm_package.mjs
+
+      - name: Upload npm package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          path: dist/npm/dux-npm-*.tgz
+          retention-days: 1
+          if-no-files-found: error
+
+  publish-npm:
+    name: Publish npm package
+    needs: [prepare-release, build-npm-package]
+    if: ${{ needs.build-npm-package.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          scope: "@patrickdappollonio"
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Download npm package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: dist/npm
+
+      - name: Publish to npm
+        env:
+          VERSION: ${{ needs.prepare-release.outputs.version }}
+          NPM_TAG: ${{ needs.prepare-release.outputs.npm_tag }}
+        run: |
+          set -euo pipefail
+          tarball="dist/npm/dux-npm-${VERSION}.tgz"
+          if [[ ! -f "$tarball" ]]; then
+            echo "npm tarball $tarball not found"
+            exit 1
+          fi
+
+          publish_cmd=(npm publish "$tarball" --access public)
+          if [[ -n "$NPM_TAG" ]]; then
+            publish_cmd+=(--tag "$NPM_TAG")
+          fi
+
+          echo "+ ${publish_cmd[*]}"
+          "${publish_cmd[@]}"
 
   upload-install-script:
     name: Upload install script

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/dist
 flamegraph.svg
 perf.data
 perf.data.old

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Every agent runs through a PTY, the same pseudo-terminal your shell uses. That m
 
 ## Install
 
-**Homebrew:**
+**Homebrew (macOS and Linux):**
+
+On macOS, Homebrew is the preferred distribution method. This command installs my tap and then installs dux in one step:
 
 ```bash
 brew install patrickdappollonio/tap/dux
@@ -37,7 +39,9 @@ npm install -g @patrickdappollonio/dux
 dux
 ```
 
-**Shell:**
+**Shell (all platforms):**
+
+The install script autodetects your operating system and architecture, then downloads the matching release archive:
 
 ```bash
 curl -sSfL https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Every agent runs through a PTY, the same pseudo-terminal your shell uses. That m
 brew install patrickdappollonio/tap/dux
 ```
 
+**npm:**
+
+```bash
+npx -y @patrickdappollonio/dux
+```
+
+Or install it globally:
+
+```bash
+npm install -g @patrickdappollonio/dux
+dux
+```
+
 **Shell:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Every agent runs through a PTY, the same pseudo-terminal your shell uses. That m
 
 **Homebrew (macOS and Linux):**
 
-On macOS, Homebrew is the preferred distribution method. This command installs my tap and then installs dux in one step:
+On macOS, Homebrew is the preferred route. This command taps the source and installs dux in one shot, because life's too short for a two-command install:
 
 ```bash
 brew install patrickdappollonio/tap/dux
@@ -28,20 +28,22 @@ brew install patrickdappollonio/tap/dux
 
 **npm:**
 
-```bash
-npx -y @patrickdappollonio/dux
-```
-
-Or install it globally:
+Install dux globally so the CLI lands on your `PATH`. Installing it as a dependency of some random project technically works, but that's not where terminal apps go to be useful:
 
 ```bash
 npm install -g @patrickdappollonio/dux
 dux
 ```
 
+For a one-off run without keeping it around:
+
+```bash
+npx -y @patrickdappollonio/dux
+```
+
 **Shell (all platforms):**
 
-The install script autodetects your operating system and architecture, then downloads the matching release archive:
+The install script sniffs out your operating system and architecture, then grabs the matching release archive. No guessing which tarball has your name on it:
 
 ```bash
 curl -sSfL https://github.com/patrickdappollonio/dux/releases/latest/download/install.sh | bash

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,41 @@
+# dux
+
+<img src="assets/dux-logo.png" width="200" align="right" />
+
+Your AI agents deserve a proper office. **dux** (pronounced "dooks") is a terminal UI that lets you run multiple AI coding agents side by side, each in its own git worktree, with full companion terminals, macros, commit generation, and a command palette that knows more tricks than you do.
+
+No protocol layers. No adapters. No JSON-RPC. Just real CLIs running in real terminals.
+
+dux is fast and keeps resource usage low, leaving more RAM for Claude, Codex, Gemini, OpenCode, or any other agent CLI you bring.
+
+## Why dux?
+
+Most AI coding tools give you one agent in one directory. dux gives you multiple agents across multiple worktrees, all visible at once. Spawn agents on separate branches, let them work in parallel, fork a session to try a different approach, and open companion terminals next to your agents for builds, tests, or manual inspection.
+
+Every agent runs through a PTY, the same pseudo-terminal your shell uses. Your MCP servers, hooks, skills, slash commands, and permission dialogs keep working because dux runs the real CLI tools you already use.
+
+## Install with npm
+
+Run dux directly with npx:
+
+```bash
+npx -y @patrickdappollonio/dux
+```
+
+Or install it globally:
+
+```bash
+npm install -g @patrickdappollonio/dux
+dux
+```
+
+## Prerequisites
+
+- **`git`** is required because dux is built around git worktrees.
+- **`gh` CLI** is optional. If authenticated, dux can pull PR statuses and check details inside the interface.
+
+## Documentation
+
+The full README, release downloads, Homebrew install instructions, shell installer, screenshots, and configuration documentation live in the GitHub repository:
+
+https://github.com/patrickdappollonio/dux

--- a/npm/bin/dux.js
+++ b/npm/bin/dux.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PLATFORM_TARGETS = [
+  { platform: "darwin", arch: "x64", key: "darwin-x64" },
+  { platform: "darwin", arch: "arm64", key: "darwin-arm64" },
+  { platform: "linux", arch: "x64", key: "linux-x64" },
+  { platform: "linux", arch: "arm64", key: "linux-arm64" }
+];
+
+const current = PLATFORM_TARGETS.find(
+  (target) => target.platform === process.platform && target.arch === process.arch
+);
+
+if (!current) {
+  throw new Error(
+    `Unsupported platform combination: ${process.platform}/${process.arch}. ` +
+      "Please open an issue to request support: " +
+      "https://github.com/patrickdappollonio/dux/issues/new"
+  );
+}
+
+const binaryName = "dux";
+const vendorRoot = path.join(__dirname, "..", "vendor", current.key);
+const binaryPath = path.join(vendorRoot, binaryName);
+
+if (!existsSync(binaryPath)) {
+  throw new Error(
+    `dux binary not found for ${current.key}. ` +
+      "Please reinstall the package or open an issue: " +
+      "https://github.com/patrickdappollonio/dux/issues/new"
+  );
+}
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env
+});
+
+child.on("error", (err) => {
+  console.error(`Failed to start dux: ${err.message}`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@patrickdappollonio/dux",
+  "version": "0.0.0-dev",
+  "description": "A terminal UI for running multiple AI coding agents side by side in isolated git worktrees.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "dux": "bin/dux.js"
+  },
+  "files": [
+    "bin",
+    "vendor",
+    "README.md",
+    "LICENSE",
+    "assets"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patrickdappollonio/dux"
+  },
+  "keywords": [
+    "ai",
+    "agents",
+    "cli",
+    "terminal",
+    "tui",
+    "worktrees"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/npm/scripts/build_npm_package.mjs
+++ b/npm/scripts/build_npm_package.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.join(__dirname, "..", "..");
+
+const releaseVersion = process.env.RELEASE_VERSION;
+if (!releaseVersion) {
+  console.error("RELEASE_VERSION is required");
+  process.exit(1);
+}
+
+const distDir = path.join(repoRoot, "dist");
+const artifactsDir = process.env.ARTIFACTS_DIR ?? distDir;
+const npmDistDir = path.join(distDir, "npm");
+const stagingDir = path.join(npmDistDir, "package");
+const tarballName = `dux-npm-${releaseVersion}.tgz`;
+const tarballPath = path.join(npmDistDir, tarballName);
+
+const TARGETS = [
+  { key: "darwin-arm64", archive: "dux-darwin-arm64.tar.gz" },
+  { key: "darwin-x64", archive: "dux-darwin-amd64.tar.gz" },
+  { key: "linux-arm64", archive: "dux-linux-arm64.tar.gz" },
+  { key: "linux-x64", archive: "dux-linux-amd64.tar.gz" }
+];
+
+async function main() {
+  await fs.rm(stagingDir, { recursive: true, force: true });
+  await fs.mkdir(stagingDir, { recursive: true });
+  await fs.mkdir(npmDistDir, { recursive: true });
+  await cleanOldTarballs();
+
+  await writePackageJson();
+  await copyStaticAssets();
+
+  for (const target of TARGETS) {
+    const archivePath = path.join(artifactsDir, target.archive);
+    await stageBinary(target, archivePath);
+  }
+
+  await packTarball();
+  console.log(`Created ${tarballPath}`);
+}
+
+async function writePackageJson() {
+  const pkgPath = path.join(repoRoot, "npm", "package.json");
+  const pkgRaw = await fs.readFile(pkgPath, "utf8");
+  const pkg = JSON.parse(pkgRaw);
+  pkg.version = releaseVersion;
+  const destPath = path.join(stagingDir, "package.json");
+  await fs.writeFile(destPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8");
+}
+
+async function copyStaticAssets() {
+  await fs.cp(path.join(repoRoot, "npm", "bin"), path.join(stagingDir, "bin"), {
+    recursive: true
+  });
+  await fs.chmod(path.join(stagingDir, "bin", "dux.js"), 0o755);
+  await fs.copyFile(path.join(repoRoot, "npm", "README.md"), path.join(stagingDir, "README.md"));
+  await fs.copyFile(path.join(repoRoot, "LICENSE"), path.join(stagingDir, "LICENSE"));
+  await copyOptionalAsset(path.join("assets", "dux-logo.png"));
+}
+
+async function copyOptionalAsset(relativePath) {
+  const sourcePath = path.join(repoRoot, relativePath);
+  try {
+    await fs.access(sourcePath);
+  } catch {
+    console.warn(`Skipping ${relativePath}; not found in repository root`);
+    return;
+  }
+
+  const destPath = path.join(stagingDir, relativePath);
+  await fs.mkdir(path.dirname(destPath), { recursive: true });
+  await fs.copyFile(sourcePath, destPath);
+}
+
+async function stageBinary(target, archivePath) {
+  try {
+    await fs.access(archivePath);
+  } catch {
+    throw new Error(`Required archive ${archivePath} not found`);
+  }
+
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dux-npm-"));
+  try {
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", tmpDir]);
+    const binarySrc = await findBinary(tmpDir, "dux");
+    if (!binarySrc) {
+      throw new Error(`Unable to find dux inside ${archivePath}`);
+    }
+
+    const destDir = path.join(stagingDir, "vendor", target.key);
+    await fs.mkdir(destDir, { recursive: true });
+    const destPath = path.join(destDir, "dux");
+    await fs.copyFile(binarySrc, destPath);
+    await fs.chmod(destPath, 0o755);
+    console.log(`Staged binary for ${target.key}`);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function findBinary(rootDir, binaryName) {
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() && entry.name === binaryName) {
+        return fullPath;
+      }
+    }
+  }
+  return null;
+}
+
+async function packTarball() {
+  const { stdout, stderr } = await execFileAsync(
+    "npm",
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", npmDistDir],
+    { cwd: stagingDir }
+  );
+  const filename = await resolvePackedFilename(stdout || stderr);
+  if (!filename) {
+    throw new Error("npm pack did not return a filename");
+  }
+  const packedPath = path.join(npmDistDir, filename);
+  await fs.rename(packedPath, tarballPath);
+}
+
+async function cleanOldTarballs() {
+  const entries = await fs.readdir(npmDistDir, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".tgz"))
+      .map((entry) => fs.rm(path.join(npmDistDir, entry.name), { force: true }))
+  );
+}
+
+async function resolvePackedFilename(output) {
+  const trimmed = output.trim();
+  if (trimmed) {
+    const jsonStart = trimmed.indexOf("[");
+    if (jsonStart === -1) {
+      throw new Error(`npm pack output did not contain JSON: ${trimmed}`);
+    }
+
+    const packInfo = JSON.parse(trimmed.slice(jsonStart));
+    const filename = packInfo.at(-1)?.filename;
+    if (filename) {
+      return filename;
+    }
+  }
+
+  const entries = await fs.readdir(npmDistDir, { withFileTypes: true });
+  const tarballs = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".tgz"))
+    .map((entry) => entry.name);
+
+  if (tarballs.length !== 1) {
+    throw new Error(`npm pack did not identify exactly one generated tarball: ${tarballs.join(", ")}`);
+  }
+
+  return tarballs[0];
+}
+
+await main();


### PR DESCRIPTION
Adds a scoped npm package for `dux` with a small Node.js launcher that selects the vendored native binary for the current Linux or macOS platform. The npm package uses a dedicated npm README while preserving the root license exactly.

Updates the release workflow to build the npm tarball from existing GitHub release archives and publish it through npm trusted publishing. Prerelease versions publish under the `next` dist tag; stable versions use npms default tag.

Also documents npm installation in the root README so release notes inherit the new install method.
