### PR TITLE
Reload config from the command palette

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ The current app provides:
 - The app spawns CLI tools directly via PTY (portable-pty) and renders their output using an embedded terminal emulator built on alacritty_terminal. There is no protocol layer (no ACP, no JSON-RPC).
 - Long-running actions should not block the UI thread.
 - All periodic or potentially-blocking work (git commands, file I/O, network) must run in background workers, never on the main UI thread. Even fast operations like `git symbolic-ref` should use workers to prevent UI freezes if the filesystem or git lock stalls.
+- Async operations must keep the status line updated for the full operation lifecycle: set a Busy message when the worker starts, then replace it with a clear success or failure message when the worker completes. Do not start background work silently.
 - User state lives under `~/.dux/` on macOS and `$XDG_CONFIG_HOME/dux/` (or `~/.config/dux/`) on Linux.
 - Worktrees are user data and should not be removed or mutated casually.
 - Git operations should be explicit and conservative, especially around the source checkout.

--- a/src/app/components/button.rs
+++ b/src/app/components/button.rs
@@ -96,6 +96,8 @@ pub(crate) enum ButtonPressedTarget {
     ConfirmNonDefaultBranchAdd,
     ConfirmUseExistingBranchCancel,
     ConfirmUseExistingBranchUse,
+    ConfigReloadFailedClose,
+    ConfigReloadFailedApply,
 }
 
 /// In-flight state for a button the user is currently pressing. `target`

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -123,6 +123,8 @@ enum PromptMouseTarget {
     ConfirmNonDefaultBranchAdd,
     ConfirmUseExistingBranchCancel,
     ConfirmUseExistingBranchUse,
+    ConfigReloadFailedClose,
+    ConfigReloadFailedApply,
     Checkbox(OverlayCheckboxId),
     RenameInput,
     NameNewAgentInput,
@@ -198,6 +200,12 @@ impl ButtonPressedTarget {
             }
             PromptMouseTarget::ConfirmUseExistingBranchUse => {
                 Some(ButtonPressedTarget::ConfirmUseExistingBranchUse)
+            }
+            PromptMouseTarget::ConfigReloadFailedClose => {
+                Some(ButtonPressedTarget::ConfigReloadFailedClose)
+            }
+            PromptMouseTarget::ConfigReloadFailedApply => {
+                Some(ButtonPressedTarget::ConfigReloadFailedApply)
             }
             PromptMouseTarget::CommandInput
             | PromptMouseTarget::CommandItem(_)
@@ -2360,6 +2368,56 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::ConfigReloadFailed {
+            recover_old_config,
+            focus,
+            ..
+        } = &mut self.prompt
+        {
+            if is_reverse_tab(key) {
+                *focus = match *focus {
+                    ConfigReloadFailedFocus::Close => ConfigReloadFailedFocus::Checkbox,
+                    ConfigReloadFailedFocus::Apply => ConfigReloadFailedFocus::Close,
+                    ConfigReloadFailedFocus::Checkbox => ConfigReloadFailedFocus::Apply,
+                };
+                return Ok(false);
+            }
+            match self.bindings.lookup(&key, BindingScope::Dialog) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::ToggleSelection) => {
+                    *focus = match *focus {
+                        ConfigReloadFailedFocus::Close => ConfigReloadFailedFocus::Apply,
+                        ConfigReloadFailedFocus::Apply => ConfigReloadFailedFocus::Checkbox,
+                        ConfigReloadFailedFocus::Checkbox => ConfigReloadFailedFocus::Close,
+                    };
+                }
+                Some(Action::Confirm) => match *focus {
+                    ConfigReloadFailedFocus::Checkbox => {
+                        *recover_old_config = !*recover_old_config;
+                    }
+                    ConfigReloadFailedFocus::Close => {
+                        return Ok(self.resolve_config_reload_failed(false));
+                    }
+                    ConfigReloadFailedFocus::Apply => {
+                        return Ok(self.resolve_config_reload_failed(true));
+                    }
+                },
+                _ if key.code == KeyCode::Char(' ') => match *focus {
+                    ConfigReloadFailedFocus::Checkbox => {
+                        *recover_old_config = !*recover_old_config;
+                    }
+                    ConfigReloadFailedFocus::Close => {
+                        return Ok(self.resolve_config_reload_failed(false));
+                    }
+                    ConfigReloadFailedFocus::Apply => {
+                        return Ok(self.resolve_config_reload_failed(true));
+                    }
+                },
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ConfirmKillRunning(confirm_prompt) = &mut self.prompt {
             match self.bindings.lookup(&key, BindingScope::Dialog) {
                 Some(Action::CloseOverlay) => {
@@ -3280,6 +3338,21 @@ impl App {
                     None
                 }
             }
+            OverlayMouseLayout::ConfigReloadFailed {
+                close_button,
+                apply_button,
+                checkbox,
+            } => {
+                if contains_point(checkbox.rect, column, row) {
+                    Some(PromptMouseTarget::Checkbox(checkbox.id))
+                } else if contains_point(close_button, column, row) {
+                    Some(PromptMouseTarget::ConfigReloadFailedClose)
+                } else if contains_point(apply_button, column, row) {
+                    Some(PromptMouseTarget::ConfigReloadFailedApply)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::RenameSession { input, checkbox } => {
                 if checkbox.is_some_and(|checkbox| contains_point(checkbox.rect, column, row)) {
                     checkbox.map(|checkbox| PromptMouseTarget::Checkbox(checkbox.id))
@@ -4154,6 +4227,17 @@ impl App {
             OverlayCheckboxId::NameNewAgentRandomizedPetName => {
                 self.toggle_name_new_agent_randomized_name();
             }
+            OverlayCheckboxId::ConfigReloadRecoverOldConfig => {
+                if let PromptState::ConfigReloadFailed {
+                    recover_old_config,
+                    focus,
+                    ..
+                } = &mut self.prompt
+                {
+                    *recover_old_config = !*recover_old_config;
+                    *focus = ConfigReloadFailedFocus::Checkbox;
+                }
+            }
         }
     }
 
@@ -4438,7 +4522,9 @@ impl App {
             | PromptMouseTarget::ConfirmNonDefaultBranchCancel
             | PromptMouseTarget::ConfirmNonDefaultBranchAdd
             | PromptMouseTarget::ConfirmUseExistingBranchCancel
-            | PromptMouseTarget::ConfirmUseExistingBranchUse => {
+            | PromptMouseTarget::ConfirmUseExistingBranchUse
+            | PromptMouseTarget::ConfigReloadFailedClose
+            | PromptMouseTarget::ConfigReloadFailedApply => {
                 debug_assert!(
                     false,
                     "button target {:?} should be dispatched via activate_button, not \
@@ -4554,7 +4640,31 @@ impl App {
             ButtonPressedTarget::ConfirmUseExistingBranchUse => {
                 self.resolve_confirm_use_existing_branch(true)
             }
+            ButtonPressedTarget::ConfigReloadFailedClose => {
+                self.resolve_config_reload_failed(false)
+            }
+            ButtonPressedTarget::ConfigReloadFailedApply => self.resolve_config_reload_failed(true),
         }
+    }
+
+    fn resolve_config_reload_failed(&mut self, apply: bool) -> bool {
+        let recover = matches!(
+            &self.prompt,
+            PromptState::ConfigReloadFailed {
+                recover_old_config: true,
+                ..
+            }
+        );
+        if apply && !recover {
+            self.set_info("Check \"Recover last working config\" before restoring config.toml.");
+            return false;
+        }
+        self.prompt = PromptState::None;
+        if apply && recover {
+            self.spawn_config_recover_worker();
+            self.set_busy("Restoring the last working config.toml.");
+        }
+        false
     }
 
     fn activate_selected_left_item(&mut self) -> Result<()> {
@@ -5214,14 +5324,14 @@ mod tests {
     use super::DOUBLE_CLICK_THRESHOLD;
     use super::components::{ButtonPressedTarget, PressedButton};
     use crate::app::{
-        App, BranchWarningKind, CenterMode, ConfirmKillRunningPrompt, ConfirmNonDefaultBranchFocus,
-        CreateAgentRequest, DeleteAgentFocus, FocusPane, FullscreenOverlay, InputTarget,
-        KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
-        KillableRuntime, KillableRuntimeKind, LeftItem, LeftSection, MacroBarState,
-        MouseClickTarget, MouseLayoutState, NameNewAgentFocus, NonDefaultBranchAction,
-        OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout, OverlayMouseLayoutState,
-        ProcessInfo, PromptState, PullTarget, ResourceStats, RightSection, RuntimeTargetId,
-        TextInput, WorkerEvent,
+        App, BranchWarningKind, CenterMode, ConfigReloadFailedFocus, ConfirmKillRunningPrompt,
+        ConfirmNonDefaultBranchFocus, CreateAgentRequest, DeleteAgentFocus, FocusPane,
+        FullscreenOverlay, InputTarget, KillRunningAction, KillRunningFocus,
+        KillRunningFooterAction, KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftItem,
+        LeftSection, MacroBarState, MouseClickTarget, MouseLayoutState, NameNewAgentFocus,
+        NonDefaultBranchAction, OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout,
+        OverlayMouseLayoutState, ProcessInfo, PromptState, PullTarget, ResourceStats, RightSection,
+        RuntimeTargetId, TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -5539,6 +5649,116 @@ mod tests {
             items,
             offset: 0,
         };
+    }
+
+    fn drain_until(app: &mut App, mut done: impl FnMut(&App) -> bool) {
+        for _ in 0..50 {
+            app.drain_events();
+            if done(app) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        app.drain_events();
+    }
+
+    #[test]
+    fn reload_config_command_applies_valid_config_immediately_after_worker_completes() {
+        let mut app = test_app(default_bindings());
+        let mut config = Config::default();
+        config.ui.right_width_pct = 37;
+        config.ui.show_diff_line_numbers = true;
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        std::fs::write(
+            &app.paths.config_path,
+            crate::config::render_config_with(&config, &bindings),
+        )
+        .expect("write valid config");
+
+        app.execute_command("reload-config".to_string())
+            .expect("start reload config");
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Busy);
+        assert_eq!(app.status.message(), "Reloading config.toml.");
+
+        drain_until(&mut app, |app| app.config.ui.right_width_pct == 37);
+
+        assert_eq!(app.right_width_pct, 37);
+        assert!(app.show_diff_line_numbers);
+        assert!(matches!(app.prompt, PromptState::None));
+        assert_eq!(
+            app.status.message(),
+            "Configuration reloaded. New settings are active now."
+        );
+    }
+
+    #[test]
+    fn reload_config_command_keeps_current_config_and_opens_modal_on_validation_error() {
+        let mut app = test_app(default_bindings());
+        app.config.ui.right_width_pct = 41;
+        std::fs::write(
+            &app.paths.config_path,
+            r#"
+[keys]
+show_terminal_keys = true
+not_a_real_action = ["x"]
+"#,
+        )
+        .expect("write invalid config");
+
+        app.execute_command("reload-config".to_string())
+            .expect("start reload config");
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Busy);
+
+        drain_until(&mut app, |app| {
+            matches!(app.prompt, PromptState::ConfigReloadFailed { .. })
+        });
+
+        assert_eq!(app.config.ui.right_width_pct, 41);
+        assert_eq!(
+            app.status.message(),
+            "Config reload failed. Review the modal before retrying."
+        );
+        match &app.prompt {
+            PromptState::ConfigReloadFailed {
+                error,
+                recover_old_config,
+                focus,
+            } => {
+                assert!(error.contains("unknown action"));
+                assert!(!recover_old_config);
+                assert_eq!(*focus, ConfigReloadFailedFocus::Close);
+            }
+            other => panic!("expected config reload failure prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reload_config_failure_can_recover_last_working_config_file_async() {
+        let mut app = test_app(default_bindings());
+        app.config.ui.right_width_pct = 42;
+        std::fs::write(&app.paths.config_path, "this is not valid toml")
+            .expect("write broken config");
+        app.prompt = PromptState::ConfigReloadFailed {
+            error: "broken".to_string(),
+            recover_old_config: true,
+            focus: ConfigReloadFailedFocus::Apply,
+        };
+
+        app.resolve_config_reload_failed(true);
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Busy);
+        assert_eq!(
+            app.status.message(),
+            "Restoring the last working config.toml."
+        );
+
+        drain_until(&mut app, |app| {
+            app.status.message() == "Restored the last working configuration to config.toml."
+        });
+
+        assert!(matches!(app.prompt, PromptState::None));
+        let recovered = std::fs::read_to_string(&app.paths.config_path).expect("read recovered");
+        let parsed: Config = toml::from_str(&recovered).expect("parse recovered config");
+        assert_eq!(parsed.ui.right_width_pct, 42);
     }
 
     fn install_kill_running_overlay(app: &mut App, items: usize) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -493,6 +493,13 @@ pub(crate) struct ConfirmKillRunningPrompt {
     pub(crate) confirm_selected: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConfigReloadFailedFocus {
+    Close,
+    Apply,
+    Checkbox,
+}
+
 /// Which selectable element has focus in the Delete Agent confirmation modal.
 /// Focus cycles through all three via Tab / arrow keys / h / l.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -543,6 +550,11 @@ pub(crate) enum PromptState {
     ChangeTheme(ChangeThemePrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
+    ConfigReloadFailed {
+        error: String,
+        recover_old_config: bool,
+        focus: ConfigReloadFailedFocus,
+    },
     ConfirmDeleteAgent {
         session_id: String,
         branch_name: String,
@@ -860,6 +872,7 @@ pub(crate) enum OverlayCheckboxId {
     RenameSessionBranch,
     NonDefaultBranchCheckoutDefault,
     NameNewAgentRandomizedPetName,
+    ConfigReloadRecoverOldConfig,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -964,6 +977,11 @@ pub(crate) enum OverlayMouseLayout {
     ConfirmUseExistingBranch {
         cancel_button: Rect,
         use_button: Rect,
+    },
+    ConfigReloadFailed {
+        close_button: Rect,
+        apply_button: Rect,
+        checkbox: OverlayCheckbox,
     },
     RenameSession {
         input: Rect,
@@ -1109,6 +1127,8 @@ pub(crate) enum WorkerEvent {
         project: Project,
         result: Result<(String, Option<BranchWarningKind>), String>,
     },
+    ConfigReloadReady(Box<Result<Config, String>>),
+    ConfigRecoverCompleted(Result<(), String>),
 }
 
 #[derive(Clone, Debug)]
@@ -1672,6 +1692,7 @@ impl App {
             "change-default-provider" => self.open_change_default_provider_prompt(),
             "change-project-default-provider" => self.open_change_project_default_provider_prompt(),
             "change-theme" => self.open_change_theme_prompt(),
+            "reload-config" => self.reload_config_from_disk(),
             "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),
@@ -1844,6 +1865,64 @@ impl App {
                 Ok(())
             }
         }
+    }
+
+    pub(crate) fn reload_config_from_disk(&mut self) -> Result<()> {
+        self.spawn_config_reload_worker();
+        self.set_busy("Reloading config.toml.");
+        Ok(())
+    }
+
+    fn open_config_reload_failed_modal(&mut self, error: String) {
+        self.prompt = PromptState::ConfigReloadFailed {
+            error,
+            recover_old_config: false,
+            focus: ConfigReloadFailedFocus::Close,
+        };
+    }
+
+    fn apply_reloaded_config(&mut self, config: Config) -> Result<()> {
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        self.interactive_patterns = bindings.interactive_byte_patterns();
+        self.bindings = bindings;
+
+        let (theme, theme_warning) = crate::theme::load_or_fallback(&config.ui.theme, &self.paths);
+        self.theme = theme;
+        self.show_diff_line_numbers = config.ui.show_diff_line_numbers;
+        self.left_width_pct = config.ui.left_width_pct;
+        self.right_width_pct = config.ui.right_width_pct;
+        self.terminal_pane_height_pct = config.ui.terminal_pane_height_pct;
+        self.staged_pane_height_pct = config.ui.staged_pane_height_pct;
+        self.commit_pane_height_pct = config.ui.commit_pane_height_pct;
+        self.github_integration_enabled = config.ui.github_integration;
+        self.pr_banner_at_bottom = config.ui.pr_banner_position == "bottom";
+        self.config = config;
+
+        self.projects = load_projects(&self.config);
+        self.selected_left = self
+            .selected_left
+            .min(self.projects.len().saturating_sub(1));
+        self.rebuild_left_items();
+        if self.selected_left >= self.left_items_cache.len() {
+            self.selected_left = self.left_items_cache.len().saturating_sub(1);
+        }
+        self.update_branch_sync_sessions();
+        if self.github_integration_enabled
+            && matches!(self.gh_status, crate::model::GhStatus::Available)
+        {
+            self.update_pr_sync_sessions();
+            self.spawn_initial_pr_refresh();
+            self.pr_sync_enabled.store(true, Ordering::Relaxed);
+        } else {
+            self.pr_statuses.clear();
+            self.pr_sync_enabled.store(false, Ordering::Relaxed);
+        }
+        self.reload_changed_files();
+        self.refresh_current_diff()?;
+        if let Some(message) = theme_warning {
+            self.set_warning(message);
+        }
+        Ok(())
     }
 
     pub(crate) fn open_edit_macros(&mut self) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3796,6 +3796,128 @@ impl App {
                     kill_button: kill_area,
                 };
             }
+            PromptState::ConfigReloadFailed {
+                error,
+                recover_old_config,
+                focus,
+            } => {
+                self.render_dim_overlay(frame);
+                let dialog_width = 68.min(frame.area().width.max(1));
+                let inner_width = dialog_width.saturating_sub(2);
+                let checkbox_label = "Recover last working config";
+                let checkbox_state = if *focus == ConfigReloadFailedFocus::Checkbox {
+                    CheckboxState::Focused
+                } else {
+                    CheckboxState::Normal
+                };
+                let checkbox = Checkbox::new(checkbox_label)
+                    .checked(*recover_old_config)
+                    .state(checkbox_state);
+                let checkbox_height = checkbox
+                    .layout(
+                        inner_width,
+                        checkbox.marker_style(Style::default()),
+                        checkbox.label_style(Style::default()),
+                    )
+                    .height;
+
+                let mut body_lines = vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " config.toml could not be reloaded, so the running config was kept.",
+                        Style::default().fg(self.theme.warning_fg),
+                    )),
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " Validation error:",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )),
+                ];
+                for line in error.lines().take(6) {
+                    body_lines.push(Line::from(format!(" {line}")));
+                }
+                let body_height = wrapped_line_count(&body_lines, inner_width, false);
+                let area = centered_rect_exact(
+                    dialog_width,
+                    2 + body_height + 1 + checkbox_height + 3,
+                    frame.area(),
+                );
+                self.clear_overlay_area(frame, area);
+                let outer = self.themed_overlay_block("Reload Config Failed");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, _, checkbox_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(body_height),
+                        Constraint::Length(1),
+                        Constraint::Length(checkbox_height),
+                        Constraint::Length(3),
+                    ])
+                    .areas(inner);
+
+                Paragraph::new(body_lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let (checkbox_rect, _) = self.render_overlay_checkbox(
+                    frame,
+                    checkbox_area,
+                    checkbox_label,
+                    *recover_old_config,
+                    checkbox_state,
+                    None,
+                );
+                let checkbox = OverlayCheckbox {
+                    id: OverlayCheckboxId::ConfigReloadRecoverOldConfig,
+                    rect: checkbox_rect,
+                };
+
+                let btn_width = shared_button_width(&["Close", "Recover"]);
+                let gap = 2u16;
+                let total = btn_width * 2 + gap;
+                let left_offset = buttons_area.width.saturating_sub(total) / 2;
+
+                let close_area = Rect {
+                    x: buttons_area.x + left_offset,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+                let apply_area = Rect {
+                    x: close_area.x + btn_width + gap,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                Button::new("Close")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::ConfigReloadFailedClose,
+                        self.pressed_button,
+                        *focus == ConfigReloadFailedFocus::Close,
+                        true,
+                    ))
+                    .render(frame, close_area, &self.theme);
+
+                Button::new("Recover")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::ConfigReloadFailedApply,
+                        self.pressed_button,
+                        *focus == ConfigReloadFailedFocus::Apply,
+                        *recover_old_config,
+                    ))
+                    .render(frame, apply_area, &self.theme);
+
+                self.overlay_layout.active = OverlayMouseLayout::ConfigReloadFailed {
+                    close_button: close_area,
+                    apply_button: apply_area,
+                    checkbox,
+                };
+            }
             PromptState::ConfirmDeleteAgent {
                 branch_name,
                 focus,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -509,6 +509,37 @@ impl App {
                         )),
                     }
                 }
+                WorkerEvent::ConfigReloadReady(result) => match *result {
+                    Ok(config) => {
+                        if let Err(err) = self.apply_reloaded_config(config) {
+                            self.set_error(format!(
+                                "Config validation passed, but applying it failed: {err:#}"
+                            ));
+                        } else {
+                            self.set_info(
+                                "Configuration reloaded. New settings are active now.",
+                            );
+                        }
+                    }
+                    Err(message) => {
+                        self.open_config_reload_failed_modal(message);
+                        self.set_error(
+                            "Config reload failed. Review the modal before retrying.",
+                        );
+                    }
+                },
+                WorkerEvent::ConfigRecoverCompleted(result) => match result {
+                    Ok(()) => {
+                        self.set_info(
+                            "Restored the last working configuration to config.toml.",
+                        );
+                    }
+                    Err(message) => {
+                        self.set_error(format!(
+                            "Couldn't restore the last working configuration: {message}"
+                        ));
+                    }
+                },
             }
         }
         self.retry_hung_resume_sessions();
@@ -976,6 +1007,33 @@ impl App {
                     break; // receiver dropped, app is shutting down
                 }
             }
