### PR TITLE
Ensure new agents start from the leading branch

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -549,6 +549,9 @@ impl App {
                 Action::NewAgent => self.create_agent_for_selected_project()?,
                 Action::ForkAgent => self.fork_selected_session()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
+                Action::CheckoutProjectDefaultBranch => {
+                    self.checkout_selected_project_default_branch()?
+                }
                 Action::ShowTerminal => self.show_or_open_first_terminal()?,
                 Action::DeleteSession => self.confirm_delete_selected_session()?,
                 Action::RenameSession => self.open_rename_session()?,
@@ -4013,6 +4016,7 @@ impl App {
             let reason = match action {
                 NonDefaultBranchAction::AddProject { .. } => "before adding the project",
                 NonDefaultBranchAction::CreateAgent { .. } => "before creating the agent",
+                NonDefaultBranchAction::CheckoutProjectDefault { .. } => "for the selected project",
             };
             self.dispatch_non_default_branch_checkout(action, target, reason.to_string());
         } else {
@@ -4024,6 +4028,9 @@ impl App {
                 }
                 NonDefaultBranchAction::CreateAgent { .. } => {
                     self.set_error("Check out the default branch before creating an agent.");
+                }
+                NonDefaultBranchAction::CheckoutProjectDefault { .. } => {
+                    self.set_error("Check out the default branch before retrying.");
                 }
             }
         }
