### PR TITLE
Separate empty projects in longer project lists

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -527,12 +527,11 @@ impl App {
             return self.handle_left_terminal_key(key);
         }
 
-        let item_count = self.left_items().len();
         if let Some(action) = self.bindings.lookup(&key, BindingScope::Left) {
             match action {
                 Action::MoveDown => {
-                    if self.selected_left + 1 < item_count {
-                        self.selected_left += 1;
+                    if let Some(next) = self.next_selectable_left_item_after(self.selected_left) {
+                        self.selected_left = next;
                         self.close_diff_view();
                         self.reload_changed_files();
                         self.update_missing_project_warning();
@@ -543,11 +542,15 @@ impl App {
                         self.close_diff_view();
                     }
                 }
-                Action::MoveUp if self.selected_left > 0 => {
-                    self.selected_left -= 1;
-                    self.close_diff_view();
-                    self.reload_changed_files();
-                    self.update_missing_project_warning();
+                Action::MoveUp => {
+                    if let Some(prev) =
+                        self.previous_selectable_left_item_before(self.selected_left)
+                    {
+                        self.selected_left = prev;
+                        self.close_diff_view();
+                        self.reload_changed_files();
+                        self.update_missing_project_warning();
+                    }
                 }
                 Action::FocusAgent | Action::ExitInteractive => {
                     self.activate_selected_left_item()?
@@ -611,9 +614,14 @@ impl App {
                     } else {
                         // Jump back to projects section.
                         self.left_section = LeftSection::Projects;
-                        let item_count = self.left_items().len();
-                        if item_count > 0 {
-                            self.selected_left = item_count - 1;
+                        if let Some(last) = self
+                            .left_items()
+                            .iter()
+                            .enumerate()
+                            .rev()
+                            .find_map(|(idx, item)| item.is_selectable().then_some(idx))
+                        {
+                            self.selected_left = last;
                             self.close_diff_view();
                         }
                     }
@@ -3428,6 +3436,9 @@ impl App {
             }
             let index = usize::from(row.saturating_sub(self.mouse_layout.left_list.y));
             if index < self.left_items().len() {
+                if !self.is_selectable_left_item(index) {
+                    return Some(MouseTarget::LeftPane);
+                }
                 return Some(MouseTarget::LeftRow(index));
             }
             return Some(MouseTarget::LeftPane);
@@ -3568,7 +3579,7 @@ impl App {
     }
 
     fn set_left_selection(&mut self, index: usize) {
-        if index >= self.left_items().len() {
+        if !self.is_selectable_left_item(index) {
             return;
         }
         self.focus = FocusPane::Left;
@@ -4792,6 +4803,7 @@ impl App {
                     self.reconnect_selected_session()?;
                 }
             }
+            Some(LeftItem::EmptyProjectsSeparator) => {}
             None => {}
         }
         Ok(())
@@ -4909,12 +4921,12 @@ impl App {
         self.set_left_selection(target_index);
 
         if down {
-            if self.selected_left + 1 < self.left_items().len() {
-                self.selected_left += 1;
+            if let Some(next) = self.next_selectable_left_item_after(self.selected_left) {
+                self.selected_left = next;
                 self.reload_changed_files();
             }
-        } else if self.selected_left > 0 {
-            self.selected_left -= 1;
+        } else if let Some(prev) = self.previous_selectable_left_item_before(self.selected_left) {
+            self.selected_left = prev;
             self.reload_changed_files();
         }
     }
@@ -7621,6 +7633,58 @@ not_a_real_action = ["x"]
 
         assert_eq!(app.selected_left, 0);
         assert!(matches!(app.center_mode, CenterMode::Agent));
+    }
+
+    fn append_empty_projects(app: &mut App, count: usize) {
+        let path = app.projects[0].path.clone();
+        for idx in 0..count {
+            app.projects.push(Project {
+                id: format!("empty-project-{idx}"),
+                name: format!("empty {idx}"),
+                path: path.clone(),
+                default_provider: ProviderKind::from_str("codex"),
+                current_branch: "main".to_string(),
+                branch_status: ProjectBranchStatus::Unknown,
+                path_missing: false,
+            });
+        }
+    }
+
+    #[test]
+    fn left_navigation_skips_empty_projects_separator() {
+        let mut app = test_app(default_bindings());
+        append_empty_projects(&mut app, 4);
+        app.config.ui.empty_project_separator_min_projects = 5;
+        app.rebuild_left_items();
+        app.selected_left = 1;
+        app.focus = FocusPane::Left;
+
+        assert!(matches!(
+            app.left_items().get(2),
+            Some(LeftItem::EmptyProjectsSeparator)
+        ));
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .unwrap();
+        assert_eq!(app.selected_left, 3);
+
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+            .unwrap();
+        assert_eq!(app.selected_left, 1);
+    }
+
+    #[test]
+    fn mouse_click_empty_projects_separator_keeps_selection() {
+        let mut app = test_app(default_bindings());
+        append_empty_projects(&mut app, 4);
+        app.config.ui.empty_project_separator_min_projects = 5;
+        app.rebuild_left_items();
+        install_mouse_layout(&mut app);
+        app.selected_left = 1;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 3));
+
+        assert_eq!(app.selected_left, 1);
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -3600,6 +3600,7 @@ impl App {
                 .and_then(|item| match item {
                     LeftItem::Project(project_index) => self.projects.get(*project_index),
                     LeftItem::Session(_) => None,
+                    LeftItem::EmptyProjectsSeparator => None,
                 })
                 .is_some_and(|project| {
                     !project.path_missing

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1047,10 +1047,91 @@ pub(crate) enum LeftSection {
     Terminals,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum LeftItem {
     Project(usize),
     Session(usize),
+    EmptyProjectsSeparator,
+}
+
+impl LeftItem {
+    pub(crate) fn is_selectable(self) -> bool {
+        matches!(self, LeftItem::Project(_) | LeftItem::Session(_))
+    }
+}
+
+pub(crate) fn build_left_items(
+    projects: &[Project],
+    sessions: &[AgentSession],
+    collapsed_projects: &HashSet<String>,
+    empty_project_separator_min_projects: u16,
+) -> Vec<LeftItem> {
+    let split_empty_projects = empty_project_separator_min_projects > 0
+        && projects.len() >= usize::from(empty_project_separator_min_projects);
+    let mut items = Vec::new();
+    let mut empty_projects = Vec::new();
+
+    for (project_index, project) in projects.iter().enumerate() {
+        let has_sessions = sessions
+            .iter()
+            .any(|session| session.project_id == project.id);
+        if split_empty_projects && !has_sessions {
+            empty_projects.push(project_index);
+            continue;
+        }
+        push_project_left_items(
+            &mut items,
+            project_index,
+            project,
+            sessions,
+            collapsed_projects,
+        );
+    }
+
+    if !items.is_empty() && !empty_projects.is_empty() {
+        items.push(LeftItem::EmptyProjectsSeparator);
+        for project_index in empty_projects {
+            let project = &projects[project_index];
+            push_project_left_items(
+                &mut items,
+                project_index,
+                project,
+                sessions,
+                collapsed_projects,
+            );
+        }
+    } else {
+        for project_index in empty_projects {
+            let project = &projects[project_index];
+            push_project_left_items(
+                &mut items,
+                project_index,
+                project,
+                sessions,
+                collapsed_projects,
+            );
+        }
+    }
+
+    items
+}
+
+fn push_project_left_items(
+    items: &mut Vec<LeftItem>,
+    project_index: usize,
+    project: &Project,
+    sessions: &[AgentSession],
+    collapsed_projects: &HashSet<String>,
+) {
+    items.push(LeftItem::Project(project_index));
+    if project.path_missing || collapsed_projects.contains(&project.id) {
+        return;
+    }
+    for (session_index, session) in sessions.iter().enumerate() {
+        if session.project_id == project.id {
+            items.push(LeftItem::Session(session_index));
+        }
+    }
 }
 
 pub(crate) struct CompanionTerminal {
@@ -2035,19 +2116,54 @@ impl App {
     }
 
     pub(crate) fn rebuild_left_items(&mut self) {
-        let mut items = Vec::new();
-        for (project_index, project) in self.projects.iter().enumerate() {
-            items.push(LeftItem::Project(project_index));
-            if project.path_missing || self.collapsed_projects.contains(&project.id) {
-                continue;
-            }
-            for (session_index, session) in self.sessions.iter().enumerate() {
-                if session.project_id == project.id {
-                    items.push(LeftItem::Session(session_index));
-                }
-            }
+        self.left_items_cache = build_left_items(
+            &self.projects,
+            &self.sessions,
+            &self.collapsed_projects,
+            self.config.ui.empty_project_separator_min_projects,
+        );
+        self.ensure_selectable_left_item();
+    }
+
+    pub(crate) fn is_selectable_left_item(&self, index: usize) -> bool {
+        self.left_items()
+            .get(index)
+            .is_some_and(|item| item.is_selectable())
+    }
+
+    pub(crate) fn next_selectable_left_item_after(&self, index: usize) -> Option<usize> {
+        self.left_items()
+            .iter()
+            .enumerate()
+            .skip(index.saturating_add(1))
+            .find_map(|(idx, item)| item.is_selectable().then_some(idx))
+    }
+
+    pub(crate) fn previous_selectable_left_item_before(&self, index: usize) -> Option<usize> {
+        self.left_items()
+            .iter()
+            .enumerate()
+            .take(index)
+            .rev()
+            .find_map(|(idx, item)| item.is_selectable().then_some(idx))
+    }
+
+    pub(crate) fn ensure_selectable_left_item(&mut self) {
+        if self.left_items_cache.is_empty() {
+            self.selected_left = 0;
+            return;
         }
-        self.left_items_cache = items;
+        if self.selected_left >= self.left_items_cache.len() {
+            self.selected_left = self.left_items_cache.len().saturating_sub(1);
+        }
+        if self.left_items_cache[self.selected_left].is_selectable() {
+            return;
+        }
+        if let Some(next) = self.next_selectable_left_item_after(self.selected_left) {
+            self.selected_left = next;
+        } else if let Some(prev) = self.previous_selectable_left_item_before(self.selected_left) {
+            self.selected_left = prev;
+        }
     }
 
     pub(crate) fn sort_sessions_by_updated(&mut self) {
@@ -2106,6 +2222,7 @@ impl App {
                     .iter()
                     .find(|project| project.id == session.project_id)
             }),
+            Some(LeftItem::EmptyProjectsSeparator) => None,
             None => None,
         }
     }
@@ -2723,6 +2840,175 @@ pub(crate) fn provider_config(config: &Config, provider: &ProviderKind) -> Provi
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_project(id: &str) -> Project {
+        Project {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: format!("/tmp/{id}"),
+            default_provider: ProviderKind::from_str("codex"),
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
+            path_missing: false,
+        }
+    }
+
+    fn test_session(id: &str, project_id: &str, created_offset: i64) -> AgentSession {
+        let now = Utc::now() + chrono::Duration::seconds(created_offset);
+        AgentSession {
+            id: id.to_string(),
+            project_id: project_id.to_string(),
+            project_path: Some(format!("/tmp/{project_id}")),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: id.to_string(),
+            worktree_path: format!("/tmp/worktrees/{id}"),
+            title: None,
+            started_providers: Vec::new(),
+            status: SessionStatus::Detached,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn build_left_items_does_not_split_below_threshold() {
+        let projects = vec![
+            test_project("project-1"),
+            test_project("project-2"),
+            test_project("project-3"),
+            test_project("project-4"),
+        ];
+        let sessions = vec![test_session("session-1", "project-2", 0)];
+
+        let items = build_left_items(&projects, &sessions, &HashSet::new(), 5);
+
+        assert_eq!(
+            items,
+            vec![
+                LeftItem::Project(0),
+                LeftItem::Project(1),
+                LeftItem::Session(0),
+                LeftItem::Project(2),
+                LeftItem::Project(3),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_left_items_splits_empty_projects_at_threshold() {
+        let projects = vec![
+            test_project("project-1"),
+            test_project("project-2"),
+            test_project("project-3"),
+            test_project("project-4"),
+            test_project("project-5"),
+        ];
+        let sessions = vec![
+            test_session("session-1", "project-2", 0),
+            test_session("session-2", "project-4", 0),
+        ];
+
+        let items = build_left_items(&projects, &sessions, &HashSet::new(), 5);
+
+        assert_eq!(
+            items,
+            vec![
+                LeftItem::Project(1),
+                LeftItem::Session(0),
+                LeftItem::Project(3),
+                LeftItem::Session(1),
+                LeftItem::EmptyProjectsSeparator,
+                LeftItem::Project(0),
+                LeftItem::Project(2),
+                LeftItem::Project(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_left_items_moves_project_above_separator_when_session_is_added() {
+        let projects = vec![
+            test_project("project-1"),
+            test_project("project-2"),
+            test_project("project-3"),
+            test_project("project-4"),
+            test_project("project-5"),
+        ];
+        let sessions = vec![
+            test_session("session-1", "project-2", 0),
+            test_session("session-2", "project-4", 0),
+            test_session("session-3", "project-3", 0),
+        ];
+
+        let items = build_left_items(&projects, &sessions, &HashSet::new(), 5);
+
+        assert_eq!(
+            items,
+            vec![
+                LeftItem::Project(1),
+                LeftItem::Session(0),
+                LeftItem::Project(2),
+                LeftItem::Session(2),
+                LeftItem::Project(3),
+                LeftItem::Session(1),
+                LeftItem::EmptyProjectsSeparator,
+                LeftItem::Project(0),
+                LeftItem::Project(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_left_items_keeps_session_sort_order_within_project_grouping() {
+        let projects = vec![
+            test_project("project-1"),
+            test_project("project-2"),
+            test_project("project-3"),
+            test_project("project-4"),
+            test_project("project-5"),
+        ];
+        let mut sessions = vec![
+            test_session("older", "project-2", 0),
+            test_session("newer", "project-2", 10),
+            test_session("other", "project-4", 5),
+        ];
+        sessions.sort_by_key(|session| std::cmp::Reverse(session.created_at));
+
+        let items = build_left_items(&projects, &sessions, &HashSet::new(), 5);
+
+        assert_eq!(
+            items,
+            vec![
+                LeftItem::Project(1),
+                LeftItem::Session(0),
+                LeftItem::Session(2),
+                LeftItem::Project(3),
+                LeftItem::Session(1),
+                LeftItem::EmptyProjectsSeparator,
+                LeftItem::Project(0),
+                LeftItem::Project(2),
+                LeftItem::Project(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_left_items_can_disable_empty_project_split() {
+        let projects = vec![
+            test_project("project-1"),
+            test_project("project-2"),
+            test_project("project-3"),
+            test_project("project-4"),
+            test_project("project-5"),
+        ];
+        let sessions = vec![test_session("session-1", "project-2", 0)];
+
+        let items = build_left_items(&projects, &sessions, &HashSet::new(), 0);
+
+        assert!(!items.contains(&LeftItem::EmptyProjectsSeparator));
+        assert_eq!(items[0], LeftItem::Project(0));
+    }
 
     #[test]
     fn current_process_is_descendant_of_pid_1() {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -586,6 +586,10 @@ impl App {
                             Span::styled(dot.to_string(), Style::default().fg(dot_color)),
                         ]))
                     }
+                    LeftItem::EmptyProjectsSeparator => ListItem::new(Line::from(Span::styled(
+                        "─",
+                        Style::default().fg(self.theme.header_separator_fg),
+                    ))),
                 })
                 .collect::<Vec<_>>();
             let mut state = ListState::default().with_selected(Some(self.selected_left));
@@ -764,6 +768,13 @@ impl App {
                         .collect::<Vec<_>>(),
                     ))
                 }
+                LeftItem::EmptyProjectsSeparator => ListItem::new(Line::from(vec![
+                    Span::styled("── ", Style::default().fg(self.theme.header_separator_fg)),
+                    Span::styled(
+                        "Empty projects",
+                        Style::default().fg(self.theme.provider_label_fg),
+                    ),
+                ])),
             })
             .collect::<Vec<_>>();
         let title = format!("Projects ({})", self.projects.len());

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -1683,6 +1683,7 @@ impl App {
                 self.sessions.get(*index).map(|s| s.worktree_path.clone())
             }
             Some(LeftItem::Project(index)) => self.projects.get(*index).map(|p| p.path.clone()),
+            Some(LeftItem::EmptyProjectsSeparator) => None,
             None => None,
         };
         match path {

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,7 @@ pub struct UiConfig {
     pub left_width_pct: u16,
     pub right_width_pct: u16,
     pub terminal_pane_height_pct: u16,
+    pub empty_project_separator_min_projects: u16,
     pub staged_pane_height_pct: u16,
     pub commit_pane_height_pct: u16,
     pub agent_scrollback_lines: usize,
@@ -214,6 +215,7 @@ impl Default for Config {
                 left_width_pct: 20,
                 right_width_pct: 23,
                 terminal_pane_height_pct: 35,
+                empty_project_separator_min_projects: 5,
                 staged_pane_height_pct: 50,
                 commit_pane_height_pct: 40,
                 agent_scrollback_lines: 10_000,
@@ -339,6 +341,7 @@ impl Default for UiConfig {
             left_width_pct: 17,
             right_width_pct: 19,
             terminal_pane_height_pct: 35,
+            empty_project_separator_min_projects: 5,
             staged_pane_height_pct: 50,
             commit_pane_height_pct: 40,
             agent_scrollback_lines: 10_000,
@@ -676,6 +679,14 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             value_fn: |c| FieldValue::U16(c.ui.terminal_pane_height_pct),
         },
         ConfigEntry::Field {
+            key: "empty_project_separator_min_projects",
+            comment: Some(CommentSource::Static(
+                "# Separate projects with no agents below an \"Empty projects\" divider once\n\
+                 # the total project count reaches this number. Set to 0 to disable.",
+            )),
+            value_fn: |c| FieldValue::U16(c.ui.empty_project_separator_min_projects),
+        },
+        ConfigEntry::Field {
             key: "staged_pane_height_pct",
             comment: Some(CommentSource::Static(
                 "# Height percentage of the right pane used by the staged changes and commit sections.\n# The remaining space goes to the unstaged changes list.",
@@ -896,6 +907,12 @@ pub fn save_config(
         "ui",
         "terminal_pane_height_pct",
         config.ui.terminal_pane_height_pct,
+    );
+    patch_table_u16(
+        &mut doc,
+        "ui",
+        "empty_project_separator_min_projects",
+        config.ui.empty_project_separator_min_projects,
     );
     patch_table_u16(
         &mut doc,
@@ -1773,6 +1790,7 @@ mod tests {
         assert!(rendered.contains("args = []"));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
+        assert!(rendered.contains("empty_project_separator_min_projects = 5"));
         assert!(rendered.contains("staged_pane_height_pct = "));
         assert!(rendered.contains("commit_pane_height_pct = "));
         assert!(rendered.contains("[editor]"));
@@ -1902,6 +1920,7 @@ terminal_pane_height_pct = 35
 agent_scrollback_lines = 10000
 "#;
         let parsed: Config = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(parsed.ui.empty_project_separator_min_projects, 5);
         assert_eq!(parsed.ui.staged_pane_height_pct, 50);
         assert_eq!(parsed.ui.commit_pane_height_pct, 40);
     }


### PR DESCRIPTION
This updates the projects pane so projects with agents stay grouped above projects that do not have any child agents once the project list reaches the configured threshold. Empty projects are shown below an `Empty projects` separator but remain selectable, so users can still create agents from them normally.

The threshold is exposed as `ui.empty_project_separator_min_projects` in the generated config, with `5` as the default and `0` available to disable the split. Existing Ctrl-p agent sorting still controls session ordering under each project, and a project moves back into the main group automatically once it has a child agent.