+        });
+    }
+
+    pub(crate) fn spawn_config_reload_worker(&self) {
+        let tx = self.worker_tx.clone();
+        let paths = self.paths.clone();
+        thread::spawn(move || {
+            let result = crate::config::ensure_config(&paths)
+                .map_err(|err| format!("{err:#}"))
+                .and_then(|config| match crate::config::validate_keys(&config.keys) {
+                    Ok(()) => Ok(config),
+                    Err(message) => Err(message),
+                });
+            let _ = tx.send(WorkerEvent::ConfigReloadReady(Box::new(result)));
+        });
+    }
+
+    pub(crate) fn spawn_config_recover_worker(&self) {
+        let tx = self.worker_tx.clone();
+        let config_path = self.paths.config_path.clone();
+        let config = self.config.clone();
+        thread::spawn(move || {
+            let bindings = RuntimeBindings::from_keys_config(&config.keys);
+            let rendered = crate::config::render_config_with(&config, &bindings);
+            let result = std::fs::write(&config_path, rendered)
+                .map_err(|err| format!("failed to write {}: {err}", config_path.display()));
+            let _ = tx.send(WorkerEvent::ConfigRecoverCompleted(result));
         });
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -90,6 +90,7 @@ pub enum Action {
     TogglePrBannerPosition,
     ForceReconnectAgent,
     ChangeTheme,
+    ReloadConfig,
 }
 
 /// Where a binding's key combo is matched.
@@ -260,6 +261,7 @@ impl Action {
             Action::TogglePrBannerPosition => "toggle_pr_banner_position",
             Action::ForceReconnectAgent => "force_reconnect_agent",
             Action::ChangeTheme => "change_theme",
+            Action::ReloadConfig => "reload_config",
         }
     }
 