@@ -5221,8 +5228,8 @@ mod tests {
     use crate::editor::{DetectedEditor, EditorKind};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
     use crate::model::{
-        AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
-        SessionSurface,
+        AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProjectBranchStatus,
+        ProviderKind, SessionStatus, SessionSurface,
     };
     use crate::pty::PtyClient;
     use crate::statusline::StatusLine;
@@ -5347,6 +5354,7 @@ mod tests {
             path: root.to_string_lossy().to_string(),
             default_provider: ProviderKind::from_str("codex"),
             current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
         let session = AgentSession {
@@ -6441,6 +6449,49 @@ mod tests {
         assert!(matches!(app.prompt, PromptState::None));
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
         assert!(app.status.text().contains("Couldn't check out \"main\""));
+    }
+
+    #[test]
+    fn project_branch_status_ready_marks_project_not_leading() {
+        let mut app = test_app(default_bindings());
+
+        app.worker_tx
+            .send(WorkerEvent::ProjectBranchStatusReady {
+                project_id: app.projects[0].id.clone(),
+                result: Ok(("feature".to_string(), ProjectBranchStatus::NotLeading)),
+            })
+            .unwrap();
+
+        app.drain_events();
+
+        assert_eq!(app.projects[0].current_branch, "feature");
+        assert_eq!(
+            app.projects[0].branch_status,
+            ProjectBranchStatus::NotLeading
+        );
+    }
+
+    #[test]
+    fn checkout_project_default_success_marks_project_leading() {
+        let mut app = test_app(default_bindings());
+        let mut project = app.projects[0].clone();
+        project.current_branch = "feature".to_string();
+        project.branch_status = ProjectBranchStatus::NotLeading;
+        app.projects[0] = project.clone();
+
+        app.worker_tx
+            .send(WorkerEvent::NonDefaultBranchCheckoutCompleted {
+                action: NonDefaultBranchAction::CheckoutProjectDefault { project },
+                target_branch: "main".to_string(),
+                result: Ok(()),
+            })
+            .unwrap();
+
+        app.drain_events();
+
+        assert_eq!(app.projects[0].current_branch, "main");
+        assert_eq!(app.projects[0].branch_status, ProjectBranchStatus::Leading);
+        assert!(app.status.text().contains("Checked out \"main\""));
     }
 
     #[test]
@@ -8893,8 +8944,10 @@ cyan = "#00ffff"
     fn tab_with_shift_moves_non_default_branch_focus_backwards_when_checkbox_present() {
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::ConfirmNonDefaultBranch {
-            path: "/tmp/project".to_string(),
-            name: "project".to_string(),
+            action: NonDefaultBranchAction::AddProject {
+                path: "/tmp/project".to_string(),
+                name: "project".to_string(),
+            },
             current_branch: "feature".to_string(),
             kind: BranchWarningKind::Known {
                 default_branch: "main".to_string(),
@@ -8936,8 +8989,10 @@ cyan = "#00ffff"
     fn tab_with_shift_moves_non_default_branch_focus_backwards_without_checkbox() {
         let mut app = test_app(default_bindings());
         app.prompt = PromptState::ConfirmNonDefaultBranch {
-            path: "/tmp/project".to_string(),
-            name: "project".to_string(),
+            action: NonDefaultBranchAction::AddProject {
+                path: "/tmp/project".to_string(),
+                name: "project".to_string(),
+            },
             current_branch: "feature".to_string(),
             kind: BranchWarningKind::Heuristic,
             focus: ConfirmNonDefaultBranchFocus::Cancel,
@@ -10822,6 +10877,7 @@ cyan = "#00ffff"
             path: app.paths.root.join("pinned").display().to_string(),
             default_provider: ProviderKind::from_str("gemini"),
             current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
         app.config.projects.push(ProjectConfig {
@@ -10938,6 +10994,7 @@ cyan = "#00ffff"
             path: app.paths.root.join("pinned").display().to_string(),
             default_provider: ProviderKind::from_str("gemini"),
             current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
         app.config.projects.push(ProjectConfig {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2508,6 +2508,7 @@ impl App {
         }
 
         if let PromptState::ConfirmNonDefaultBranch {
+            action,
             focus,
             kind,
             checkout_default,
@@ -2515,8 +2516,10 @@ impl App {
         } = &mut self.prompt
         {
             // Checkbox is only reachable in the confident (Known) path.
-            // Heuristic warnings have no checkbox, so focus cycles Cancel ↔ Add.
-            let has_checkbox = matches!(kind, BranchWarningKind::Known { .. });
+            // Heuristic warnings and create-agent prompts have no checkbox,
+            // so focus cycles Cancel ↔ Add.
+            let has_checkbox =
+                matches!(kind, BranchWarningKind::Known { .. }) && action.allows_add_anyway();
             match self.bindings.lookup(&key, BindingScope::Dialog) {
                 Some(Action::CloseOverlay) => self.prompt = PromptState::None,
                 Some(Action::ToggleSelection) => {
@@ -3982,10 +3985,9 @@ impl App {
     }
 
     fn resolve_confirm_non_default_branch(&mut self) -> bool {
-        let (path, name, branch, checkout_default, default_branch) = match &self.prompt {
+        let (action, branch, checkout_default, default_branch) = match &self.prompt {
             PromptState::ConfirmNonDefaultBranch {
-                path,
-                name,
+                action,
                 current_branch,
                 kind,
                 checkout_default,
@@ -3996,8 +3998,7 @@ impl App {
                     BranchWarningKind::Heuristic => None,
                 };
                 (
-                    path.clone(),
-                    name.clone(),
+                    action.clone(),
                     current_branch.clone(),
                     *checkout_default && default_branch.is_some(),
                     default_branch,
@@ -4009,9 +4010,22 @@ impl App {
         if checkout_default {
             // Safe: `checkout_default` is only true when `default_branch` is `Some`.
             let target = default_branch.expect("checkout_default implies known default branch");
-            self.dispatch_add_project_checkout(path, name, target);
-        } else if let Err(e) = self.finish_add_project(path, name, branch) {
-            self.set_error(format!("{e:#}"));
+            let reason = match action {
+                NonDefaultBranchAction::AddProject { .. } => "before adding the project",
+                NonDefaultBranchAction::CreateAgent { .. } => "before creating the agent",
+            };
+            self.dispatch_non_default_branch_checkout(action, target, reason.to_string());
+        } else {
+            match action {
+                NonDefaultBranchAction::AddProject { path, name } => {
+                    if let Err(e) = self.finish_add_project(path, name, branch) {
+                        self.set_error(format!("{e:#}"));
+                    }
+                }
+                NonDefaultBranchAction::CreateAgent { .. } => {
+                    self.set_error("Check out the default branch before creating an agent.");
+                }
+            }
         }
         false
     }
@@ -4117,12 +4131,14 @@ impl App {
             }
             OverlayCheckboxId::NonDefaultBranchCheckoutDefault => {
                 if let PromptState::ConfirmNonDefaultBranch {
+                    action,
                     kind,
                     checkout_default,
                     focus,
                     ..
                 } = &mut self.prompt
                     && matches!(kind, BranchWarningKind::Known { .. })
+                    && action.allows_add_anyway()
                 {
                     *checkout_default = !*checkout_default;
                     *focus = ConfirmNonDefaultBranchFocus::Checkbox;
@@ -5195,9 +5211,10 @@ mod tests {
         CreateAgentRequest, DeleteAgentFocus, FocusPane, FullscreenOverlay, InputTarget,
         KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
         KillableRuntime, KillableRuntimeKind, LeftItem, LeftSection, MacroBarState,
-        MouseClickTarget, MouseLayoutState, NameNewAgentFocus, OverlayCheckbox, OverlayCheckboxId,
-        OverlayMouseLayout, OverlayMouseLayoutState, ProcessInfo, PromptState, PullTarget,
-        ResourceStats, RightSection, RuntimeTargetId, TextInput, WorkerEvent,
+        MouseClickTarget, MouseLayoutState, NameNewAgentFocus, NonDefaultBranchAction,
+        OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout, OverlayMouseLayoutState,
+        ProcessInfo, PromptState, PullTarget, ResourceStats, RightSection, RuntimeTargetId,
+        TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -5253,10 +5270,66 @@ mod tests {
         )
     }
 
+    fn run_git(cwd: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_test_repo(path: &std::path::Path) {
+        run_git(path, &["init", "-b", "main"]);
+        run_git(path, &["config", "user.name", "test"]);
+        run_git(path, &["config", "user.email", "t@t"]);
+        run_git(path, &["commit", "--allow-empty", "-m", "init"]);
+    }
+
+    fn set_remote_default(path: &std::path::Path, branch: &str) {
+        run_git(
+            path,
+            &[
+                "update-ref",
+                &format!("refs/remotes/origin/{branch}"),
+                "HEAD",
+            ],
+        );
+        run_git(
+            path,
+            &[
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                &format!("refs/remotes/origin/{branch}"),
+            ],
+        );
+    }
+
+    fn complete_create_agent_branch_inspection(
+        app: &mut App,
+        branch: &str,
+        warning_kind: Option<BranchWarningKind>,
+    ) {
+        let project = app.projects[0].clone();
+        app.worker_tx
+            .send(WorkerEvent::CreateAgentBranchInspected {
+                project,
+                result: Ok((branch.to_string(), warning_kind)),
+            })
+            .unwrap();
+        app.drain_events();
+    }
+
     fn test_app(bindings: RuntimeBindings) -> App {
         let tmp = tempdir().expect("tempdir");
         let root = tmp.path().to_path_buf();
         std::mem::forget(tmp);
+        init_test_repo(&root);
 
         let paths = DuxPaths {
             config_path: root.join("config.toml"),
@@ -6235,6 +6308,7 @@ mod tests {
         let mut app = test_app(default_bindings());
 
         app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", None);
 
         match &app.prompt {
             PromptState::NameNewAgent {
@@ -6254,11 +6328,128 @@ mod tests {
     }
 
     #[test]
+    fn create_agent_known_non_default_branch_opens_checkout_modal() {
+        let mut app = test_app(default_bindings());
+        let repo_path = PathBuf::from(&app.projects[0].path);
+        set_remote_default(&repo_path, "main");
+        run_git(&repo_path, &["switch", "-c", "feature"]);
+
+        app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(
+            &mut app,
+            "feature",
+            Some(BranchWarningKind::Known {
+                default_branch: "main".to_string(),
+            }),
+        );
+
+        match &app.prompt {
+            PromptState::ConfirmNonDefaultBranch {
+                action,
+                current_branch,
+                kind,
+                checkout_default,
+                ..
+            } => {
+                assert!(matches!(action, NonDefaultBranchAction::CreateAgent { .. }));
+                assert_eq!(current_branch, "feature");
+                assert!(matches!(
+                    kind,
+                    BranchWarningKind::Known { default_branch } if default_branch == "main"
+                ));
+                assert!(*checkout_default);
+            }
+            other => panic!("expected non-default branch prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_agent_unknown_default_on_feature_sets_error() {
+        let mut app = test_app(default_bindings());
+        let repo_path = PathBuf::from(&app.projects[0].path);
+        run_git(&repo_path, &["switch", "-c", "feature"]);
+
+        app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(
+            &mut app,
+            "feature",
+            Some(BranchWarningKind::Heuristic),
+        );
+
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(
+            app.status
+                .text()
+                .contains("Can't determine the default branch")
+        );
+    }
+
+    #[test]
+    fn create_agent_unknown_default_on_main_opens_name_prompt() {
+        let mut app = test_app(default_bindings());
+
+        app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", None);
+
+        assert!(matches!(app.prompt, PromptState::NameNewAgent { .. }));
+    }
+
+    #[test]
+    fn create_agent_checkout_success_opens_name_prompt_and_updates_branch() {
+        let mut app = test_app(default_bindings());
+        let mut project = app.projects[0].clone();
+        project.current_branch = "feature".to_string();
+
+        app.worker_tx
+            .send(WorkerEvent::NonDefaultBranchCheckoutCompleted {
+                action: NonDefaultBranchAction::CreateAgent { project },
+                target_branch: "main".to_string(),
+                result: Ok(()),
+            })
+            .unwrap();
+
+        app.drain_events();
+
+        assert_eq!(app.projects[0].current_branch, "main");
+        match &app.prompt {
+            PromptState::NameNewAgent { request, .. } => match request {
+                CreateAgentRequest::NewProject { project, .. } => {
+                    assert_eq!(project.current_branch, "main");
+                }
+                other => panic!("expected new project request, got {other:?}"),
+            },
+            other => panic!("expected name-new-agent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn create_agent_checkout_failure_sets_error_without_name_prompt() {
+        let mut app = test_app(default_bindings());
+        let project = app.projects[0].clone();
+
+        app.worker_tx
+            .send(WorkerEvent::NonDefaultBranchCheckoutCompleted {
+                action: NonDefaultBranchAction::CreateAgent { project },
+                target_branch: "main".to_string(),
+                result: Err("switch failed".to_string()),
+            })
+            .unwrap();
+
+        app.drain_events();
+
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(app.status.text().contains("Couldn't check out \"main\""));
+    }
+
+    #[test]
     fn create_agent_prefills_name_when_randomized_default_enabled() {
         let mut app = test_app(default_bindings());
         app.config.defaults.enable_randomized_pet_name_by_default = true;
 
         app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", None);
 
         match &app.prompt {
             PromptState::NameNewAgent {
@@ -6279,6 +6470,7 @@ mod tests {
     fn name_prompt_toggle_randomized_name_fills_and_clears_input() {
         let mut app = test_app(default_bindings());
         app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", None);
 
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
             .unwrap();
@@ -8823,6 +9015,7 @@ cyan = "#00ffff"
     fn mouse_click_name_prompt_checkbox_toggles_randomized_name() {
         let mut app = test_app(default_bindings());
         app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", None);
         install_name_new_agent_overlay(&mut app);
 
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 30, 12));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -593,8 +593,7 @@ pub(crate) enum PromptState {
         pending_delete: Option<PendingMacroDelete>,
     },
     ConfirmNonDefaultBranch {
-        path: String,
-        name: String,
+        action: NonDefaultBranchAction,
         current_branch: String,
         kind: BranchWarningKind,
         focus: ConfirmNonDefaultBranchFocus,
@@ -630,6 +629,36 @@ pub(crate) enum BranchWarningKind {
     Known { default_branch: String },
     /// `origin/HEAD` unavailable; current branch is not `main` or `master`.
     Heuristic,
+}
+
+pub(crate) fn branch_warning_kind(path: &Path, branch: &str) -> Option<BranchWarningKind> {
+    match git::remote_default_branch(path) {
+        Some(default) if default != branch => Some(BranchWarningKind::Known {
+            default_branch: default,
+        }),
+        Some(_) => None,
+        None if branch != "main" && branch != "master" => Some(BranchWarningKind::Heuristic),
+        None => None,
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum NonDefaultBranchAction {
+    AddProject { path: String, name: String },
+    CreateAgent { project: Project },
+}
+
+impl NonDefaultBranchAction {
+    pub(crate) fn repo_path(&self) -> &str {
+        match self {
+            Self::AddProject { path, .. } => path,
+            Self::CreateAgent { project } => &project.path,
+        }
+    }
+
+    pub(crate) fn allows_add_anyway(&self) -> bool {
+        matches!(self, Self::AddProject { .. })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1047,15 +1076,19 @@ pub(crate) enum WorkerEvent {
         session_id: String,
         result: Result<bool, String>,
     },
-    /// Background `git switch <target_branch>` run from the "Add Project"
-    /// warning modal has finished. On `Ok`, the main loop proceeds with
-    /// `finish_add_project` using `target_branch`. On `Err`, the formatted
-    /// git error is surfaced and the project is not added.
-    AddProjectCheckoutCompleted {
-        path: String,
-        name: String,
+    /// Background `git switch <target_branch>` run from a non-default branch
+    /// warning modal has finished. On `Ok`, the main loop continues the
+    /// original action. On `Err`, the formatted git error is surfaced.
+    NonDefaultBranchCheckoutCompleted {
+        action: NonDefaultBranchAction,
         target_branch: String,
         result: Result<(), String>,
+    },
+    /// Background inspection of the selected project checkout before opening
+    /// the New Agent prompt.
+    CreateAgentBranchInspected {
+        project: Project,
+        result: Result<(String, Option<BranchWarningKind>), String>,
     },
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -39,8 +39,8 @@ use crate::keybindings::{
 use crate::lockfile::SingleInstanceLock;
 use crate::logger;
 use crate::model::{
-    AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProviderKind, SessionStatus,
-    SessionSurface,
+    AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProjectBranchStatus, ProviderKind,
+    SessionStatus, SessionSurface,
 };
 use crate::provider;
 use crate::pty::PtyClient;
@@ -642,10 +642,20 @@ pub(crate) fn branch_warning_kind(path: &Path, branch: &str) -> Option<BranchWar
     }
 }
 
+pub(crate) fn branch_status_from_warning(
+    warning_kind: Option<&BranchWarningKind>,
+) -> ProjectBranchStatus {
+    match warning_kind {
+        Some(_) => ProjectBranchStatus::NotLeading,
+        None => ProjectBranchStatus::Leading,
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum NonDefaultBranchAction {
     AddProject { path: String, name: String },
     CreateAgent { project: Project },
+    CheckoutProjectDefault { project: Project },
 }
 
 impl NonDefaultBranchAction {
@@ -653,6 +663,7 @@ impl NonDefaultBranchAction {
         match self {
             Self::AddProject { path, .. } => path,
             Self::CreateAgent { project } => &project.path,
+            Self::CheckoutProjectDefault { project } => &project.path,
         }
     }
 
@@ -1090,6 +1101,14 @@ pub(crate) enum WorkerEvent {
         project: Project,
         result: Result<(String, Option<BranchWarningKind>), String>,
     },
+    ProjectBranchStatusReady {
+        project_id: String,
+        result: Result<(String, ProjectBranchStatus), String>,
+    },
+    CheckoutProjectDefaultBranchInspected {
+        project: Project,
+        result: Result<(String, Option<BranchWarningKind>), String>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1270,6 +1289,7 @@ impl App {
     pub fn run(&mut self) -> Result<()> {
         self.spawn_changed_files_poller();
         self.spawn_branch_sync_worker();
+        self.spawn_project_branch_status_checks();
         self.spawn_gh_status_check();
         let mut terminal = ratatui::init();
         execute!(stdout(), EnableMouseCapture)?;
@@ -2435,6 +2455,7 @@ pub(crate) fn load_projects(config: &Config) -> Vec<Project> {
             } else {
                 git::current_branch(&path).unwrap_or_else(|_| "main".to_string())
             },
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: missing,
         });
     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -557,9 +557,20 @@ impl App {
                                 } else {
                                     "▾"
                                 };
+                            let icon = if project.branch_status == ProjectBranchStatus::NotLeading {
+                                "!"
+                            } else {
+                                icon
+                            };
                             ListItem::new(Line::from(Span::styled(
                                 icon,
-                                Style::default().fg(self.theme.project_icon),
+                                Style::default().fg(
+                                    if project.branch_status == ProjectBranchStatus::NotLeading {
+                                        self.theme.warning_fg
+                                    } else {
+                                        self.theme.project_icon
+                                    },
+                                ),
                             )))
                         }
                     }
@@ -659,6 +670,12 @@ impl App {
                             spans.push(Span::styled(
                                 format!(" ({count})"),
                                 Style::default().fg(self.theme.provider_label_fg),
+                            ));
+                        }
+                        if project.branch_status == ProjectBranchStatus::NotLeading {
+                            spans.push(Span::styled(
+                                " !",
+                                Style::default().fg(self.theme.warning_fg),
                             ));
                         }
                         ListItem::new(Line::from(spans))

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -4197,6 +4197,7 @@ impl App {
                 };
             }
             PromptState::ConfirmNonDefaultBranch {
+                action,
                 current_branch,
                 kind,
                 focus,
@@ -4206,7 +4207,9 @@ impl App {
                 self.render_dim_overlay(frame);
                 let dialog_width = 60u16.min(frame.area().width.max(1));
                 let inner_width = dialog_width.saturating_sub(2);
-                let has_checkbox = matches!(kind, BranchWarningKind::Known { .. });
+                let has_checkbox =
+                    matches!(kind, BranchWarningKind::Known { .. }) && action.allows_add_anyway();
+                let is_create_agent = matches!(action, NonDefaultBranchAction::CreateAgent { .. });
 
                 // Body: warning text + the "new worktrees branch from …" note,
                 // plus a dim info line on the heuristic path explaining why dux
@@ -4214,22 +4217,43 @@ impl App {
                 let mut body_lines = vec![Line::from("")];
                 match kind {
                     BranchWarningKind::Known { default_branch } => {
-                        body_lines.push(Line::from(vec![
-                            Span::raw(" This repository is on branch "),
-                            Span::styled(
-                                current_branch.as_str(),
-                                Style::default().add_modifier(Modifier::BOLD),
-                            ),
-                            Span::raw(", but the"),
-                        ]));
-                        body_lines.push(Line::from(vec![
-                            Span::raw(" remote default branch is "),
-                            Span::styled(
-                                default_branch.as_str(),
-                                Style::default().add_modifier(Modifier::BOLD),
-                            ),
-                            Span::raw("."),
-                        ]));
+                        if is_create_agent {
+                            body_lines
+                                .push(Line::from(" This project checkout has changed and is no"));
+                            body_lines.push(Line::from(vec![
+                                Span::raw(" longer on the default branch "),
+                                Span::styled(
+                                    default_branch.as_str(),
+                                    Style::default().add_modifier(Modifier::BOLD),
+                                ),
+                                Span::raw("."),
+                            ]));
+                            body_lines.push(Line::from(""));
+                            body_lines.push(Line::from(vec![
+                                Span::raw(" Current branch: "),
+                                Span::styled(
+                                    current_branch.as_str(),
+                                    Style::default().add_modifier(Modifier::BOLD),
+                                ),
+                            ]));
+                        } else {
+                            body_lines.push(Line::from(vec![
+                                Span::raw(" This repository is on branch "),
+                                Span::styled(
+                                    current_branch.as_str(),
+                                    Style::default().add_modifier(Modifier::BOLD),
+                                ),
+                                Span::raw(", but the"),
+                            ]));
+                            body_lines.push(Line::from(vec![
+                                Span::raw(" remote default branch is "),
+                                Span::styled(
+                                    default_branch.as_str(),
+                                    Style::default().add_modifier(Modifier::BOLD),
+                                ),
+                                Span::raw("."),
+                            ]));
+                        }
                     }
                     BranchWarningKind::Heuristic => {
                         body_lines.push(Line::from(vec![
@@ -4244,8 +4268,13 @@ impl App {
                     }
                 }
                 body_lines.push(Line::from(""));
+                let worktree_warning = if is_create_agent {
+                    " New agents should branch from the default branch.".to_string()
+                } else {
+                    format!(" New worktrees will branch from \"{current_branch}\".")
+                };
                 body_lines.push(Line::from(Span::styled(
-                    format!(" New worktrees will branch from \"{current_branch}\"."),
+                    worktree_warning,
                     Style::default().fg(self.theme.warning_fg),
                 )));
                 if matches!(kind, BranchWarningKind::Heuristic) {
@@ -4263,7 +4292,10 @@ impl App {
 
                 // Checkbox height is measured up-front so the outer rect can
                 // be sized exactly — mirrors the Delete Agent modal.
-                let checkbox_height = if let BranchWarningKind::Known { default_branch } = kind {
+                let checkbox_height = if has_checkbox {
+                    let BranchWarningKind::Known { default_branch } = kind else {
+                        unreachable!("has_checkbox requires a known default branch");
+                    };
                     let state = if *focus == ConfirmNonDefaultBranchFocus::Checkbox {
                         CheckboxState::Focused
                     } else {
@@ -4309,7 +4341,10 @@ impl App {
                     .wrap(Wrap { trim: false })
                     .render(body_area, frame.buffer_mut());
 
-                let checkbox_rect = if let BranchWarningKind::Known { default_branch } = kind {
+                let checkbox_rect = if has_checkbox {
+                    let BranchWarningKind::Known { default_branch } = kind else {
+                        unreachable!("has_checkbox requires a known default branch");
+                    };
                     let checkbox_state = if *focus == ConfirmNonDefaultBranchFocus::Checkbox {
                         CheckboxState::Focused
                     } else {
@@ -4337,7 +4372,11 @@ impl App {
                 // "Check Out & Add" and "Add Anyway" in the calculation keeps
                 // the layout stable when the user toggles the checkbox —
                 // otherwise the buttons would resize mid-modal.
-                let btn_width = shared_button_width(&["Cancel", "Add Anyway", "Check Out & Add"]);
+                let btn_width = if is_create_agent {
+                    shared_button_width(&["Cancel", "Check Out & Create"])
+                } else {
+                    shared_button_width(&["Cancel", "Add Anyway", "Check Out & Add"])
+                };
                 let gap = 2u16;
                 let total = btn_width * 2 + gap;
                 let left_offset = buttons_area.width.saturating_sub(total) / 2;
@@ -4359,7 +4398,9 @@ impl App {
                 // pressing it will do. When the checkbox is on and we know the
                 // default branch, the action is a two-step (switch + add),
                 // otherwise it's the original "Add Anyway" add-as-is.
-                let add_label = if has_checkbox && *checkout_default {
+                let add_label = if is_create_agent {
+                    "Check Out & Create"
+                } else if has_checkbox && *checkout_default {
                     "Check Out & Add"
                 } else {
                     "Add Anyway"

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -65,27 +65,17 @@ impl App {
         }
         let branch = git::current_branch(&path)?;
 
-        // Check whether the current branch matches the remote default branch.
-        // Two-tier warning: confident when origin/HEAD is available, heuristic
-        // when it isn't but the branch name doesn't look like a main branch.
-        let warning_kind = match git::remote_default_branch(&path) {
-            Some(default) if default != branch => Some(BranchWarningKind::Known {
-                default_branch: default,
-            }),
-            Some(_) => None, // on the default branch — no warning
-            None if branch != "main" && branch != "master" => Some(BranchWarningKind::Heuristic),
-            None => None, // looks like main/master — no warning
-        };
-
-        if let Some(kind) = warning_kind {
+        if let Some(kind) = branch_warning_kind(&path, &branch) {
             // Default the checkbox to on for the confident path so hitting
             // Enter resolves the warning in the way users typically want —
             // "switch to main, then add". The heuristic path ignores this
             // field (no checkbox is shown).
             let checkout_default = matches!(kind, BranchWarningKind::Known { .. });
             self.prompt = PromptState::ConfirmNonDefaultBranch {
-                path: path.to_string_lossy().to_string(),
-                name,
+                action: NonDefaultBranchAction::AddProject {
+                    path: path.to_string_lossy().to_string(),
+                    name,
+                },
                 current_branch: branch,
                 kind,
                 focus: ConfirmNonDefaultBranchFocus::Cancel,
@@ -150,6 +140,39 @@ impl App {
             return Ok(());
         }
 
+        self.dispatch_create_agent_branch_inspection(project);
+        Ok(())
+    }
+
+    pub(crate) fn continue_create_agent_after_branch_inspection(
+        &mut self,
+        mut project: Project,
+        current_branch: String,
+        warning_kind: Option<BranchWarningKind>,
+    ) -> Result<()> {
+        if let Some(kind) = warning_kind {
+            match kind {
+                BranchWarningKind::Known { .. } => {
+                    project.current_branch = current_branch.clone();
+                    self.prompt = PromptState::ConfirmNonDefaultBranch {
+                        action: NonDefaultBranchAction::CreateAgent { project },
+                        current_branch,
+                        kind,
+                        focus: ConfirmNonDefaultBranchFocus::Cancel,
+                        checkout_default: true,
+                    };
+                }
+                BranchWarningKind::Heuristic => {
+                    self.set_error(format!(
+                        "Can't determine the default branch for project \"{}\" while it is on \"{}\". Check out the leading branch in your terminal, then create the agent.",
+                        project.name, current_branch
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
+        project.current_branch = current_branch;
         self.open_name_new_agent_prompt(CreateAgentRequest::NewProject {
             project,
             custom_name: None,
@@ -176,7 +199,7 @@ impl App {
         })
     }
 
-    fn open_name_new_agent_prompt(&mut self, request: CreateAgentRequest) -> Result<()> {
+    pub(crate) fn open_name_new_agent_prompt(&mut self, request: CreateAgentRequest) -> Result<()> {
         let randomize_name = self.config.defaults.enable_randomized_pet_name_by_default;
         let mut input = TextInput::new().with_char_map(crate::git::agent_name_char_map);
         let mut randomized_name = None;
@@ -200,20 +223,32 @@ impl App {
 
     /// Spawns a background worker that runs `git switch <target_branch>` in
     /// the source repo before registering the project. On success, the
-    /// `WorkerEvent::AddProjectCheckoutCompleted` handler calls
-    /// `finish_add_project`; on failure it surfaces the git error.
-    pub(crate) fn dispatch_add_project_checkout(
+    /// `WorkerEvent::NonDefaultBranchCheckoutCompleted` handler continues the
+    /// selected action; on failure it surfaces the git error.
+    pub(crate) fn dispatch_non_default_branch_checkout(
         &mut self,
-        path: String,
-        name: String,
+        action: NonDefaultBranchAction,
         target_branch: String,
+        reason: String,
     ) {
+        let path = action.repo_path().to_string();
         self.set_busy(format!(
-            "Checking out \"{target_branch}\" in {path} before adding the project..."
+            "Checking out \"{target_branch}\" in {path} {reason}..."
         ));
         let worker_tx = self.worker_tx.clone();
         thread::spawn(move || {
-            super::workers::run_add_project_checkout_job(path, name, target_branch, worker_tx);
+            super::workers::run_add_project_checkout_job(action, target_branch, worker_tx);
+        });
+    }
+
+    pub(crate) fn dispatch_create_agent_branch_inspection(&mut self, project: Project) {
+        self.set_busy(format!(
+            "Checking the current branch for project \"{}\" before creating an agent...",
+            project.name
+        ));
+        let worker_tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            super::workers::run_create_agent_branch_inspection_job(project, worker_tx);
         });
     }
 

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -122,6 +122,7 @@ impl App {
             path,
             default_provider: self.config.default_provider(),
             current_branch: branch,
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         });
         self.rebuild_left_items();
@@ -173,6 +174,7 @@ impl App {
         }
 
         project.current_branch = current_branch;
+        project.branch_status = ProjectBranchStatus::Leading;
         self.open_name_new_agent_prompt(CreateAgentRequest::NewProject {
             project,
             custom_name: None,
@@ -250,6 +252,31 @@ impl App {
         thread::spawn(move || {
             super::workers::run_create_agent_branch_inspection_job(project, worker_tx);
         });
+    }
+
+    pub(crate) fn checkout_selected_project_default_branch(&mut self) -> Result<()> {
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+
+        if project.path_missing {
+            self.set_warning(format!(
+                "Cannot check out default branch: path not found for \"{}\"",
+                project.name
+            ));
+            return Ok(());
+        }
+
+        self.set_busy(format!(
+            "Checking the default branch for project \"{}\"...",
+            project.name
+        ));
+        let worker_tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            super::workers::run_checkout_project_default_branch_inspection_job(project, worker_tx);
+        });
+        Ok(())
     }
 
     pub(crate) fn dispatch_create_agent_request(
@@ -2172,6 +2199,7 @@ mod tests {
             path: "/tmp/project".to_string(),
             default_provider: ProviderKind::from_str(provider),
             current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         }
     }
@@ -2321,6 +2349,7 @@ mod tests {
             path: path.to_string(),
             default_provider: ProviderKind::from_str(provider),
             current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         }
     }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -351,44 +351,84 @@ impl App {
                         }
                     }
                 }
-                WorkerEvent::AddProjectCheckoutCompleted {
-                    path,
-                    name,
+                WorkerEvent::NonDefaultBranchCheckoutCompleted {
+                    action,
                     target_branch,
                     result,
                 } => match result {
-                    Ok(()) => {
-                        let display_name = if name.trim().is_empty() {
-                            std::path::Path::new(&path)
-                                .file_name()
-                                .and_then(|s| s.to_str())
-                                .unwrap_or("project")
-                                .to_string()
-                        } else {
-                            name.trim().to_string()
-                        };
-                        if let Err(e) =
-                            self.finish_add_project(path, name, target_branch.clone())
-                        {
-                            self.set_error(format!("{e:#}"));
-                        } else {
-                            // Override the generic "Added project" status from
-                            // finish_add_project with the more informative
-                            // two-step message.
-                            self.set_info(format!(
-                                "Checked out \"{target_branch}\" and added project \"{display_name}\" to workspace."
-                            ));
+                    Ok(()) => match action {
+                        NonDefaultBranchAction::AddProject { path, name } => {
+                            let display_name = if name.trim().is_empty() {
+                                std::path::Path::new(&path)
+                                    .file_name()
+                                    .and_then(|s| s.to_str())
+                                    .unwrap_or("project")
+                                    .to_string()
+                            } else {
+                                name.trim().to_string()
+                            };
+                            if let Err(e) =
+                                self.finish_add_project(path, name, target_branch.clone())
+                            {
+                                self.set_error(format!("{e:#}"));
+                            } else {
+                                // Override the generic "Added project" status from
+                                // finish_add_project with the more informative
+                                // two-step message.
+                                self.set_info(format!(
+                                    "Checked out \"{target_branch}\" and added project \"{display_name}\" to workspace."
+                                ));
+                            }
                         }
-                    }
+                        NonDefaultBranchAction::CreateAgent { mut project } => {
+                            if let Some(existing) =
+                                self.projects.iter_mut().find(|p| p.id == project.id)
+                            {
+                                existing.current_branch = target_branch.clone();
+                            }
+                            project.current_branch = target_branch.clone();
+                            if let Err(e) =
+                                self.open_name_new_agent_prompt(CreateAgentRequest::NewProject {
+                                    project,
+                                    custom_name: None,
+                                    use_existing_branch: false,
+                                })
+                            {
+                                self.set_error(format!("{e:#}"));
+                            } else {
+                                self.set_info(format!(
+                                    "Checked out \"{target_branch}\". Enter a name for the new agent."
+                                ));
+                            }
+                        }
+                    },
                     Err(err) => {
                         // Preserve the full git stderr in the log so
                         // debugging stays possible after the status line
                         // summary is overwritten by the next message.
+                        let path = action.repo_path().to_string();
                         logger::error(&format!(
-                            "add-project checkout failed for {path}: {err}"
+                            "non-default branch checkout failed for {path}: {err}"
                         ));
                         self.set_error(format!(
                             "Couldn't check out \"{target_branch}\" in {path} — resolve in your terminal and retry."
+                        ));
+                    }
+                },
+                WorkerEvent::CreateAgentBranchInspected { project, result } => match result {
+                    Ok((current_branch, warning_kind)) => {
+                        if let Err(err) = self.continue_create_agent_after_branch_inspection(
+                            project,
+                            current_branch,
+                            warning_kind,
+                        ) {
+                            self.set_error(format!("{err:#}"));
+                        }
+                    }
+                    Err(err) => {
+                        self.set_error(format!(
+                            "Couldn't inspect the current branch for project \"{}\": {err}",
+                            project.name
                         ));
                     }
                 },
@@ -914,21 +954,35 @@ impl App {
 
 /// Background job for "Add Project" when the user opted to have dux switch to
 /// the default branch first. Runs `git switch <target_branch>` in the source
-/// repo and reports the outcome via `WorkerEvent::AddProjectCheckoutCompleted`
-/// so the main loop can either call `finish_add_project` or surface the error.
+/// repo and reports the outcome via
+/// `WorkerEvent::NonDefaultBranchCheckoutCompleted` so the main loop can
+/// continue the selected action or surface the error.
 pub(crate) fn run_add_project_checkout_job(
-    path: String,
-    name: String,
+    action: NonDefaultBranchAction,
     target_branch: String,
     worker_tx: Sender<WorkerEvent>,
 ) {
+    let path = action.repo_path().to_string();
     let result = git::switch_branch(Path::new(&path), &target_branch).map_err(|e| format!("{e:#}"));
-    let _ = worker_tx.send(WorkerEvent::AddProjectCheckoutCompleted {
-        path,
-        name,
+    let _ = worker_tx.send(WorkerEvent::NonDefaultBranchCheckoutCompleted {
+        action,
         target_branch,
         result,
     });
+}
+
+pub(crate) fn run_create_agent_branch_inspection_job(
+    project: Project,
+    worker_tx: Sender<WorkerEvent>,
+) {
+    let repo_path = PathBuf::from(&project.path);
+    let result = git::current_branch(&repo_path)
+        .map(|branch| {
+            let warning_kind = branch_warning_kind(&repo_path, &branch);
+            (branch, warning_kind)
+        })
+        .map_err(|err| format!("{err:#}"));
+    let _ = worker_tx.send(WorkerEvent::CreateAgentBranchInspected { project, result });
 }
 
 pub(crate) fn run_create_agent_job(

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -98,6 +98,11 @@ impl App {
                                     && let Some(branch_name) = branch_name
                                 {
                                     existing.current_branch = branch_name;
+                                    let warning = branch_warning_kind(
+                                        Path::new(&existing.path),
+                                        &existing.current_branch,
+                                    );
+                                    existing.branch_status = branch_status_from_warning(warning.as_ref());
                                 }
                                 self.set_info(format!(
                                     "Refreshed project \"{}\". Local branch is up to date with remote.",
@@ -385,8 +390,10 @@ impl App {
                                 self.projects.iter_mut().find(|p| p.id == project.id)
                             {
                                 existing.current_branch = target_branch.clone();
+                                existing.branch_status = ProjectBranchStatus::Leading;
                             }
                             project.current_branch = target_branch.clone();
+                            project.branch_status = ProjectBranchStatus::Leading;
                             if let Err(e) =
                                 self.open_name_new_agent_prompt(CreateAgentRequest::NewProject {
                                     project,
@@ -400,6 +407,18 @@ impl App {
                                     "Checked out \"{target_branch}\". Enter a name for the new agent."
                                 ));
                             }
+                        }
+                        NonDefaultBranchAction::CheckoutProjectDefault { project } => {
+                            if let Some(existing) =
+                                self.projects.iter_mut().find(|p| p.id == project.id)
+                            {
+                                existing.current_branch = target_branch.clone();
+                                existing.branch_status = ProjectBranchStatus::Leading;
+                            }
+                            self.set_info(format!(
+                                "Checked out \"{target_branch}\" for project \"{}\".",
+                                project.name
+                            ));
                         }
                     },
                     Err(err) => {
@@ -417,6 +436,12 @@ impl App {
                 },
                 WorkerEvent::CreateAgentBranchInspected { project, result } => match result {
                     Ok((current_branch, warning_kind)) => {
+                        if let Some(existing) =
+                            self.projects.iter_mut().find(|p| p.id == project.id)
+                        {
+                            existing.current_branch = current_branch.clone();
+                            existing.branch_status = branch_status_from_warning(warning_kind.as_ref());
+                        }
                         if let Err(err) = self.continue_create_agent_after_branch_inspection(
                             project,
                             current_branch,
@@ -432,6 +457,58 @@ impl App {
                         ));
                     }
                 },
+                WorkerEvent::ProjectBranchStatusReady { project_id, result } => match result {
+                    Ok((current_branch, branch_status)) => {
+                        if let Some(project) =
+                            self.projects.iter_mut().find(|p| p.id == project_id)
+                        {
+                            project.current_branch = current_branch;
+                            project.branch_status = branch_status;
+                        }
+                    }
+                    Err(err) => {
+                        logger::debug(&format!(
+                            "project branch status inspection failed for {project_id}: {err}"
+                        ));
+                    }
+                },
+                WorkerEvent::CheckoutProjectDefaultBranchInspected { project, result } => {
+                    match result {
+                        Ok((current_branch, warning_kind)) => match warning_kind {
+                            Some(BranchWarningKind::Known { default_branch }) => {
+                                let mut project = project;
+                                project.current_branch = current_branch;
+                                self.dispatch_non_default_branch_checkout(
+                                    NonDefaultBranchAction::CheckoutProjectDefault { project },
+                                    default_branch,
+                                    "for the selected project".to_string(),
+                                );
+                            }
+                            Some(BranchWarningKind::Heuristic) => {
+                                self.set_error(format!(
+                                    "Can't determine the default branch for project \"{}\" while it is on \"{}\". Resolve the default branch in your terminal and retry.",
+                                    project.name, current_branch
+                                ));
+                            }
+                            None => {
+                                if let Some(existing) =
+                                    self.projects.iter_mut().find(|p| p.id == project.id)
+                                {
+                                    existing.current_branch = current_branch.clone();
+                                    existing.branch_status = ProjectBranchStatus::Leading;
+                                }
+                                self.set_info(format!(
+                                    "Project \"{}\" is already on the leading branch \"{}\".",
+                                    project.name, current_branch
+                                ));
+                            }
+                        },
+                        Err(err) => self.set_error(format!(
+                            "Couldn't inspect the default branch for project \"{}\": {err}",
+                            project.name
+                        )),
+                    }
+                }
             }
         }
         self.retry_hung_resume_sessions();
@@ -627,6 +704,16 @@ impl App {
                 }
             }
         });
+    }
+
+    pub(crate) fn spawn_project_branch_status_checks(&self) {
+        for project in self.projects.iter().filter(|project| !project.path_missing) {
+            let project = project.clone();
+            let worker_tx = self.worker_tx.clone();
+            thread::spawn(move || {
+                run_project_branch_status_job(project, worker_tx);
+            });
+        }
     }
 
     // -- Git refs watcher for push detection --
@@ -983,6 +1070,34 @@ pub(crate) fn run_create_agent_branch_inspection_job(
         })
         .map_err(|err| format!("{err:#}"));
     let _ = worker_tx.send(WorkerEvent::CreateAgentBranchInspected { project, result });
+}
+
+pub(crate) fn run_project_branch_status_job(project: Project, worker_tx: Sender<WorkerEvent>) {
+    let repo_path = PathBuf::from(&project.path);
+    let result = git::current_branch(&repo_path)
+        .map(|branch| {
+            let warning_kind = branch_warning_kind(&repo_path, &branch);
+            (branch, branch_status_from_warning(warning_kind.as_ref()))
+        })
+        .map_err(|err| format!("{err:#}"));
+    let _ = worker_tx.send(WorkerEvent::ProjectBranchStatusReady {
+        project_id: project.id,
+        result,
+    });
+}
+
+pub(crate) fn run_checkout_project_default_branch_inspection_job(
+    project: Project,
+    worker_tx: Sender<WorkerEvent>,
+) {
+    let repo_path = PathBuf::from(&project.path);
+    let result = git::current_branch(&repo_path)
+        .map(|branch| {
+            let warning_kind = branch_warning_kind(&repo_path, &branch);
+            (branch, warning_kind)
+        })
+        .map_err(|err| format!("{err:#}"));
+    let _ = worker_tx.send(WorkerEvent::CheckoutProjectDefaultBranchInspected { project, result });
 }
 
 pub(crate) fn run_create_agent_job(

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -20,6 +20,7 @@ pub enum Action {
     OpenWorktreeInEditor,
     ChooseWorktreeEditor,
     RefreshProject,
+    CheckoutProjectDefaultBranch,
     ReconnectAgent,
     DeleteSession,
     DeleteTerminal,
@@ -196,6 +197,7 @@ impl Action {
             Action::OpenWorktreeInEditor => "open_worktree_in_editor",
             Action::ChooseWorktreeEditor => "choose_worktree_editor",
             Action::RefreshProject => "refresh_project",
+            Action::CheckoutProjectDefaultBranch => "checkout_project_default_branch",
             Action::ReconnectAgent => "reconnect_agent",
             Action::DeleteSession => "delete_session",
             Action::DeleteTerminal => "delete_terminal",
@@ -288,6 +290,9 @@ impl Action {
                 "Open a picker and choose which editor should open the selected agent worktree."
             }
             Action::RefreshProject => "Git pull the selected project checkout.",
+            Action::CheckoutProjectDefaultBranch => {
+                "Check out the default branch for the selected project."
+            }
             Action::ReconnectAgent => "Restart the CLI for the selected agent.",
             Action::DeleteSession => "Delete the selected session and worktree.",
             Action::DeleteTerminal => "Delete the selected companion terminal.",
@@ -376,6 +381,7 @@ impl Action {
             | Action::OpenWorktreeInEditor
             | Action::ChooseWorktreeEditor
             | Action::RefreshProject
+            | Action::CheckoutProjectDefaultBranch
             | Action::InteractAgent
             | Action::ReconnectAgent
             | Action::DeleteSession
@@ -692,6 +698,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "pull-project",
             description: "Git pull the selected project checkout",
+        }),
+    },
+    BindingDef {
+        action: Action::CheckoutProjectDefaultBranch,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "checkout-project-default-branch",
+            description: "Check out the selected project's default branch",
         }),
     },
     BindingDef {

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,7 +55,15 @@ pub struct Project {
     pub path: String,
     pub default_provider: ProviderKind,
     pub current_branch: String,
+    pub branch_status: ProjectBranchStatus,
     pub path_missing: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProjectBranchStatus {
+    Leading,
+    NotLeading,
+    Unknown,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
**What changed:** New agent creation now checks the selected project's checkout against the same leading/default branch rules used when adding projects. Known non-default checkouts show a checkout-and-create modal; unknown leading branches fail with an actionable status error.

**Why:** Agent worktrees inherit the project checkout, so creating one from a stale feature branch can quietly start work from the wrong base. The branch inspection runs in a background worker to keep the UI responsive.

**Verified:** `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.