### PR TITLE
Open active PRs from the agent pane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,8 @@ Use:
 cargo fmt
 cargo clippy --all-targets --all-features -- -D warnings
 cargo test
-cargo run
 ```
 
 `cargo clippy --all-targets --all-features -- -D warnings` is a CI gate — the `Clippy` check on every pull request runs this exact command and fails the PR if it emits any warning. Run it locally before committing so a toolchain bump or a newly introduced lint doesn't surface only once the PR is pushed. A new stable Rust release can enable lints that previously passed; when that happens, fix the code rather than suppressing the lint unless there is a specific, documented reason.
+
+For interactive smoke testing, ask the user to run `cargo run` as a final sanity check rather than running it automatically.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -632,6 +632,9 @@ impl App {
                 Action::ShowTerminal if !in_diff => self.show_or_open_first_terminal()?,
                 Action::DeleteSession if !in_diff => self.confirm_delete_selected_session()?,
                 Action::RenameSession if !in_diff => self.open_rename_session()?,
+                Action::OpenCurrentPullRequest if !in_diff && self.current_pr_info().is_some() => {
+                    self.open_current_pr_in_browser()?
+                }
                 Action::ReconnectAgent if !in_diff => {
                     // Allow relaunching an exited agent from the center pane,
                     // or entering interactive mode if the agent is active.
@@ -1744,14 +1747,16 @@ impl App {
                     self.prompt = PromptState::None;
                 }
                 Some(Action::MoveDown) => {
-                    if let PromptState::Command {
-                        input, selected, ..
-                    } = &mut self.prompt
-                    {
-                        let count = self.bindings.filtered_palette(&input.text).len();
-                        if *selected + 1 < count {
-                            *selected += 1;
+                    let count = match &self.prompt {
+                        PromptState::Command { input, .. } => {
+                            self.filtered_palette(&input.text).len()
                         }
+                        _ => 0,
+                    };
+                    if let PromptState::Command { selected, .. } = &mut self.prompt
+                        && *selected + 1 < count
+                    {
+                        *selected += 1;
                     }
                 }
                 Some(Action::MoveUp) => {
@@ -1766,17 +1771,29 @@ impl App {
                 }
                 _ => {
                     // Text input fallback: Tab (autocomplete), then delegate to TextInput.
+                    let tab_completion = if key.code == KeyCode::Tab {
+                        match &self.prompt {
+                            PromptState::Command {
+                                input, selected, ..
+                            } => self
+                                .filtered_palette(&input.text)
+                                .get(*selected)
+                                .and_then(|binding| binding.palette_name)
+                                .map(str::to_string),
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
                     if let PromptState::Command {
                         input, selected, ..
                     } = &mut self.prompt
                     {
-                        if key.code == KeyCode::Tab {
-                            if let Some(binding) =
-                                self.bindings.filtered_palette(&input.text).get(*selected)
-                            {
-                                input.set_text(binding.palette_name.unwrap().to_string());
-                                *selected = 0;
-                            }
+                        if let Some(command) = tab_completion {
+                            input.set_text(command);
+                            *selected = 0;
+                        } else if key.code == KeyCode::Tab {
+                            // No completion matched; leave the command text unchanged.
                         } else if input.handle_key(key) {
                             *selected = 0;
                         }
@@ -3491,7 +3508,7 @@ impl App {
 
     fn set_command_palette_selection(&mut self, index: usize) {
         let count = match &self.prompt {
-            PromptState::Command { input, .. } => self.bindings.filtered_palette(&input.text).len(),
+            PromptState::Command { input, .. } => self.filtered_palette(&input.text).len(),
             _ => 0,
         };
         if count == 0 {
@@ -3519,7 +3536,7 @@ impl App {
             input, selected, ..
         } = &self.prompt
         {
-            if let Some(binding) = self.bindings.filtered_palette(&input.text).get(*selected) {
+            if let Some(binding) = self.filtered_palette(&input.text).get(*selected) {
                 binding.palette_name.unwrap().to_string()
             } else {
                 input.text.trim().to_string()
@@ -5228,8 +5245,8 @@ mod tests {
     use crate::editor::{DetectedEditor, EditorKind};
     use crate::keybindings::{Action, BINDING_DEFS, BindingScope, RuntimeBindings};
     use crate::model::{
-        AgentSession, ChangedFile, CompanionTerminalStatus, Project, ProjectBranchStatus,
-        ProviderKind, SessionStatus, SessionSurface,
+        AgentSession, ChangedFile, CompanionTerminalStatus, PrInfo, PrState, Project,
+        ProjectBranchStatus, ProviderKind, SessionStatus, SessionSurface,
     };
     use crate::pty::PtyClient;
     use crate::statusline::StatusLine;
@@ -7590,6 +7607,68 @@ mod tests {
             }
             other => panic!("expected command prompt, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn command_palette_hides_current_pr_command_without_known_pr() {
+        let app = test_app(default_bindings());
+        let commands = app.filtered_palette("open-current-pr");
+
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn command_palette_shows_current_pr_command_with_known_pr() {
+        let mut app = test_app(default_bindings());
+        app.pr_statuses.insert(
+            "session-1".to_string(),
+            PrInfo {
+                number: 42,
+                state: PrState::Merged,
+                title: "Demo PR".to_string(),
+                owner_repo: "owner/repo".to_string(),
+                url: "https://github.com/owner/repo/pull/42".to_string(),
+            },
+        );
+
+        let commands = app.filtered_palette("open-current-pr");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].palette_name, Some("open-current-pr"));
+        assert_eq!(
+            app.current_pr_url(),
+            Some("https://github.com/owner/repo/pull/42")
+        );
+    }
+
+    #[test]
+    fn footer_hints_show_pr_only_for_center_focus_with_known_pr() {
+        let mut app = test_app(default_bindings());
+        app.pr_statuses.insert(
+            "session-1".to_string(),
+            PrInfo {
+                number: 42,
+                state: PrState::Closed,
+                title: "Demo PR".to_string(),
+                owner_repo: "owner/repo".to_string(),
+                url: "https://github.com/owner/repo/pull/42".to_string(),
+            },
+        );
+
+        let center_hints = app.footer_hints_for(crate::keybindings::HintContext::Center);
+        let left_hints = app.footer_hints_for(crate::keybindings::HintContext::LeftSession);
+
+        assert_eq!(center_hints.first().map(|hint| hint.1), Some("PR"));
+        assert_eq!(center_hints.first().map(|hint| hint.0.as_str()), Some("p"));
+        assert!(!left_hints.iter().any(|(_, desc)| *desc == "PR"));
+    }
+
+    #[test]
+    fn footer_hints_hide_pr_without_known_pr() {
+        let app = test_app(default_bindings());
+        let center_hints = app.footer_hints_for(crate::keybindings::HintContext::Center);
+
+        assert!(!center_hints.iter().any(|(_, desc)| *desc == "PR"));
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -34,7 +34,7 @@ use crate::diff::SyntaxCache;
 use crate::editor::DetectedEditor;
 use crate::git;
 use crate::keybindings::{
-    Action, BindingScope, HintContext, InteractiveBytePatterns, RuntimeBindings,
+    Action, BindingScope, HintContext, InteractiveBytePatterns, RuntimeBinding, RuntimeBindings,
 };
 use crate::lockfile::SingleInstanceLock;
 use crate::logger;
@@ -1475,6 +1475,7 @@ impl App {
                     state,
                     title: pr.title,
                     owner_repo: pr.owner_repo,
+                    url: pr.url,
                 },
             );
         }
@@ -1624,6 +1625,21 @@ impl App {
         self.spawn_resource_stats_worker();
     }
 
+    pub(crate) fn filtered_palette(&self, input: &str) -> Vec<&RuntimeBinding> {
+        self.bindings
+            .filtered_palette(input)
+            .into_iter()
+            .filter(|binding| self.is_palette_action_available(binding.action))
+            .collect()
+    }
+
+    fn is_palette_action_available(&self, action: Action) -> bool {
+        match action {
+            Action::OpenCurrentPullRequest => self.current_pr_info().is_some(),
+            _ => true,
+        }
+    }
+
     /// Gather the labeled PIDs that the resource monitor should report on.
     /// Each entry is `(label, root_pid)` — the worker will aggregate the
     /// full process tree under each root.
@@ -1687,6 +1703,7 @@ impl App {
             "copy-path" => self.copy_selected_path(),
             "open-worktree" => self.open_selected_worktree_in_default_editor(),
             "open-worktree-with" => self.open_worktree_editor_picker(),
+            "open-current-pr" => self.open_current_pr_in_browser(),
             "toggle-project" => {
                 self.toggle_collapse_selected_project();
                 Ok(())

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1872,7 +1872,7 @@ impl App {
             FocusPane::Center => HintContext::Center,
             FocusPane::Files => HintContext::Files,
         };
-        let hints = self.bindings.hints_for(ctx);
+        let hints = self.footer_hints_for(ctx);
         let [hints_area, status_area] = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(1), Constraint::Min(1)])
@@ -1940,6 +1940,17 @@ impl App {
             .style(Style::default().bg(status_bg))
             .wrap(Wrap { trim: false })
             .render(status_area, frame.buffer_mut());
+    }
+
+    pub(crate) fn footer_hints_for(&self, ctx: HintContext) -> Vec<(String, &'static str)> {
+        let mut hints = self.bindings.hints_for(ctx);
+        if matches!(ctx, HintContext::Center) && self.current_pr_info().is_some() {
+            let key = self.bindings.label_for(Action::OpenCurrentPullRequest);
+            if !key.is_empty() {
+                hints.insert(0, (key, "PR"));
+            }
+        }
+        hints
     }
 
     fn render_help(&mut self, frame: &mut Frame) {
@@ -2253,7 +2264,7 @@ impl App {
                 self.render_dim_overlay(frame);
                 let popup = centered_rect(72, 40, frame.area());
                 self.clear_overlay_area(frame, popup);
-                let commands = self.bindings.filtered_palette(&input.text);
+                let commands = self.filtered_palette(&input.text);
                 let items = if commands.is_empty() {
                     vec![ListItem::new("No matching commands.")]
                 } else {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::browser;
 use crate::editor;
 
 impl App {
@@ -1721,6 +1722,30 @@ impl App {
         self.set_info(format!(
             "Opened agent \"{session_label}\" in {} via {}.",
             editor_choice.label, editor_choice.command
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn current_pr_info(&self) -> Option<&crate::model::PrInfo> {
+        self.selected_session()
+            .and_then(|session| self.pr_statuses.get(&session.id))
+    }
+
+    pub(crate) fn current_pr_url(&self) -> Option<&str> {
+        self.current_pr_info().map(|pr| pr.url.as_str())
+    }
+
+    pub(crate) fn open_current_pr_in_browser(&mut self) -> Result<()> {
+        let Some(pr) = self.current_pr_info().cloned() else {
+            self.set_error("No pull request is known for the selected agent yet.");
+            return Ok(());
+        };
+
+        let url = self.current_pr_url().unwrap_or(pr.url.as_str()).to_string();
+        browser::open_url(&url)?;
+        self.set_info(format!(
+            "Opened PR {}#{} in the default browser.",
+            pr.owner_repo, pr.number
         ));
         Ok(())
     }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -216,15 +216,15 @@ impl App {
                                     crate::model::PrState::Merged => "MERGED",
                                     crate::model::PrState::Closed => "CLOSED",
                                 };
-                                let _ = self.session_store.upsert_pr(
-                                    &session_id,
-                                    pr.number,
-                                    &pr.host,
-                                    &pr.owner_repo,
-                                    state_str,
-                                    &pr.title,
-                                    &pr.url,
-                                );
+                                let _ = self.session_store.upsert_pr(&crate::storage::StoredPr {
+                                    session_id: session_id.clone(),
+                                    pr_number: pr.number,
+                                    host: pr.host.clone(),
+                                    owner_repo: pr.owner_repo.clone(),
+                                    state: state_str.to_string(),
+                                    title: pr.title.clone(),
+                                    url: pr.url.clone(),
+                                });
                                 self.pr_statuses.insert(session_id, pr);
                                 changed = true;
                             }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -222,6 +222,7 @@ impl App {
                                     &pr.owner_repo,
                                     state_str,
                                     &pr.title,
+                                    &pr.url,
                                 );
                                 self.pr_statuses.insert(session_id, pr);
                                 changed = true;
@@ -1504,6 +1505,7 @@ fn reconstruct_from_stored(stored: &crate::storage::StoredPr) -> Option<crate::m
         state,
         title: stored.title.clone(),
         owner_repo: stored.owner_repo.clone(),
+        url: stored.url.clone(),
     })
 }
 
@@ -1521,7 +1523,7 @@ fn view_pr_by_number(
             "--repo",
             owner_repo,
             "--json",
-            "number,state,title",
+            "number,state,title,url",
         ])
         .output()
         .ok()?;
@@ -1555,7 +1557,7 @@ fn discover_pr_by_branch(
             "--state",
             "all",
             "--json",
-            "number,state,title",
+            "number,state,title,url",
             "--limit",
             "1",
         ])
@@ -1593,6 +1595,12 @@ fn parse_pr_json_value(obj: &serde_json::Value, owner_repo: &str) -> Option<crat
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    let url = obj
+        .get("url")
+        .and_then(|v| v.as_str())
+        .filter(|v| !v.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| crate::storage::fallback_pr_url(owner_repo, number));
     let state = match state_str {
         "OPEN" => PrState::Open,
         "MERGED" => PrState::Merged,
@@ -1605,5 +1613,37 @@ fn parse_pr_json_value(obj: &serde_json::Value, owner_repo: &str) -> Option<crat
         state,
         title,
         owner_repo: owner_repo.to_string(),
+        url,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::PrState;
+
+    #[test]
+    fn parse_pr_json_object_uses_gh_url_when_present() {
+        let pr = parse_pr_json_object(
+            r#"{"number":42,"state":"OPEN","title":"Demo","url":"https://github.com/owner/repo/pull/42"}"#,
+            "owner/repo",
+        )
+        .expect("pr");
+
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.state, PrState::Open);
+        assert_eq!(pr.url, "https://github.com/owner/repo/pull/42");
+    }
+
+    #[test]
+    fn parse_pr_json_object_falls_back_to_github_url() {
+        let pr = parse_pr_json_object(
+            r#"{"number":42,"state":"MERGED","title":"Demo"}"#,
+            "owner/repo",
+        )
+        .expect("pr");
+
+        assert_eq!(pr.state, PrState::Merged);
+        assert_eq!(pr.url, "https://github.com/owner/repo/pull/42");
+    }
 }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,0 +1,37 @@
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result};
+
+pub fn open_url(url: &str) -> Result<()> {
+    let launcher = default_browser_launcher();
+    Command::new(launcher)
+        .arg(url)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to launch default browser via {launcher}"))?;
+    Ok(())
+}
+
+fn default_browser_launcher() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn browser_launcher_matches_supported_platform() {
+        if cfg!(target_os = "macos") {
+            assert_eq!(default_browser_launcher(), "open");
+        } else {
+            assert_eq!(default_browser_launcher(), "xdg-open");
+        }
+    }
+}

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -29,6 +29,7 @@ pub enum Action {
     ShowTerminal,
     ExitInteractive,
     OpenMacroBar,
+    OpenCurrentPullRequest,
     ToggleFullscreen,
     ScrollPageUp,
     ScrollPageDown,
@@ -205,6 +206,7 @@ impl Action {
             Action::ShowTerminal => "show_terminal",
             Action::ExitInteractive => "exit_interactive",
             Action::OpenMacroBar => "open_macro_bar",
+            Action::OpenCurrentPullRequest => "open_current_pull_request",
             Action::ToggleFullscreen => "toggle_fullscreen",
             Action::ScrollPageUp => "scroll_page_up",
             Action::ScrollPageDown => "scroll_page_down",
@@ -303,6 +305,9 @@ impl Action {
             Action::NewTerminal => "Spawn a new companion terminal for the selected agent.",
             Action::ExitInteractive => "Exit interactive mode (stop forwarding keys to agent).",
             Action::OpenMacroBar => "Open the macro command bar to send text macros.",
+            Action::OpenCurrentPullRequest => {
+                "Open the selected agent's current pull request in the default browser."
+            }
             Action::ToggleFullscreen => "Toggle fullscreen overlay for the agent terminal.",
             Action::ScrollPageUp => "Scroll up one page in the agent output.",
             Action::ScrollPageDown => "Scroll down one page in the agent output.",
@@ -388,6 +393,7 @@ impl Action {
             | Action::DeleteTerminal => Some("Projects pane"),
             Action::ExitInteractive
             | Action::OpenMacroBar
+            | Action::OpenCurrentPullRequest
             | Action::ToggleFullscreen
             | Action::ScrollPageUp
             | Action::ScrollPageDown
@@ -808,6 +814,20 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         }),
         hint_contexts: &[],
         palette: None,
+    },
+    BindingDef {
+        action: Action::OpenCurrentPullRequest,
+        default_keys: &[key!(p)],
+        scopes: &[BindingScope::Center],
+        help: Some(HelpEntry {
+            section: "Agent pane",
+            description: "Open current pull request in the default browser",
+        }),
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "open-current-pr",
+            description: "Open the selected agent's current pull request in the default browser",
+        }),
     },
     BindingDef {
         action: Action::ToggleFullscreen,
@@ -2140,6 +2160,29 @@ mod tests {
         let move_hint = hints.iter().find(|(_, desc)| *desc == "Move");
         assert!(move_hint.is_some());
         assert_eq!(move_hint.unwrap().0, "j/k");
+    }
+
+    #[test]
+    fn open_current_pr_key_is_center_pane_only() {
+        let bindings = default_bindings();
+        let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
+
+        assert_eq!(
+            bindings.lookup(&key, BindingScope::Center),
+            Some(Action::OpenCurrentPullRequest)
+        );
+        assert_ne!(
+            bindings.lookup(&key, BindingScope::Left),
+            Some(Action::OpenCurrentPullRequest)
+        );
+        assert_ne!(
+            bindings.lookup(&key, BindingScope::Files),
+            Some(Action::OpenCurrentPullRequest)
+        );
+        assert_ne!(
+            bindings.lookup(&key, BindingScope::Interactive),
+            Some(Action::OpenCurrentPullRequest)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod browser;
 mod cli;
 mod clipboard;
 mod config;

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,6 +29,7 @@ pub struct PrInfo {
     pub state: PrState,
     pub title: String,
     pub owner_repo: String,
+    pub url: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -91,16 +91,7 @@ impl SessionStore {
     }
 
     /// Insert a PR association or update its state and title if it already exists.
-    pub fn upsert_pr(
-        &self,
-        session_id: &str,
-        pr_number: u64,
-        host: &str,
-        owner_repo: &str,
-        state: &str,
-        title: &str,
-        url: &str,
-    ) -> Result<()> {
+    pub fn upsert_pr(&self, pr: &StoredPr) -> Result<()> {
         self.conn.execute(
             r#"
             insert into session_prs (session_id, pr_number, host, owner_repo, state, title, url)
@@ -113,13 +104,13 @@ impl SessionStore {
                 url=excluded.url
             "#,
             params![
-                session_id,
-                pr_number as i64,
-                host,
-                owner_repo,
-                state,
-                title,
-                url
+                pr.session_id,
+                pr.pr_number as i64,
+                pr.host,
+                pr.owner_repo,
+                pr.state,
+                pr.title,
+                pr.url
             ],
         )?;
         Ok(())
@@ -398,15 +389,15 @@ mod pr_tests {
     use super::*;
     use chrono::Duration;
 
-    fn spr(sid: &str, num: u64, repo: &str, state: &str, title: &str) -> StoredPr {
+    fn spr(sid: &str, num: u64, host: &str, repo: &str, state: &str, title: &str) -> StoredPr {
         StoredPr {
             session_id: sid.to_string(),
             pr_number: num,
-            host: "github.com".to_string(),
+            host: host.to_string(),
             owner_repo: repo.to_string(),
             state: state.to_string(),
             title: title.to_string(),
-            url: fallback_pr_url("github.com", repo, num),
+            url: fallback_pr_url(host, repo, num),
         }
     }
 
@@ -418,36 +409,50 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 10, "github.com", "owner/repo", "OPEN", "First PR", "")
+            .upsert_pr(&spr(
+                "s1",
+                10,
+                "github.com",
+                "owner/repo",
+                "OPEN",
+                "First PR",
+            ))
             .unwrap();
         store
-            .upsert_pr(
+            .upsert_pr(&spr(
                 "s1",
                 20,
                 "github.com",
                 "owner/repo",
                 "OPEN",
                 "Second PR",
-                "",
-            )
+            ))
             .unwrap();
         store
-            .upsert_pr(
+            .upsert_pr(&spr(
                 "s1",
                 15,
                 "github.com",
                 "owner/repo",
                 "MERGED",
                 "Middle PR",
-                "",
-            )
+            ))
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
         assert_eq!(prs.len(), 3);
-        assert_eq!(prs[0], spr("s1", 20, "owner/repo", "OPEN", "Second PR"));
-        assert_eq!(prs[1], spr("s1", 15, "owner/repo", "MERGED", "Middle PR"));
-        assert_eq!(prs[2], spr("s1", 10, "owner/repo", "OPEN", "First PR"));
+        assert_eq!(
+            prs[0],
+            spr("s1", 20, "github.com", "owner/repo", "OPEN", "Second PR")
+        );
+        assert_eq!(
+            prs[1],
+            spr("s1", 15, "github.com", "owner/repo", "MERGED", "Middle PR")
+        );
+        assert_eq!(
+            prs[2],
+            spr("s1", 10, "github.com", "owner/repo", "OPEN", "First PR")
+        );
     }
 
     #[test]
@@ -458,18 +463,20 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 42, "github.com", "owner/repo", "OPEN", "My PR", "")
+            .upsert_pr(&spr("s1", 42, "github.com", "owner/repo", "OPEN", "My PR"))
             .unwrap();
         store
-            .upsert_pr(
-                "s1",
-                42,
-                "github.example.com",
-                "owner/repo",
-                "MERGED",
-                "My PR (updated)",
-                "https://github.com/owner/repo/pull/42",
-            )
+            .upsert_pr(&StoredPr {
+                url: "https://github.com/owner/repo/pull/42".to_string(),
+                ..spr(
+                    "s1",
+                    42,
+                    "github.example.com",
+                    "owner/repo",
+                    "MERGED",
+                    "My PR (updated)",
+                )
+            })
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
@@ -490,27 +497,54 @@ mod pr_tests {
         store.upsert_session(&s2).unwrap();
 
         store
-            .upsert_pr("s1", 10, "github.com", "owner/repo", "CLOSED", "Old PR", "")
+            .upsert_pr(&spr(
+                "s1",
+                10,
+                "github.com",
+                "owner/repo",
+                "CLOSED",
+                "Old PR",
+            ))
             .unwrap();
         store
-            .upsert_pr(
+            .upsert_pr(&spr(
                 "s1",
                 20,
                 "github.com",
                 "owner/repo",
                 "MERGED",
                 "Latest PR",
-                "",
-            )
+            ))
             .unwrap();
         store
-            .upsert_pr("s2", 5, "github.com", "other/repo", "OPEN", "Other PR", "")
+            .upsert_pr(&spr(
+                "s2",
+                5,
+                "github.com",
+                "other/repo",
+                "OPEN",
+                "Other PR",
+            ))
             .unwrap();
 
         let latest = store.load_all_latest_prs().unwrap();
         assert_eq!(latest.len(), 2);
-        assert!(latest.contains(&spr("s1", 20, "owner/repo", "MERGED", "Latest PR")));
-        assert!(latest.contains(&spr("s2", 5, "other/repo", "OPEN", "Other PR")));
+        assert!(latest.contains(&spr(
+            "s1",
+            20,
+            "github.com",
+            "owner/repo",
+            "MERGED",
+            "Latest PR"
+        )));
+        assert!(latest.contains(&spr(
+            "s2",
+            5,
+            "github.com",
+            "other/repo",
+            "OPEN",
+            "Other PR"
+        )));
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,6 +12,7 @@ pub struct StoredPr {
     pub owner_repo: String,
     pub state: String,
     pub title: String,
+    pub url: String,
 }
 
 pub struct SessionStore {
@@ -77,6 +78,7 @@ impl SessionStore {
             "title",
             "text not null default ''",
         )?;
+        ensure_column(&self.conn, "session_prs", "url", "text not null default ''")?;
         Ok(())
     }
 
@@ -88,16 +90,18 @@ impl SessionStore {
         owner_repo: &str,
         state: &str,
         title: &str,
+        url: &str,
     ) -> Result<()> {
         self.conn.execute(
             r#"
-            insert into session_prs (session_id, pr_number, owner_repo, state, title)
-            values (?1, ?2, ?3, ?4, ?5)
+            insert into session_prs (session_id, pr_number, owner_repo, state, title, url)
+            values (?1, ?2, ?3, ?4, ?5, ?6)
             on conflict(session_id, pr_number) do update set
                 state=excluded.state,
-                title=excluded.title
+                title=excluded.title,
+                url=excluded.url
             "#,
-            params![session_id, pr_number as i64, owner_repo, state, title],
+            params![session_id, pr_number as i64, owner_repo, state, title, url],
         )?;
         Ok(())
     }
@@ -106,7 +110,7 @@ impl SessionStore {
     pub fn load_prs(&self, session_id: &str) -> Result<Vec<StoredPr>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select pr_number, owner_repo, state, title
+            select pr_number, owner_repo, state, title, url
             from session_prs
             where session_id = ?1
             order by pr_number desc
@@ -120,6 +124,7 @@ impl SessionStore {
                 owner_repo: row.get(1)?,
                 state: row.get(2)?,
                 title: row.get(3)?,
+                url: normalize_pr_url(row.get(4)?, row.get(1)?, row.get::<_, i64>(0)? as u64),
             })
         })?;
         let mut prs = Vec::new();
@@ -133,7 +138,7 @@ impl SessionStore {
     pub fn load_all_latest_prs(&self) -> Result<Vec<StoredPr>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select session_id, pr_number, owner_repo, state, title
+            select session_id, pr_number, owner_repo, state, title, url
             from session_prs
             where (session_id, pr_number) in (
                 select session_id, max(pr_number) from session_prs group by session_id
@@ -147,6 +152,7 @@ impl SessionStore {
                 owner_repo: row.get(2)?,
                 state: row.get(3)?,
                 title: row.get(4)?,
+                url: normalize_pr_url(row.get(5)?, row.get(2)?, row.get::<_, i64>(1)? as u64),
             })
         })?;
         let mut result = Vec::new();
@@ -246,6 +252,18 @@ fn serialize_started_providers(started_providers: &[String]) -> String {
 
 fn parse_started_providers(value: &str) -> Vec<String> {
     serde_json::from_str::<Vec<String>>(value).unwrap_or_default()
+}
+
+pub fn fallback_pr_url(owner_repo: &str, pr_number: u64) -> String {
+    format!("https://github.com/{owner_repo}/pull/{pr_number}")
+}
+
+fn normalize_pr_url(url: String, owner_repo: String, pr_number: u64) -> String {
+    if url.trim().is_empty() {
+        fallback_pr_url(&owner_repo, pr_number)
+    } else {
+        url
+    }
 }
 
 /// Opens an in-memory session store for tests.
@@ -355,6 +373,7 @@ mod pr_tests {
             owner_repo: repo.to_string(),
             state: state.to_string(),
             title: title.to_string(),
+            url: fallback_pr_url(repo, num),
         }
     }
 
@@ -366,13 +385,13 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 10, "owner/repo", "OPEN", "First PR")
+            .upsert_pr("s1", 10, "owner/repo", "OPEN", "First PR", "")
             .unwrap();
         store
-            .upsert_pr("s1", 20, "owner/repo", "OPEN", "Second PR")
+            .upsert_pr("s1", 20, "owner/repo", "OPEN", "Second PR", "")
             .unwrap();
         store
-            .upsert_pr("s1", 15, "owner/repo", "MERGED", "Middle PR")
+            .upsert_pr("s1", 15, "owner/repo", "MERGED", "Middle PR", "")
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
@@ -390,16 +409,24 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 42, "owner/repo", "OPEN", "My PR")
+            .upsert_pr("s1", 42, "owner/repo", "OPEN", "My PR", "")
             .unwrap();
         store
-            .upsert_pr("s1", 42, "owner/repo", "MERGED", "My PR (updated)")
+            .upsert_pr(
+                "s1",
+                42,
+                "owner/repo",
+                "MERGED",
+                "My PR (updated)",
+                "https://github.com/owner/repo/pull/42",
+            )
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
         assert_eq!(prs.len(), 1);
         assert_eq!(prs[0].state, "MERGED");
         assert_eq!(prs[0].title, "My PR (updated)");
+        assert_eq!(prs[0].url, "https://github.com/owner/repo/pull/42");
     }
 
     #[test]
@@ -412,13 +439,13 @@ mod pr_tests {
         store.upsert_session(&s2).unwrap();
 
         store
-            .upsert_pr("s1", 10, "owner/repo", "CLOSED", "Old PR")
+            .upsert_pr("s1", 10, "owner/repo", "CLOSED", "Old PR", "")
             .unwrap();
         store
-            .upsert_pr("s1", 20, "owner/repo", "MERGED", "Latest PR")
+            .upsert_pr("s1", 20, "owner/repo", "MERGED", "Latest PR", "")
             .unwrap();
         store
-            .upsert_pr("s2", 5, "other/repo", "OPEN", "Other PR")
+            .upsert_pr("s2", 5, "other/repo", "OPEN", "Other PR", "")
             .unwrap();
 
         let latest = store.load_all_latest_prs().unwrap();


### PR DESCRIPTION
Adds a conditional command palette action and agent-pane keybinding for opening the selected session's known pull request in the user's default browser. The command and footer hint only appear when PR data is available for that session.

The GitHub PR cache now stores canonical PR URLs from `gh` and falls back to the standard GitHub pull request URL for older cached entries. Browser launch uses the platform default opener without adding a new dependency.