@@ -363,6 +365,7 @@ impl Action {
             }
             Action::ForceReconnectAgent => "Restart the agent without resuming the prior session.",
             Action::ChangeTheme => "Open a picker to switch the dux color theme.",
+            Action::ReloadConfig => "Reload the configuration file.",
         }
     }
 
@@ -444,7 +447,8 @@ impl Action {
             | Action::ForceReconnectAgent
             | Action::ChangeDefaultProvider
             | Action::ChangeProjectDefaultProvider
-            | Action::ChangeTheme => None,
+            | Action::ChangeTheme
+            | Action::ReloadConfig => None,
         }
     }
 }
@@ -604,6 +608,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "change-theme",
             description: "Switch the dux color theme",
+        }),
+    },
+    BindingDef {
+        action: Action::ReloadConfig,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "reload-config",
+            description: "Reload config.toml after validating it",
         }),
     },
     BindingDef {
@@ -2255,6 +2270,17 @@ mod tests {
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
         assert!(names.contains(&"resource-monitor"));
+    }
+
+    #[test]
+    fn filtered_palette_includes_reload_config_command() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("reload");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"reload-config"));
     }
 
     #[test]


### PR DESCRIPTION
This adds a `reload-config` command palette entry so users can reload `config.toml` without restarting dux. Reload work runs asynchronously and keeps the status line updated while it is in progress.

When the new config validates, dux applies the refreshed settings immediately to the running app. If validation fails, the current running config stays active and dux shows a modal with the validation error.

The failure modal includes a recovery checkbox that restores the last working config back to disk through the same background-worker flow.