### PR TITLE
Prevent mouse reports leaking after Escape

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1106,6 +1106,7 @@ impl App {
             self.terminal_selection = None;
             self.in_bracket_paste = false;
             self.raw_input_buf.clear();
+            self.raw_input_parser.clear();
             self.loading_input_buf.clear();
             return Ok(false);
         }
@@ -1115,6 +1116,7 @@ impl App {
             self.terminal_selection = None;
             self.in_bracket_paste = false;
             self.raw_input_buf.clear();
+            self.raw_input_parser.clear();
             self.loading_input_buf.clear();
             let label = match surface {
                 SessionSurface::Agent => "Agent",
@@ -1255,7 +1257,7 @@ impl App {
         use rustix::event::{PollFd, PollFlags, poll};
         use std::io::Read;
 
-        if self.raw_input_buf != [0x1b] {
+        if self.raw_input_parser.pending() != [0x1b] {
             return Ok(false);
         }
 
@@ -1289,16 +1291,24 @@ impl App {
     /// This is the core logic of interactive input handling, split out from
     /// `poll_and_forward_raw_input` so it can be tested without real stdin I/O.
     pub(crate) fn process_raw_input_bytes(&mut self, bytes: &[u8]) -> Result<bool> {
-        self.raw_input_buf.extend_from_slice(bytes);
-
-        // Split into complete sequences and collect actions to avoid borrow
-        // conflicts between raw_input_buf and &mut self methods.
-        let (mut sequences, mut remainder) = crate::raw_input::split_sequences(&self.raw_input_buf);
-        if bytes.is_empty() && remainder == [0x1b] {
-            sequences.push(remainder);
-            remainder = &self.raw_input_buf[self.raw_input_buf.len()..];
+        // Keep compatibility with tests that still seed raw_input_buf
+        // directly, while making the parser the owner of live pending bytes.
+        if self.raw_input_buf.as_slice() != self.raw_input_parser.pending() {
+            self.raw_input_parser
+                .replace_pending(self.raw_input_buf.as_slice());
         }
-        let remainder_len = remainder.len();
+
+        let mut sequences = self.raw_input_parser.feed_sequences(bytes);
+        if bytes.is_empty()
+            && let Some(seq) = self.raw_input_parser.resolve_pending_esc()
+        {
+            sequences.push(crate::raw_input::ParsedSequence {
+                bytes: seq,
+                in_bracket_paste: self.raw_input_parser.in_bracket_paste(),
+            });
+        }
+        self.raw_input_buf = self.raw_input_parser.pending().to_vec();
+        self.in_bracket_paste = self.raw_input_parser.in_bracket_paste();
 
         // Collect what to do for each sequence: an intercepted action, a
         // mouse event to handle in the UI, or raw bytes to forward.
@@ -1312,18 +1322,19 @@ impl App {
         // (between ESC[200~ and ESC[201~), skip intercept matching so
         // pasted text never triggers keybindings.
         let mut actions: Vec<SeqAction> = Vec::with_capacity(sequences.len());
-        for seq in &sequences {
-            if *seq == crate::raw_input::BRACKET_PASTE_START {
-                self.in_bracket_paste = true;
+        for parsed in &sequences {
+            let seq = parsed.bytes.as_slice();
+            if seq == crate::raw_input::BRACKET_PASTE_START {
+                self.in_bracket_paste = self.raw_input_parser.in_bracket_paste();
                 actions.push(SeqAction::Forward(seq.to_vec()));
                 continue;
             }
-            if *seq == crate::raw_input::BRACKET_PASTE_END {
-                self.in_bracket_paste = false;
+            if seq == crate::raw_input::BRACKET_PASTE_END {
+                self.in_bracket_paste = self.raw_input_parser.in_bracket_paste();
                 actions.push(SeqAction::Forward(seq.to_vec()));
                 continue;
             }
-            if self.in_bracket_paste {
+            if parsed.in_bracket_paste {
                 actions.push(SeqAction::Forward(seq.to_vec()));
                 continue;
             }
@@ -1340,11 +1351,6 @@ impl App {
                 actions.push(SeqAction::Forward(seq.to_vec()));
             }
         }
-
-        // Trim buffer to remainder.
-        let buf_len = self.raw_input_buf.len();
-        let keep_from = buf_len - remainder_len;
-        self.raw_input_buf = self.raw_input_buf[keep_from..].to_vec();
 
         // Check once whether the user is scrolled back so we can suppress
         // non-scroll input for the entire batch.
@@ -1394,6 +1400,7 @@ impl App {
                     if self.filtered_macros("").is_empty() {
                         self.set_info("No macros defined for this surface.");
                         self.raw_input_buf.clear();
+                        self.raw_input_parser.clear();
                         return Ok(false);
                     }
                     let prev = self.input_target;
@@ -1405,6 +1412,7 @@ impl App {
                     self.input_target = InputTarget::None;
                     self.terminal_selection = None;
                     self.raw_input_buf.clear();
+                    self.raw_input_parser.clear();
                     return Ok(false);
                 }
                 SeqAction::Intercept(Action::ExitInteractive, _, _) => {
@@ -5132,6 +5140,7 @@ impl App {
         self.terminal_selection = None;
         self.in_bracket_paste = false;
         self.raw_input_buf.clear();
+        self.raw_input_parser.clear();
         self.loading_input_buf.clear();
         if return_to_terminal_list {
             self.left_section = LeftSection::Terminals;
@@ -5356,6 +5365,7 @@ mod tests {
             interactive_patterns: crate::keybindings::InteractiveBytePatterns {
                 bindings: Vec::new(),
             },
+            raw_input_parser: crate::raw_input::RawInputParser::default(),
             raw_input_buf: Vec::new(),
             loading_input_buf: Vec::new(),
             in_bracket_paste: false,
@@ -9268,6 +9278,52 @@ cyan = "#00ffff"
         assert!(
             app.raw_input_buf.is_empty(),
             "SGR mouse report must not leave a [<...M printable remainder"
+        );
+    }
+
+    #[test]
+    fn fragmented_pending_esc_before_sgr_mouse_does_not_leave_printable_tail() {
+        let mut app = app_with_scrolled_back_pty();
+
+        app.process_raw_input_bytes(b"\x1b").unwrap();
+        assert_eq!(app.raw_input_buf, b"\x1b");
+
+        app.process_raw_input_bytes(b"\x1b[<35;").unwrap();
+        assert_eq!(
+            app.input_target,
+            InputTarget::Agent,
+            "default bindings should keep interactive mode active"
+        );
+        assert_eq!(
+            app.raw_input_buf, b"\x1b[<35;",
+            "incomplete mouse report should stay pending with its ESC prefix"
+        );
+
+        app.process_raw_input_bytes(b"138;12M").unwrap();
+        assert!(
+            app.raw_input_buf.is_empty(),
+            "completed mouse report must not leave a [<...M printable remainder"
+        );
+    }
+
+    #[test]
+    fn app_preserves_alt_key_before_timeout_resolution() {
+        let bindings = bindings_with_overrides(&[(Action::ExitInteractive, &["esc"])]);
+        let mut app = app_with_scrolled_back_pty();
+        app.bindings = bindings;
+        app.interactive_patterns = app.bindings.interactive_byte_patterns();
+
+        app.process_raw_input_bytes(b"\x1b").unwrap();
+        app.process_raw_input_bytes(b"x").unwrap();
+
+        assert_eq!(
+            app.input_target,
+            InputTarget::Agent,
+            "ESC followed by a key should stay an Alt-key sequence"
+        );
+        assert!(
+            app.raw_input_buf.is_empty(),
+            "Alt-key sequence should be complete, not a pending bare ESC"
         );
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -8,6 +8,7 @@ const MIN_RIGHT_WIDTH_PCT: u16 = 14;
 const MAX_RIGHT_WIDTH_PCT: u16 = 50;
 const MIN_CENTER_WIDTH_PCT: u16 = 20;
 const DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(500);
+const ESC_AMBIGUITY_TIMEOUT: Duration = Duration::from_millis(25);
 
 /// Maximum size of `loading_input_buf`. During the loading phase we
 /// accumulate bytes only to detect a (possibly multi-byte) ExitInteractive
@@ -1125,6 +1126,7 @@ impl App {
 
         // Poll stdin with 100ms timeout (matches the crossterm poll interval).
         let stdin_handle = std::io::stdin();
+        let mut buf = [0u8; 4096];
         let timeout = rustix::time::Timespec {
             tv_sec: 0,
             tv_nsec: 100_000_000, // 100ms
@@ -1135,11 +1137,13 @@ impl App {
             poll(&mut pollfd, Some(&timeout))
         })?;
         if ready == 0 {
+            if self.resolve_pending_bare_esc(&stdin_borrow, None, &mut buf)? {
+                return Ok(false);
+            }
             return Ok(false);
         }
 
         // Read available bytes from the same handle used for polling.
-        let mut buf = [0u8; 4096];
         let mut stdin_lock = stdin_handle.lock();
         let n = crate::io_retry::retry_on_interrupt(|| stdin_lock.read(&mut buf))?;
         if n == 0 {
@@ -1235,7 +1239,49 @@ impl App {
             }
         }
 
+        if self.resolve_pending_bare_esc(&stdin_borrow, Some(&mut stdin_lock), &mut buf)? {
+            return Ok(false);
+        }
+
         Ok(false)
+    }
+
+    fn resolve_pending_bare_esc(
+        &mut self,
+        stdin_borrow: &impl std::os::fd::AsFd,
+        stdin_lock: Option<&mut std::io::StdinLock<'_>>,
+        buf: &mut [u8; 4096],
+    ) -> Result<bool> {
+        use rustix::event::{PollFd, PollFlags, poll};
+        use std::io::Read;
+
+        if self.raw_input_buf != [0x1b] {
+            return Ok(false);
+        }
+
+        std::thread::sleep(ESC_AMBIGUITY_TIMEOUT);
+        let zero_timeout = rustix::time::Timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let more = crate::io_retry::retry_on_interrupt_errno(|| {
+            let mut pollfd = [PollFd::new(stdin_borrow, PollFlags::IN)];
+            poll(&mut pollfd, Some(&zero_timeout))
+        })?;
+        if more != 0 {
+            let n = if let Some(stdin_lock) = stdin_lock {
+                crate::io_retry::retry_on_interrupt(|| stdin_lock.read(buf))?
+            } else {
+                let stdin_handle = std::io::stdin();
+                let mut stdin_lock = stdin_handle.lock();
+                crate::io_retry::retry_on_interrupt(|| stdin_lock.read(buf))?
+            };
+            if n != 0 {
+                return self.process_raw_input_bytes(&buf[..n]);
+            }
+        }
+
+        self.process_raw_input_bytes(&[])
     }
 
     /// Process raw bytes that have already been read from stdin.
@@ -1247,7 +1293,11 @@ impl App {
 
         // Split into complete sequences and collect actions to avoid borrow
         // conflicts between raw_input_buf and &mut self methods.
-        let (sequences, remainder) = crate::raw_input::split_sequences(&self.raw_input_buf);
+        let (mut sequences, mut remainder) = crate::raw_input::split_sequences(&self.raw_input_buf);
+        if bytes.is_empty() && remainder == [0x1b] {
+            sequences.push(remainder);
+            remainder = &self.raw_input_buf[self.raw_input_buf.len()..];
+        }
         let remainder_len = remainder.len();
 
         // Collect what to do for each sequence: an intercepted action, a
@@ -9175,6 +9225,50 @@ cyan = "#00ffff"
             "ExitInteractive must work even when scrolled back"
         );
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+    }
+
+    #[test]
+    fn timed_out_bare_esc_can_exit_interactive() {
+        let bindings = bindings_with_overrides(&[(Action::ExitInteractive, &["esc"])]);
+        let mut app = app_with_scrolled_back_pty();
+        app.bindings = bindings;
+        app.interactive_patterns = app.bindings.interactive_byte_patterns();
+
+        app.process_raw_input_bytes(b"\x1b").unwrap();
+        assert_eq!(
+            app.input_target,
+            InputTarget::Agent,
+            "bare ESC is held until the ambiguity timeout resolves it"
+        );
+        assert_eq!(app.raw_input_buf, b"\x1b");
+
+        app.process_raw_input_bytes(&[]).unwrap();
+        assert_eq!(
+            app.input_target,
+            InputTarget::None,
+            "timed-out bare ESC should resolve as ExitInteractive"
+        );
+        assert!(app.raw_input_buf.is_empty());
+    }
+
+    #[test]
+    fn pending_esc_before_sgr_mouse_does_not_leave_printable_tail() {
+        let bindings = bindings_with_overrides(&[(Action::ExitInteractive, &["esc"])]);
+        let mut app = app_with_scrolled_back_pty();
+        app.bindings = bindings;
+        app.interactive_patterns = app.bindings.interactive_byte_patterns();
+
+        app.process_raw_input_bytes(b"\x1b\x1b[<35;138;12M")
+            .unwrap();
+        assert_eq!(
+            app.input_target,
+            InputTarget::None,
+            "first ESC should exit interactive mode"
+        );
+        assert!(
+            app.raw_input_buf.is_empty(),
+            "SGR mouse report must not leave a [<...M printable remainder"
+        );
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -133,6 +133,7 @@ pub struct App {
     /// is still inside) and on any keystroke or modal-close event.
     pub(crate) pressed_button: Option<components::PressedButton>,
     pub(crate) interactive_patterns: InteractiveBytePatterns,
+    pub(crate) raw_input_parser: crate::raw_input::RawInputParser,
     pub(crate) raw_input_buf: Vec<u8>,
     /// Separate buffer for scanning ExitInteractive during the loading phase.
     /// Kept independent of `raw_input_buf` so that suppressed keystrokes
@@ -1192,6 +1193,7 @@ impl App {
             last_mouse_click: None,
             pressed_button: None,
             interactive_patterns,
+            raw_input_parser: crate::raw_input::RawInputParser::default(),
             raw_input_buf: Vec::new(),
             loading_input_buf: Vec::new(),
             in_bracket_paste: false,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -2077,6 +2077,7 @@ mod tests {
             interactive_patterns: crate::keybindings::InteractiveBytePatterns {
                 bindings: Vec::new(),
             },
+            raw_input_parser: crate::raw_input::RawInputParser::default(),
             raw_input_buf: Vec::new(),
             loading_input_buf: Vec::new(),
             in_bracket_paste: false,

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -168,6 +168,15 @@ pub fn split_sequences(buf: &[u8]) -> (Vec<&[u8]>, &[u8]) {
 
             let next = buf[i + 1];
             match next {
+                0x1b => {
+                    // A bare ESC followed by another escape sequence. Keep
+                    // the first ESC as its own sequence so the second ESC can
+                    // still prefix CSI/OSC/SS3 input such as SGR mouse
+                    // reports. Otherwise ESC ESC [ < ... M would consume the
+                    // first two bytes and leak "[<...M" as printable input.
+                    i += 1;
+                    sequences.push(&buf[start..i]);
+                }
                 b'[' => {
                     // CSI sequence: ESC [ <params> <final byte 0x40-0x7e>
                     i += 2; // skip ESC [
@@ -496,6 +505,17 @@ mod tests {
         assert_eq!(seqs.len(), 2);
         assert!(rem.is_empty());
         assert!(is_sgr_mouse(seqs[0]));
+        assert!(is_sgr_mouse(seqs[1]));
+    }
+
+    #[test]
+    fn bare_esc_before_sgr_mouse_does_not_strip_mouse_prefix() {
+        let input = b"\x1b\x1b[<35;138;12M";
+        let (seqs, rem) = split_sequences(input);
+        assert_eq!(seqs.len(), 2);
+        assert_eq!(seqs[0], b"\x1b");
+        assert_eq!(seqs[1], b"\x1b[<35;138;12M");
+        assert!(rem.is_empty());
         assert!(is_sgr_mouse(seqs[1]));
     }
 

--- a/src/raw_input.rs
+++ b/src/raw_input.rs
@@ -141,6 +141,172 @@ pub fn translate_sgr_mouse(seq: &[u8], origin_col: u16, origin_row: u16) -> Opti
     Some(format!("\x1b[<{cb};{tx};{ty}{}", final_byte as char).into_bytes())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SequenceStatus {
+    Complete(usize),
+    Incomplete,
+}
+
+/// Incremental parser for terminal input bytes.
+///
+/// Terminals encode a bare Escape, Alt-key chords, CSI/OSC/SS3 controls,
+/// bracket paste markers, UTF-8, and SGR mouse reports on the same byte
+/// stream. This parser keeps incomplete trailing bytes in one place so
+/// callers do not need to splice buffers manually or guess whether a pending
+/// `ESC` is standalone.
+#[derive(Debug, Clone, Default)]
+pub struct RawInputParser {
+    pending: Vec<u8>,
+    in_bracket_paste: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedSequence {
+    pub bytes: Vec<u8>,
+    pub in_bracket_paste: bool,
+}
+
+impl RawInputParser {
+    pub fn feed_sequences(&mut self, bytes: &[u8]) -> Vec<ParsedSequence> {
+        self.pending.extend_from_slice(bytes);
+        let mut sequences = Vec::new();
+
+        loop {
+            if self.pending.is_empty() {
+                break;
+            }
+            match scan_one_sequence(&self.pending) {
+                SequenceStatus::Complete(len) => {
+                    let bytes: Vec<u8> = self.pending.drain(..len).collect();
+                    let in_bracket_paste = self.in_bracket_paste;
+                    if bytes == BRACKET_PASTE_START {
+                        self.in_bracket_paste = true;
+                    } else if bytes == BRACKET_PASTE_END {
+                        self.in_bracket_paste = false;
+                    }
+                    sequences.push(ParsedSequence {
+                        bytes,
+                        in_bracket_paste,
+                    });
+                }
+                SequenceStatus::Incomplete => break,
+            }
+        }
+
+        sequences
+    }
+
+    pub fn resolve_pending_esc(&mut self) -> Option<Vec<u8>> {
+        if self.pending == [0x1b] {
+            self.pending.clear();
+            Some(vec![0x1b])
+        } else {
+            None
+        }
+    }
+
+    pub fn in_bracket_paste(&self) -> bool {
+        self.in_bracket_paste
+    }
+
+    pub fn pending(&self) -> &[u8] {
+        &self.pending
+    }
+
+    pub fn replace_pending(&mut self, bytes: &[u8]) {
+        self.pending.clear();
+        self.pending.extend_from_slice(bytes);
+    }
+
+    pub fn clear(&mut self) {
+        self.pending.clear();
+        self.in_bracket_paste = false;
+    }
+}
+
+fn scan_one_sequence(buf: &[u8]) -> SequenceStatus {
+    if buf.is_empty() {
+        return SequenceStatus::Incomplete;
+    }
+
+    let b = buf[0];
+    if b == 0x1b {
+        // ESC — start of an escape sequence.
+        if buf.len() < 2 {
+            // Bare ESC at end of buffer — could be incomplete.
+            return SequenceStatus::Incomplete;
+        }
+
+        match buf[1] {
+            0x1b => {
+                // A bare ESC followed by another escape sequence. Keep the
+                // first ESC as its own sequence so the second ESC can still
+                // prefix CSI/OSC/SS3 input such as SGR mouse reports.
+                SequenceStatus::Complete(1)
+            }
+            b'[' => {
+                let mut i = 2;
+                loop {
+                    if i >= buf.len() {
+                        return SequenceStatus::Incomplete;
+                    }
+                    let c = buf[i];
+                    i += 1;
+                    if (0x40..=0x7e).contains(&c) {
+                        return SequenceStatus::Complete(i);
+                    }
+                }
+            }
+            b'O' => {
+                if buf.len() < 3 {
+                    SequenceStatus::Incomplete
+                } else {
+                    SequenceStatus::Complete(3)
+                }
+            }
+            b']' => {
+                let mut i = 2;
+                loop {
+                    if i >= buf.len() {
+                        return SequenceStatus::Incomplete;
+                    }
+                    if buf[i] == 0x07 {
+                        return SequenceStatus::Complete(i + 1);
+                    }
+                    if buf[i] == 0x1b {
+                        if i + 1 >= buf.len() {
+                            return SequenceStatus::Incomplete;
+                        }
+                        if buf[i + 1] == b'\\' {
+                            return SequenceStatus::Complete(i + 2);
+                        }
+                        // Malformed OSC: complete the bytes before the new ESC
+                        // and let the outer parser reconsider that ESC next.
+                        return SequenceStatus::Complete(i);
+                    }
+                    i += 1;
+                }
+            }
+            _ => SequenceStatus::Complete(2),
+        }
+    } else if (0xc0..0xfe).contains(&b) {
+        let expected = if b < 0xe0 {
+            2
+        } else if b < 0xf0 {
+            3
+        } else {
+            4
+        };
+        if expected <= buf.len() {
+            SequenceStatus::Complete(expected)
+        } else {
+            SequenceStatus::Incomplete
+        }
+    } else {
+        SequenceStatus::Complete(1)
+    }
+}
+
 /// Splits a raw byte buffer into complete terminal input sequences.
 ///
 /// Returns `(complete, remainder)` where `complete` is a list of byte-slice
@@ -157,107 +323,12 @@ pub fn split_sequences(buf: &[u8]) -> (Vec<&[u8]>, &[u8]) {
 
     while i < buf.len() {
         let start = i;
-        let b = buf[i];
-
-        if b == 0x1b {
-            // ESC — start of an escape sequence.
-            if i + 1 >= buf.len() {
-                // Bare ESC at end of buffer — could be incomplete.
-                return (sequences, &buf[start..]);
+        match scan_one_sequence(&buf[start..]) {
+            SequenceStatus::Complete(len) => {
+                i += len;
+                sequences.push(&buf[start..i]);
             }
-
-            let next = buf[i + 1];
-            match next {
-                0x1b => {
-                    // A bare ESC followed by another escape sequence. Keep
-                    // the first ESC as its own sequence so the second ESC can
-                    // still prefix CSI/OSC/SS3 input such as SGR mouse
-                    // reports. Otherwise ESC ESC [ < ... M would consume the
-                    // first two bytes and leak "[<...M" as printable input.
-                    i += 1;
-                    sequences.push(&buf[start..i]);
-                }
-                b'[' => {
-                    // CSI sequence: ESC [ <params> <final byte 0x40-0x7e>
-                    i += 2; // skip ESC [
-                    loop {
-                        if i >= buf.len() {
-                            // Incomplete CSI — return as remainder.
-                            return (sequences, &buf[start..]);
-                        }
-                        let c = buf[i];
-                        i += 1;
-                        if (0x40..=0x7e).contains(&c) {
-                            // Final byte — sequence complete.
-                            break;
-                        }
-                        // Parameter/intermediate bytes (0x20-0x3f) — keep scanning.
-                    }
-                    sequences.push(&buf[start..i]);
-                }
-                b'O' => {
-                    // SS3 sequence: ESC O <one byte>
-                    if i + 2 >= buf.len() {
-                        return (sequences, &buf[start..]);
-                    }
-                    i += 3; // ESC O <byte>
-                    sequences.push(&buf[start..i]);
-                }
-                b']' => {
-                    // OSC sequence: ESC ] <params> <BEL|ST>
-                    // Terminated by BEL (0x07) or ST (ESC \).
-                    i += 2; // skip ESC ]
-                    loop {
-                        if i >= buf.len() {
-                            // Incomplete OSC — return as remainder.
-                            return (sequences, &buf[start..]);
-                        }
-                        if buf[i] == 0x07 {
-                            // BEL terminator.
-                            i += 1;
-                            break;
-                        }
-                        if buf[i] == 0x1b {
-                            // Possible ST (ESC \).
-                            if i + 1 >= buf.len() {
-                                return (sequences, &buf[start..]);
-                            }
-                            if buf[i + 1] == b'\\' {
-                                i += 2;
-                                break;
-                            }
-                            // Malformed — treat ESC as start of next sequence.
-                            break;
-                        }
-                        i += 1;
-                    }
-                    sequences.push(&buf[start..i]);
-                }
-                _ => {
-                    // Alt+key or other two-byte ESC sequence.
-                    i += 2;
-                    sequences.push(&buf[start..i]);
-                }
-            }
-        } else if (0xc0..0xfe).contains(&b) {
-            // UTF-8 multi-byte lead byte.
-            let expected = if b < 0xe0 {
-                2
-            } else if b < 0xf0 {
-                3
-            } else {
-                4
-            };
-            if i + expected > buf.len() {
-                // Incomplete UTF-8 — return as remainder.
-                return (sequences, &buf[start..]);
-            }
-            i += expected;
-            sequences.push(&buf[start..i]);
-        } else {
-            // Single byte: control chars, printable ASCII, DEL (0x7f).
-            i += 1;
-            sequences.push(&buf[start..i]);
+            SequenceStatus::Incomplete => return (sequences, &buf[start..]),
         }
     }
 
@@ -517,6 +588,109 @@ mod tests {
         assert_eq!(seqs[1], b"\x1b[<35;138;12M");
         assert!(rem.is_empty());
         assert!(is_sgr_mouse(seqs[1]));
+    }
+
+    #[test]
+    fn parser_keeps_fragmented_csi_pending_until_complete() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b[").is_empty());
+        assert_eq!(parser.pending(), b"\x1b[");
+
+        let seqs = parser.feed_sequences(b"5~");
+        assert_eq!(seqs[0].bytes, b"\x1b[5~".to_vec());
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_resolves_timed_out_bare_esc() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b").is_empty());
+        assert_eq!(parser.pending(), b"\x1b");
+        assert_eq!(parser.resolve_pending_esc(), Some(b"\x1b".to_vec()));
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_does_not_resolve_pending_csi_as_bare_esc() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b[").is_empty());
+        assert_eq!(parser.pending(), b"\x1b[");
+        assert!(parser.resolve_pending_esc().is_none());
+        assert_eq!(parser.pending(), b"\x1b[");
+    }
+
+    #[test]
+    fn parser_keeps_alt_key_as_single_sequence() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b").is_empty());
+        let seqs = parser.feed_sequences(b"x");
+        assert_eq!(seqs[0].bytes, b"\x1bx".to_vec());
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_does_not_strip_mouse_prefix_after_pending_esc() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b").is_empty());
+        let seqs = parser.feed_sequences(b"\x1b[<35;138;12M");
+        assert_eq!(seqs[0].bytes, b"\x1b".to_vec());
+        assert_eq!(seqs[1].bytes, b"\x1b[<35;138;12M".to_vec());
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_handles_fragmented_esc_then_sgr_mouse() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b").is_empty());
+        let first = parser.feed_sequences(b"\x1b[<35;");
+        assert_eq!(
+            first,
+            vec![ParsedSequence {
+                bytes: b"\x1b".to_vec(),
+                in_bracket_paste: false,
+            }]
+        );
+        assert_eq!(parser.pending(), b"\x1b[<35;");
+
+        let second = parser.feed_sequences(b"138;12M");
+        assert_eq!(
+            second,
+            vec![ParsedSequence {
+                bytes: b"\x1b[<35;138;12M".to_vec(),
+                in_bracket_paste: false,
+            }]
+        );
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_completes_malformed_osc_before_new_escape() {
+        let mut parser = RawInputParser::default();
+        assert!(parser.feed_sequences(b"\x1b]11;rgb").is_empty());
+        let seqs = parser.feed_sequences(b"\x1b[A");
+        assert_eq!(seqs.len(), 2);
+        assert_eq!(seqs[0].bytes, b"\x1b]11;rgb");
+        assert_eq!(seqs[1].bytes, b"\x1b[A");
+        assert!(parser.pending().is_empty());
+    }
+
+    #[test]
+    fn parser_tracks_bracket_paste_context() {
+        let mut parser = RawInputParser::default();
+        let mut input = Vec::new();
+        input.extend_from_slice(BRACKET_PASTE_START);
+        input.push(0x07);
+        input.extend_from_slice(BRACKET_PASTE_END);
+
+        let seqs = parser.feed_sequences(&input);
+        assert_eq!(seqs.len(), 3);
+        assert_eq!(seqs[0].bytes, BRACKET_PASTE_START);
+        assert!(!seqs[0].in_bracket_paste);
+        assert_eq!(seqs[1].bytes, b"\x07");
+        assert!(seqs[1].in_bracket_paste);
+        assert_eq!(seqs[2].bytes, BRACKET_PASTE_END);
+        assert!(seqs[2].in_bracket_paste);
+        assert!(!parser.in_bracket_paste());
     }
 
     #[test]


### PR DESCRIPTION
Raw interactive input could receive a bare `Esc` immediately before an SGR mouse report. The previous splitter could consume both escape bytes together, leaving the mouse report body as printable text that was forwarded into the active agent or companion terminal.

This keeps the mouse report's escape prefix intact when consecutive escape bytes arrive, and resolves a lone `Esc` after a short ambiguity window so it can still be used as an interactive binding.

The change is shared by the agent and companion terminal raw-input path.