### PR TITLE
Show development label for local builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
           cargo set-version "$VERSION"
 
       - name: Build
+        env:
+          DUX_RELEASE_BUILD: "1"
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Strip binary

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=DUX_RELEASE_BUILD");
+
+    let display_version = if env::var("DUX_RELEASE_BUILD").as_deref() == Ok("1") {
+        format!("v{}", env!("CARGO_PKG_VERSION"))
+    } else {
+        "development".to_string()
+    };
+
+    println!("cargo:rustc-env=DUX_DISPLAY_VERSION={display_version}");
+}

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -10703,6 +10703,31 @@ cyan = "#00ffff"
     }
 
     #[test]
+    fn header_shows_development_version_for_local_builds() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect();
+
+        assert!(
+            rendered.contains("dux development"),
+            "expected local build version label, got: {rendered}"
+        );
+    }
+
+    #[test]
     fn header_shows_project_and_global_provider_when_project_is_overridden() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -437,7 +437,7 @@ impl App {
         let mut spans = vec![
             Span::styled(" dux ", Style::default().fg(label_fg).bg(bg)),
             Span::styled(
-                format!("v{}", env!("CARGO_PKG_VERSION")),
+                env!("DUX_DISPLAY_VERSION"),
                 Style::default().fg(self.theme.branch_fg).bg(bg),
             ),
         ];


### PR DESCRIPTION
This makes local Cargo builds show `dux development` in the app header instead of the static package version. That covers `cargo run`, `cargo build`, and `cargo install --path .` unless the build explicitly opts into release labeling.

Release artifacts now set `DUX_RELEASE_BUILD=1` in CI, which keeps the existing tag-driven version rewrite and displays `v${CARGO_PKG_VERSION}` for published builds.

The header reads one compile-time display label, keeping the UI logic simple while making the local-vs-release distinction explicit.