### PR TITLE
Create agents from existing worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Grab the latest release for your platform from the [Releases](https://github.com
 
 dux organizes work around **projects** (git repos) and **agents** (worktree sessions). When you create an agent, dux branches off a new git worktree so the agent has its own isolated copy of the code. No conflicts with your main checkout, no stepping on other agents' changes.
 
+Already have a Git worktree you want dux to use? The `new-agent-from-worktree` command in the palette lets you pick from existing worktrees for the selected project. If the worktree is already managed by dux, dux reuses it and reconnects like a continuable session; if it's outside dux's managed worktree directory, dux copies it into a fresh managed worktree first so the original checkout is left alone.
+
 The interface has three panes:
 
 - **Left:** your projects and agent sessions

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -91,6 +91,7 @@ enum PromptMouseTarget {
     BrowseProjectInput,
     BrowseProjectItem(usize),
     PickEditorItem(usize),
+    PickProjectWorktreeItem(usize),
     ChangeThemeItem(usize),
     ChangeAgentProviderItem(usize),
     ChangeAgentProviderCancel,
@@ -214,6 +215,7 @@ impl ButtonPressedTarget {
             | PromptMouseTarget::BrowseProjectInput
             | PromptMouseTarget::BrowseProjectItem(_)
             | PromptMouseTarget::PickEditorItem(_)
+            | PromptMouseTarget::PickProjectWorktreeItem(_)
             | PromptMouseTarget::ChangeThemeItem(_)
             | PromptMouseTarget::ChangeAgentProviderItem(_)
             | PromptMouseTarget::ChangeDefaultProviderItem(_)
@@ -560,6 +562,7 @@ impl App {
                     self.open_project_browser()?;
                 }
                 Action::NewAgent => self.create_agent_for_selected_project()?,
+                Action::NewAgentFromWorktree => self.create_agent_from_existing_worktree()?,
                 Action::ForkAgent => self.fork_selected_session()?,
                 Action::RefreshProject => self.refresh_selected_project()?,
                 Action::CheckoutProjectDefaultBranch => {
@@ -2159,6 +2162,39 @@ impl App {
             return Ok(false);
         }
 
+        if let PromptState::PickProjectWorktree(prompt) = &mut self.prompt {
+            match self.bindings.lookup(&key, BindingScope::Palette) {
+                Some(Action::CloseOverlay) => self.prompt = PromptState::None,
+                Some(Action::MoveDown) => {
+                    let selectable = selectable_project_worktree_indices(&prompt.entries);
+                    if let Some(current) = prompt.selected
+                        && let Some(position) = selectable.iter().position(|idx| *idx == current)
+                        && let Some(next) = selectable.get(position + 1)
+                    {
+                        prompt.selected = Some(*next);
+                    } else if prompt.selected.is_none() {
+                        prompt.selected = selectable.into_iter().next();
+                    }
+                }
+                Some(Action::MoveUp) => {
+                    let selectable = selectable_project_worktree_indices(&prompt.entries);
+                    if let Some(current) = prompt.selected
+                        && let Some(position) = selectable.iter().position(|idx| *idx == current)
+                        && position > 0
+                    {
+                        prompt.selected = Some(selectable[position - 1]);
+                    } else if prompt.selected.is_none() {
+                        prompt.selected = selectable.into_iter().next();
+                    }
+                }
+                Some(Action::Confirm) => {
+                    self.open_selected_project_worktree_agent_prompt()?;
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ChangeAgentProvider(prompt) = &mut self.prompt {
             let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
             let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
@@ -2768,6 +2804,27 @@ impl App {
                                 "Forking agent \"{source_label}\" as \"{name}\" by cloning its current worktree contents into a fresh session...",
                             )
                         }
+                        CreateAgentRequest::ExistingManagedWorktree {
+                            project,
+                            worktree_path,
+                            ..
+                        } => {
+                            format!(
+                                "Starting agent \"{name}\" in existing worktree {} for project \"{}\"...",
+                                worktree_path.display(),
+                                project.name
+                            )
+                        }
+                        CreateAgentRequest::ForkExternalWorktree {
+                            project,
+                            source_label,
+                            ..
+                        } => {
+                            format!(
+                                "Copying external worktree \"{source_label}\" into a managed worktree \"{name}\" for project \"{}\"...",
+                                project.name
+                            )
+                        }
                     };
                     set_create_agent_request_custom_name(&mut request, name);
                     self.dispatch_create_agent_request(request, msg)?;
@@ -3168,6 +3225,13 @@ impl App {
                 ..
             } => Self::overlay_row_at(list, offset, items, column, row)
                 .map(PromptMouseTarget::PickEditorItem),
+            OverlayMouseLayout::PickProjectWorktree {
+                list,
+                items,
+                offset,
+                ..
+            } => Self::overlay_row_at(list, offset, items, column, row)
+                .map(PromptMouseTarget::PickProjectWorktreeItem),
             OverlayMouseLayout::ResourceMonitor { .. } => None,
             OverlayMouseLayout::ChangeTheme {
                 list,
@@ -3993,6 +4057,83 @@ impl App {
         }
     }
 
+    fn set_project_worktree_selection_from_visual_row(&mut self, visual_index: usize) {
+        let entry_index = match &self.prompt {
+            PromptState::PickProjectWorktree(prompt) => {
+                let rows = project_worktree_visual_rows(
+                    &prompt.entries,
+                    prompt.loading,
+                    prompt.error.as_deref(),
+                );
+                rows.get(visual_index).and_then(|row| match row {
+                    ProjectWorktreeVisualRow::Entry(index)
+                        if prompt
+                            .entries
+                            .get(*index)
+                            .is_some_and(|entry| entry.is_selectable) =>
+                    {
+                        Some(*index)
+                    }
+                    _ => None,
+                })
+            }
+            _ => None,
+        };
+        let Some(entry_index) = entry_index else {
+            return;
+        };
+        if let PromptState::PickProjectWorktree(prompt) = &mut self.prompt {
+            prompt.selected = Some(entry_index);
+        }
+    }
+
+    fn open_selected_project_worktree_agent_prompt(&mut self) -> Result<()> {
+        let (project, entry) = match &self.prompt {
+            PromptState::PickProjectWorktree(prompt) => {
+                let Some(selected) = prompt.selected else {
+                    self.set_error("No available worktree is selected.");
+                    return Ok(());
+                };
+                let Some(entry) = prompt.entries.get(selected).cloned() else {
+                    self.set_error("No available worktree is selected.");
+                    return Ok(());
+                };
+                if !entry.is_selectable {
+                    self.set_error("That worktree already has an agent.");
+                    return Ok(());
+                }
+                (prompt.project.clone(), entry)
+            }
+            _ => return Ok(()),
+        };
+
+        let request = if entry.is_external {
+            CreateAgentRequest::ForkExternalWorktree {
+                project,
+                source_worktree_path: entry.path.clone(),
+                source_label: entry.display_name(),
+                source_branch: entry.branch_name.clone(),
+                custom_name: None,
+            }
+        } else {
+            let managed_root = self.paths.worktrees_root.join(&project.name);
+            let default_name = entry
+                .path
+                .strip_prefix(&managed_root)
+                .ok()
+                .map(|relative| relative.to_string_lossy().to_string())
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| entry.display_name());
+            CreateAgentRequest::ExistingManagedWorktree {
+                project,
+                worktree_path: entry.path.clone(),
+                branch_name: entry.branch_name.clone(),
+                custom_name: Some(default_name),
+            }
+        };
+        self.open_name_new_agent_prompt_for_request(request)
+    }
+
     fn next_change_agent_provider_focus(
         current: ChangeAgentProviderFocus,
         forward: bool,
@@ -4262,7 +4403,9 @@ impl App {
                     project.name
                 )
             }
-            CreateAgentRequest::ForkSession { .. } => unreachable!(),
+            CreateAgentRequest::ForkSession { .. }
+            | CreateAgentRequest::ExistingManagedWorktree { .. }
+            | CreateAgentRequest::ForkExternalWorktree { .. } => unreachable!(),
         };
         if let Err(e) = self.dispatch_create_agent_request(request, msg) {
             self.set_error(format!("{e:#}"));
@@ -4559,6 +4702,15 @@ impl App {
                 self.set_pick_editor_selection(index);
                 if double_click {
                     self.open_selected_pick_editor();
+                }
+            }
+            PromptMouseTarget::PickProjectWorktreeItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
+                self.set_project_worktree_selection_from_visual_row(index);
+                if double_click && let Err(err) = self.open_selected_project_worktree_agent_prompt()
+                {
+                    self.set_error(format!("{err:#}"));
                 }
             }
             PromptMouseTarget::ChangeThemeItem(index) => {
@@ -5448,7 +5600,9 @@ fn set_create_agent_request_custom_name(request: &mut CreateAgentRequest, name: 
     match request {
         CreateAgentRequest::NewProject { custom_name, .. }
         | CreateAgentRequest::ForkSession { custom_name, .. }
-        | CreateAgentRequest::PullRequest { custom_name, .. } => {
+        | CreateAgentRequest::PullRequest { custom_name, .. }
+        | CreateAgentRequest::ExistingManagedWorktree { custom_name, .. }
+        | CreateAgentRequest::ForkExternalWorktree { custom_name, .. } => {
             *custom_name = Some(name);
         }
     }
@@ -5463,15 +5617,15 @@ mod tests {
     use super::DOUBLE_CLICK_THRESHOLD;
     use super::components::{ButtonPressedTarget, PressedButton};
     use crate::app::{
-        App, BranchWarningKind, CenterMode, ConfigReloadFailedFocus, ConfirmKillRunningPrompt,
-        ConfirmNonDefaultBranchFocus, CreateAgentBranchInspection, CreateAgentRequest,
-        DeleteAgentFocus, FocusPane, FullscreenOverlay, InputTarget, KillRunningAction,
-        KillRunningFocus, KillRunningFooterAction, KillRunningPrompt, KillableRuntime,
-        KillableRuntimeKind, LeftItem, LeftSection, MacroBarState, MouseClickTarget,
-        MouseLayoutState, NameNewAgentFocus, NonDefaultBranchAction, OverlayCheckbox,
-        OverlayCheckboxId, OverlayMouseLayout, OverlayMouseLayoutState, ProcessInfo, PromptState,
-        PullTarget, ResolvedPullRequest, ResourceStats, RightSection, RuntimeTargetId, TextInput,
-        WorkerEvent,
+        AgentLaunchKind, App, BranchWarningKind, CenterMode, ConfigReloadFailedFocus,
+        ConfirmKillRunningPrompt, ConfirmNonDefaultBranchFocus, CreateAgentBranchInspection,
+        CreateAgentRequest, DeleteAgentFocus, FocusPane, FullscreenOverlay, InputTarget,
+        KillRunningAction, KillRunningFocus, KillRunningFooterAction, KillRunningPrompt,
+        KillableRuntime, KillableRuntimeKind, LeftItem, LeftSection, MacroBarState,
+        MouseClickTarget, MouseLayoutState, NameNewAgentFocus, NonDefaultBranchAction,
+        OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout, OverlayMouseLayoutState,
+        PickProjectWorktreePrompt, ProcessInfo, ProjectWorktreeEntry, PromptState, PullTarget,
+        ResolvedPullRequest, ResourceStats, RightSection, RuntimeTargetId, TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -6940,6 +7094,226 @@ not_a_real_action = ["x"]
             other => panic!("expected name-new-agent prompt, got {other:?}"),
         }
         assert!(!app.create_agent_in_flight);
+    }
+
+    #[test]
+    fn palette_command_opens_project_worktree_picker() {
+        let mut app = test_app(default_bindings());
+        app.selected_left = 0;
+
+        app.execute_command("new-agent-from-worktree".to_string())
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::PickProjectWorktree(prompt) => {
+                assert_eq!(prompt.project.id, app.projects[0].id);
+                assert!(prompt.loading);
+                assert!(prompt.entries.is_empty());
+            }
+            other => panic!("expected PickProjectWorktree prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disabled_project_worktree_entries_cannot_be_selected_or_confirmed() {
+        let mut app = test_app(default_bindings());
+        let project = app.projects[0].clone();
+        app.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project,
+            entries: vec![ProjectWorktreeEntry {
+                path: PathBuf::from("/tmp/has-agent"),
+                branch_name: "main".to_string(),
+                is_managed_by_dux: true,
+                existing_session_id: Some("session-1".to_string()),
+                is_external: false,
+                is_project_checkout: false,
+                is_selectable: false,
+            }],
+            loading: false,
+            selected: None,
+            error: None,
+        });
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(matches!(
+            app.prompt,
+            PromptState::PickProjectWorktree(PickProjectWorktreePrompt { selected: None, .. })
+        ));
+    }
+
+    #[test]
+    fn selecting_managed_orphan_worktree_opens_name_prompt() {
+        let mut app = test_app(default_bindings());
+        let project = app.projects[0].clone();
+        let worktree_path = app.paths.worktrees_root.join("demo").join("orphan");
+        app.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project,
+            entries: vec![ProjectWorktreeEntry {
+                path: worktree_path.clone(),
+                branch_name: "orphan".to_string(),
+                is_managed_by_dux: true,
+                existing_session_id: None,
+                is_external: false,
+                is_project_checkout: false,
+                is_selectable: true,
+            }],
+            loading: false,
+            selected: Some(0),
+            error: None,
+        });
+
+        app.open_selected_project_worktree_agent_prompt().unwrap();
+
+        match &app.prompt {
+            PromptState::NameNewAgent { request, input, .. } => match request {
+                CreateAgentRequest::ExistingManagedWorktree {
+                    project,
+                    worktree_path: selected_path,
+                    branch_name,
+                    ..
+                } => {
+                    assert_eq!(project.id, app.projects[0].id);
+                    assert_eq!(selected_path, &worktree_path);
+                    assert_eq!(branch_name, "orphan");
+                    assert_eq!(input.text, "orphan");
+                }
+                other => panic!("expected ExistingManagedWorktree request, got {other:?}"),
+            },
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn managed_worktree_default_name_overrides_randomized_default() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.enable_randomized_pet_name_by_default = true;
+        let project = app.projects[0].clone();
+        let worktree_path = app.paths.worktrees_root.join("demo").join("managed-name");
+        app.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project,
+            entries: vec![ProjectWorktreeEntry {
+                path: worktree_path,
+                branch_name: "feature/other-name".to_string(),
+                is_managed_by_dux: true,
+                existing_session_id: None,
+                is_external: false,
+                is_project_checkout: false,
+                is_selectable: true,
+            }],
+            loading: false,
+            selected: Some(0),
+            error: None,
+        });
+
+        app.open_selected_project_worktree_agent_prompt().unwrap();
+
+        match &app.prompt {
+            PromptState::NameNewAgent {
+                input,
+                randomize_name,
+                randomized_name,
+                ..
+            } => {
+                assert_eq!(input.text, "managed-name");
+                assert!(!*randomize_name);
+                assert!(randomized_name.is_none());
+            }
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn imported_managed_worktree_is_tracked_for_resume_fallback() {
+        let mut app = test_app(default_bindings());
+        let worktree = app.paths.worktrees_root.join("demo").join("imported");
+        std::fs::create_dir_all(&worktree).expect("imported worktree");
+        let session = AgentSession {
+            id: "imported-session".to_string(),
+            project_id: app.projects[0].id.clone(),
+            project_path: Some(app.projects[0].path.clone()),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "main".to_string(),
+            worktree_path: worktree.to_string_lossy().to_string(),
+            title: Some("imported".to_string()),
+            started_providers: vec!["codex".to_string()],
+            desired_running: true,
+            auto_reopen_enabled: true,
+            status: SessionStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let args = vec!["-c".to_string(), "sleep 1".to_string()];
+        let client = PtyClient::spawn("/bin/sh", &args, &worktree, 24, 80, 1_000)
+            .expect("spawn imported agent");
+
+        let request = app.agent_launch_request(
+            session.clone(),
+            true,
+            AgentLaunchKind::Create {
+                status_message: "imported".to_string(),
+                repo_path: app.projects[0].path.clone(),
+                owns_worktree: false,
+            },
+        );
+        app.worker_tx
+            .send(WorkerEvent::AgentLaunchReady(Box::new(
+                crate::app::AgentLaunchReadyData { request, client },
+            )))
+            .unwrap();
+        app.drain_events();
+
+        assert!(app.resume_fallback_candidates.contains_key(&session.id));
+        assert_eq!(
+            app.sessions
+                .iter()
+                .find(|candidate| candidate.id == session.id)
+                .and_then(|candidate| candidate.title.as_deref()),
+            Some("imported")
+        );
+    }
+
+    #[test]
+    fn selecting_external_worktree_opens_name_prompt_with_fork_request() {
+        let mut app = test_app(default_bindings());
+        let project = app.projects[0].clone();
+        let worktree_path = PathBuf::from("/tmp/external-checkout");
+        app.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project,
+            entries: vec![ProjectWorktreeEntry {
+                path: worktree_path.clone(),
+                branch_name: "feature".to_string(),
+                is_managed_by_dux: false,
+                existing_session_id: None,
+                is_external: true,
+                is_project_checkout: false,
+                is_selectable: true,
+            }],
+            loading: false,
+            selected: Some(0),
+            error: None,
+        });
+
+        app.open_selected_project_worktree_agent_prompt().unwrap();
+
+        match &app.prompt {
+            PromptState::NameNewAgent { request, .. } => match request {
+                CreateAgentRequest::ForkExternalWorktree {
+                    source_worktree_path,
+                    source_branch,
+                    ..
+                } => {
+                    assert_eq!(source_worktree_path, &worktree_path);
+                    assert_eq!(source_branch, "feature");
+                }
+                other => panic!("expected ForkExternalWorktree request, got {other:?}"),
+            },
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -4113,7 +4113,7 @@ impl App {
                 source_worktree_path: entry.path.clone(),
                 source_label: entry.display_name(),
                 source_branch: entry.branch_name.clone(),
-                custom_name: None,
+                custom_name: Some(entry.display_name()),
             }
         } else {
             let managed_root = self.paths.worktrees_root.join(&project.name);
@@ -7301,7 +7301,7 @@ not_a_real_action = ["x"]
         app.open_selected_project_worktree_agent_prompt().unwrap();
 
         match &app.prompt {
-            PromptState::NameNewAgent { request, .. } => match request {
+            PromptState::NameNewAgent { request, input, .. } => match request {
                 CreateAgentRequest::ForkExternalWorktree {
                     source_worktree_path,
                     source_branch,
@@ -7309,9 +7309,49 @@ not_a_real_action = ["x"]
                 } => {
                     assert_eq!(source_worktree_path, &worktree_path);
                     assert_eq!(source_branch, "feature");
+                    assert_eq!(input.text, "external-checkout");
                 }
                 other => panic!("expected ForkExternalWorktree request, got {other:?}"),
             },
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn external_worktree_default_name_overrides_randomized_default() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.enable_randomized_pet_name_by_default = true;
+        let project = app.projects[0].clone();
+        let worktree_path = PathBuf::from("/tmp/external-checkout");
+        app.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project,
+            entries: vec![ProjectWorktreeEntry {
+                path: worktree_path,
+                branch_name: "feature".to_string(),
+                is_managed_by_dux: false,
+                existing_session_id: None,
+                is_external: true,
+                is_project_checkout: false,
+                is_selectable: true,
+            }],
+            loading: false,
+            selected: Some(0),
+            error: None,
+        });
+
+        app.open_selected_project_worktree_agent_prompt().unwrap();
+
+        match &app.prompt {
+            PromptState::NameNewAgent {
+                input,
+                randomize_name,
+                randomized_name,
+                ..
+            } => {
+                assert_eq!(input.text, "external-checkout");
+                assert!(!*randomize_name);
+                assert!(randomized_name.is_none());
+            }
             other => panic!("expected NameNewAgent prompt, got {other:?}"),
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -487,6 +487,43 @@ pub(crate) struct ChangeThemePrompt {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct ProjectWorktreeEntry {
+    pub(crate) path: PathBuf,
+    pub(crate) branch_name: String,
+    pub(crate) is_managed_by_dux: bool,
+    pub(crate) existing_session_id: Option<String>,
+    pub(crate) is_external: bool,
+    pub(crate) is_project_checkout: bool,
+    pub(crate) is_selectable: bool,
+}
+
+impl ProjectWorktreeEntry {
+    pub(crate) fn display_name(&self) -> String {
+        self.path
+            .file_name()
+            .and_then(|part| part.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.path.display().to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ProjectWorktreeVisualRow {
+    Header(&'static str),
+    Empty(String),
+    Entry(usize),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PickProjectWorktreePrompt {
+    pub(crate) project: Project,
+    pub(crate) entries: Vec<ProjectWorktreeEntry>,
+    pub(crate) loading: bool,
+    pub(crate) selected: Option<usize>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ConfirmKillRunningPrompt {
     pub(crate) previous: KillRunningPrompt,
     pub(crate) action: KillRunningAction,
@@ -571,6 +608,7 @@ pub(crate) enum PromptState {
     ChangeDefaultProvider(ChangeDefaultProviderPrompt),
     ChangeProjectDefaultProvider(ChangeProjectDefaultProviderPrompt),
     ChangeTheme(ChangeThemePrompt),
+    PickProjectWorktree(PickProjectWorktreePrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
     ConfigReloadFailed {
@@ -767,6 +805,132 @@ pub(crate) fn build_visual_rows(rows: &[ResourceStats], expanded: &HashSet<u32>)
         }
     }
     visual
+}
+
+pub(crate) fn project_worktree_visual_rows(
+    entries: &[ProjectWorktreeEntry],
+    loading: bool,
+    error: Option<&str>,
+) -> Vec<ProjectWorktreeVisualRow> {
+    if loading {
+        return vec![ProjectWorktreeVisualRow::Empty(
+            "Loading project worktrees...".to_string(),
+        )];
+    }
+    if let Some(error) = error {
+        return vec![ProjectWorktreeVisualRow::Empty(format!(
+            "Could not load worktrees: {error}"
+        ))];
+    }
+
+    let available = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.is_selectable)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let project_checkout = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.is_project_checkout)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let disabled = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| !entry.is_selectable && !entry.is_project_checkout)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+
+    let mut rows = Vec::new();
+    rows.push(ProjectWorktreeVisualRow::Header("Available Worktrees"));
+    if available.is_empty() {
+        rows.push(ProjectWorktreeVisualRow::Empty(
+            "No available worktrees. Worktrees that already have agents are shown below."
+                .to_string(),
+        ));
+    } else {
+        rows.extend(available.into_iter().map(ProjectWorktreeVisualRow::Entry));
+    }
+    if !disabled.is_empty() {
+        rows.push(ProjectWorktreeVisualRow::Header("Already Has Agent"));
+        rows.extend(disabled.into_iter().map(ProjectWorktreeVisualRow::Entry));
+    }
+    if !project_checkout.is_empty() {
+        rows.push(ProjectWorktreeVisualRow::Header("Project Checkout"));
+        rows.extend(
+            project_checkout
+                .into_iter()
+                .map(ProjectWorktreeVisualRow::Entry),
+        );
+    }
+    rows
+}
+
+pub(crate) fn selectable_project_worktree_indices(entries: &[ProjectWorktreeEntry]) -> Vec<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.is_selectable.then_some(index))
+        .collect()
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub(crate) fn classify_project_worktrees(
+    project: &Project,
+    paths: &DuxPaths,
+    sessions: &[AgentSession],
+    worktrees: Vec<git::GitWorktree>,
+) -> Vec<ProjectWorktreeEntry> {
+    let managed_project_root = paths.worktrees_root.join(&project.name);
+    let project_checkout_path = canonical_or_original(Path::new(&project.path));
+    let session_by_path = sessions
+        .iter()
+        .map(|session| {
+            (
+                canonical_or_original(Path::new(&session.worktree_path)),
+                session.id.clone(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut entries = worktrees
+        .into_iter()
+        .map(|worktree| {
+            let canonical_path = canonical_or_original(&worktree.path);
+            let existing_session_id = session_by_path.get(&canonical_path).cloned();
+            let is_project_checkout = canonical_path == project_checkout_path;
+            let is_managed_by_dux = git::is_under(&managed_project_root, &worktree.path);
+            let is_external = !is_managed_by_dux;
+            let is_selectable = existing_session_id.is_none() && !is_project_checkout;
+            ProjectWorktreeEntry {
+                path: canonical_path,
+                branch_name: worktree.label(),
+                is_managed_by_dux,
+                existing_session_id,
+                is_external,
+                is_project_checkout,
+                is_selectable,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    entries.sort_by(|a, b| {
+        a.is_selectable
+            .cmp(&b.is_selectable)
+            .reverse()
+            .then_with(|| a.is_project_checkout.cmp(&b.is_project_checkout))
+            .then_with(|| {
+                a.branch_name
+                    .to_lowercase()
+                    .cmp(&b.branch_name.to_lowercase())
+            })
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    entries
 }
 
 #[derive(Clone, Debug)]
@@ -967,6 +1131,11 @@ pub(crate) enum OverlayMouseLayout {
         apply_button: Rect,
     },
     PickEditor {
+        list: Rect,
+        items: usize,
+        offset: usize,
+    },
+    PickProjectWorktree {
         list: Rect,
         items: usize,
         offset: usize,
@@ -1230,6 +1399,19 @@ pub(crate) enum CreateAgentRequest {
         source_label: String,
         custom_name: Option<String>,
     },
+    ExistingManagedWorktree {
+        project: Project,
+        worktree_path: PathBuf,
+        branch_name: String,
+        custom_name: Option<String>,
+    },
+    ForkExternalWorktree {
+        project: Project,
+        source_worktree_path: PathBuf,
+        source_label: String,
+        source_branch: String,
+        custom_name: Option<String>,
+    },
 }
 
 pub(crate) enum WorkerEvent {
@@ -1252,6 +1434,10 @@ pub(crate) enum WorkerEvent {
     BrowserEntriesReady {
         dir: PathBuf,
         entries: Vec<BrowserEntry>,
+    },
+    ProjectWorktreesReady {
+        project_id: String,
+        result: Result<Vec<ProjectWorktreeEntry>, String>,
     },
     ClipboardCopyCompleted {
         /// Human-readable success message shown in the status bar.
@@ -1953,6 +2139,7 @@ impl App {
         match command {
             "new-agent" => self.create_agent_for_selected_project(),
             "new-agent-from-pr" => self.open_new_agent_from_pr_prompt(),
+            "new-agent-from-worktree" => self.create_agent_from_existing_worktree(),
             "fork-agent" => self.fork_selected_session(),
             "change-agent-provider" => self.open_change_agent_provider_prompt(),
             "change-default-provider" => self.open_change_default_provider_prompt(),
@@ -3348,6 +3535,155 @@ leading_branch = "main"
         expanded.insert(999);
         let visual = build_visual_rows(&rows, &expanded);
         assert_eq!(visual.len(), 3);
+    }
+
+    #[test]
+    fn classify_project_worktrees_marks_managed_external_and_existing_agent() {
+        let root =
+            std::env::temp_dir().join(format!("dux-classify-worktrees-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let repo = root.join("repo");
+        let managed = root.join("worktrees").join("demo").join("managed-orphan");
+        let external = root.join("external checkout");
+        let existing = root.join("worktrees").join("demo").join("existing-agent");
+        fs::create_dir_all(&repo).unwrap();
+        fs::create_dir_all(&managed).unwrap();
+        fs::create_dir_all(&external).unwrap();
+        fs::create_dir_all(&existing).unwrap();
+
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: repo.to_string_lossy().to_string(),
+            explicit_default_provider: None,
+            default_provider: ProviderKind::new("codex"),
+            leading_branch: Some("main".to_string()),
+            auto_reopen_agents: None,
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Leading,
+            path_missing: false,
+        };
+        let paths = DuxPaths {
+            root: root.clone(),
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("lock"),
+        };
+        let sessions = vec![AgentSession {
+            id: "session-1".to_string(),
+            project_id: project.id.clone(),
+            project_path: Some(project.path.clone()),
+            provider: ProviderKind::new("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "existing".to_string(),
+            worktree_path: existing.to_string_lossy().to_string(),
+            title: None,
+            started_providers: Vec::new(),
+            desired_running: false,
+            auto_reopen_enabled: true,
+            status: SessionStatus::Detached,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }];
+        let worktrees = vec![
+            git::GitWorktree {
+                path: repo.clone(),
+                head: Some("0000000".to_string()),
+                branch_name: Some("main".to_string()),
+                detached: false,
+            },
+            git::GitWorktree {
+                path: managed.clone(),
+                head: Some("1111111".to_string()),
+                branch_name: Some("managed-orphan".to_string()),
+                detached: false,
+            },
+            git::GitWorktree {
+                path: external.clone(),
+                head: Some("2222222".to_string()),
+                branch_name: Some("feature".to_string()),
+                detached: false,
+            },
+            git::GitWorktree {
+                path: existing.clone(),
+                head: Some("3333333".to_string()),
+                branch_name: Some("existing".to_string()),
+                detached: false,
+            },
+        ];
+
+        let entries = classify_project_worktrees(&project, &paths, &sessions, worktrees);
+        let managed_entry = entries
+            .iter()
+            .find(|entry| entry.path == managed.canonicalize().unwrap())
+            .unwrap();
+        assert!(managed_entry.is_managed_by_dux);
+        assert!(!managed_entry.is_external);
+        assert!(managed_entry.is_selectable);
+
+        let external_entry = entries
+            .iter()
+            .find(|entry| entry.path == external.canonicalize().unwrap())
+            .unwrap();
+        assert!(!external_entry.is_managed_by_dux);
+        assert!(external_entry.is_external);
+        assert!(external_entry.is_selectable);
+
+        let existing_entry = entries
+            .iter()
+            .find(|entry| entry.path == existing.canonicalize().unwrap())
+            .unwrap();
+        assert_eq!(
+            existing_entry.existing_session_id.as_deref(),
+            Some("session-1")
+        );
+        assert!(!existing_entry.is_selectable);
+
+        let project_checkout_entry = entries
+            .iter()
+            .find(|entry| entry.path == repo.canonicalize().unwrap())
+            .unwrap();
+        assert!(project_checkout_entry.is_project_checkout);
+        assert!(!project_checkout_entry.is_selectable);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn project_worktree_visual_rows_separate_project_checkout() {
+        let entries = vec![
+            ProjectWorktreeEntry {
+                path: PathBuf::from("/repo/managed"),
+                branch_name: "feature".to_string(),
+                is_managed_by_dux: true,
+                existing_session_id: None,
+                is_external: false,
+                is_project_checkout: false,
+                is_selectable: true,
+            },
+            ProjectWorktreeEntry {
+                path: PathBuf::from("/repo/main"),
+                branch_name: "main".to_string(),
+                is_managed_by_dux: false,
+                existing_session_id: None,
+                is_external: true,
+                is_project_checkout: true,
+                is_selectable: false,
+            },
+        ];
+
+        let rows = project_worktree_visual_rows(&entries, false, None);
+
+        assert!(matches!(
+            rows.first(),
+            Some(ProjectWorktreeVisualRow::Header("Available Worktrees"))
+        ));
+        assert!(
+            rows.iter()
+                .any(|row| matches!(row, ProjectWorktreeVisualRow::Header("Project Checkout")))
+        );
+        assert_eq!(selectable_project_worktree_indices(&entries), vec![0]);
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3419,6 +3419,174 @@ impl App {
                     offset: state.offset(),
                 };
             }
+            PromptState::PickProjectWorktree(prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(78, 58, frame.area());
+                self.clear_overlay_area(frame, area);
+
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let move_down = self.bindings.label_for(Action::MoveDown);
+                let move_up = self.bindings.label_for(Action::MoveUp);
+                let mut bottom_spans = vec![Span::raw(" ")];
+                bottom_spans.extend(self.theme.key_badge_default(&move_down));
+                bottom_spans.push(Span::styled(
+                    " down  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&move_up));
+                bottom_spans.push(Span::styled(
+                    " up  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&confirm_key));
+                bottom_spans.push(Span::styled(
+                    " use  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let [details_area, list_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(4), Constraint::Min(6)])
+                    .areas(area);
+
+                let detail_lines = vec![
+                    Line::from(vec![
+                        Span::styled(" Project: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::styled(
+                            prompt.project.name.as_str(),
+                            Style::default()
+                                .fg(self.theme.text_fg)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled(" Repo: ", Style::default().fg(self.theme.hint_desc_fg)),
+                        Span::styled(
+                            prompt.project.path.as_str(),
+                            Style::default().fg(self.theme.text_fg),
+                        ),
+                    ]),
+                ];
+                Paragraph::new(detail_lines)
+                    .block(
+                        self.themed_overlay_block("New Agent From Worktree")
+                            .title_bottom(Line::from(bottom_spans)),
+                    )
+                    .render(details_area, frame.buffer_mut());
+
+                let rows = project_worktree_visual_rows(
+                    &prompt.entries,
+                    prompt.loading,
+                    prompt.error.as_deref(),
+                );
+                let path_col = prompt
+                    .entries
+                    .iter()
+                    .map(|entry| entry.display_name().chars().count())
+                    .max()
+                    .unwrap_or(8)
+                    .clamp(8, 24);
+                let items = rows
+                    .iter()
+                    .map(|row| match row {
+                        ProjectWorktreeVisualRow::Header(label) => {
+                            ListItem::new(Line::from(Span::styled(
+                                format!(" {label}"),
+                                Style::default()
+                                    .fg(self.theme.help_section_header_fg)
+                                    .add_modifier(Modifier::BOLD),
+                            )))
+                        }
+                        ProjectWorktreeVisualRow::Empty(message) => {
+                            ListItem::new(Line::from(Span::styled(
+                                format!("  {message}"),
+                                Style::default().fg(self.theme.hint_dim_desc_fg),
+                            )))
+                        }
+                        ProjectWorktreeVisualRow::Entry(index) => {
+                            let entry = &prompt.entries[*index];
+                            let style = if entry.is_selectable {
+                                Style::default().fg(self.theme.text_fg)
+                            } else {
+                                Style::default().fg(self.theme.hint_dim_desc_fg)
+                            };
+                            let kind = if entry.is_project_checkout {
+                                "project"
+                            } else if entry.is_external {
+                                "external"
+                            } else {
+                                "managed"
+                            };
+                            let session_suffix = entry
+                                .existing_session_id
+                                .as_ref()
+                                .map(|id| format!("  agent {id}"))
+                                .unwrap_or_default();
+                            let kind_style = if !entry.is_selectable {
+                                Style::default().fg(self.theme.hint_dim_desc_fg)
+                            } else if entry.is_managed_by_dux {
+                                Style::default().fg(self.theme.branch_fg)
+                            } else {
+                                Style::default().fg(self.theme.hint_desc_fg)
+                            };
+                            let branch_label_style = Style::default().fg(if entry.is_selectable {
+                                self.theme.branch_fg
+                            } else {
+                                self.theme.hint_dim_desc_fg
+                            });
+                            let branch_value_style = Style::default().fg(if entry.is_selectable {
+                                self.theme.hint_desc_fg
+                            } else {
+                                self.theme.hint_dim_desc_fg
+                            });
+                            let name = git::ellipsize_middle(&entry.display_name(), path_col);
+                            ListItem::new(Line::from(vec![
+                                Span::styled(
+                                    format!("  {:path_col$}", name),
+                                    style.add_modifier(Modifier::BOLD),
+                                ),
+                                Span::styled(format!("  {:<8}", kind), kind_style),
+                                Span::styled("  branch: ", branch_label_style),
+                                Span::styled(entry.branch_name.as_str(), branch_value_style),
+                                Span::styled(
+                                    session_suffix,
+                                    Style::default().fg(self.theme.hint_dim_desc_fg),
+                                ),
+                            ]))
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let selected_visual = prompt.selected.and_then(|selected| {
+                    rows.iter().position(|row| {
+                        matches!(row, ProjectWorktreeVisualRow::Entry(index) if *index == selected)
+                    })
+                });
+                let mut state = ListState::default().with_selected(selected_visual);
+                let list_block = Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                    .border_style(Style::default().fg(self.theme.overlay_border))
+                    .style(Style::default().bg(self.theme.overlay_bg));
+                let list_inner = list_block.inner(list_area);
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(list_block)
+                        .highlight_style(self.theme.selection_style()),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+                self.overlay_layout.active = OverlayMouseLayout::PickProjectWorktree {
+                    list: list_inner,
+                    items: rows.len(),
+                    offset: state.offset(),
+                };
+            }
             PromptState::KillRunning(prompt) => {
                 self.render_dim_overlay(frame);
                 let popup = centered_rect(78, 72, frame.area());
@@ -4931,6 +5099,7 @@ impl App {
                 hint_para.render(hint_area, frame.buffer_mut());
             }
             PromptState::NameNewAgent {
+                request,
                 input,
                 randomize_name,
                 focus,
@@ -4956,9 +5125,26 @@ impl App {
                     .saturating_add(1);
                 let checkbox_spacing = 1;
                 let footer_spacing = 1;
+                let context_line = match request {
+                    CreateAgentRequest::ExistingManagedWorktree { worktree_path, .. } => {
+                        Some(format!(
+                            " This starts a fresh agent session in {}.",
+                            worktree_path.display()
+                        ))
+                    }
+                    CreateAgentRequest::ForkExternalWorktree {
+                        source_worktree_path,
+                        ..
+                    } => Some(format!(
+                        " External worktree will be copied into a fresh managed dux worktree: {}.",
+                        source_worktree_path.display()
+                    )),
+                    _ => None,
+                };
+                let context_height = u16::from(context_line.is_some());
                 let area = centered_rect_exact(
                     dialog_width,
-                    8 + checkbox_spacing + checkbox_height + footer_spacing,
+                    8 + context_height + checkbox_spacing + checkbox_height + footer_spacing,
                     frame.area(),
                 );
                 self.clear_overlay_area(frame, area);
@@ -4967,10 +5153,19 @@ impl App {
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
 
-                let [label_area, input_area, _, checkbox_area, _, hint_area] = Layout::default()
+                let [
+                    label_area,
+                    context_area,
+                    input_area,
+                    _,
+                    checkbox_area,
+                    _,
+                    hint_area,
+                ] = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Length(1),
+                        Constraint::Length(context_height),
                         Constraint::Length(3),
                         Constraint::Length(checkbox_spacing),
                         Constraint::Length(checkbox_height),
@@ -4979,11 +5174,24 @@ impl App {
                     ])
                     .areas(inner);
 
+                let label = if matches!(request, CreateAgentRequest::ExistingManagedWorktree { .. })
+                {
+                    " Enter a display name for the new agent:"
+                } else {
+                    " Enter a name for the new agent (used as branch name):"
+                };
                 Paragraph::new(Line::from(Span::styled(
-                    " Enter a name for the new agent (used as branch name):",
+                    label,
                     Style::default().fg(self.theme.input_label_fg),
                 )))
                 .render(label_area, frame.buffer_mut());
+                if let Some(context_line) = context_line {
+                    Paragraph::new(Line::from(Span::styled(
+                        git::ellipsize_middle(&context_line, inner.width as usize),
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    )))
+                    .render(context_area, frame.buffer_mut());
+                }
 
                 // Input field with cursor indicator.
                 let display = if input.cursor < input.text.len() {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -6477,10 +6477,13 @@ fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {
 
 fn path_completion_display_label(completion: &str) -> String {
     let trimmed = completion.trim_end_matches('/');
-    let folder = Path::new(trimmed)
+    let Some(folder) = Path::new(trimmed)
         .file_name()
         .and_then(|part| part.to_str())
-        .unwrap_or(trimmed);
+    else {
+        return completion.to_string();
+    };
+
     format!(".../{folder}/")
 }
 
@@ -6717,6 +6720,16 @@ mod tests {
         assert_eq!(spans[0].style, prose);
         assert_eq!(spans[1].style, quoted);
         assert_eq!(spans[3].style, quoted);
+    }
+
+    #[test]
+    fn path_completion_display_label_handles_unicode_leaf() {
+        assert_eq!(path_completion_display_label("/tmp/项目/"), ".../项目/");
+    }
+
+    #[test]
+    fn path_completion_display_label_keeps_root_without_leaf() {
+        assert_eq!(path_completion_display_label("/"), "/");
     }
 
     #[test]

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -204,6 +204,31 @@ impl App {
         })
     }
 
+    pub(crate) fn create_agent_from_existing_worktree(&mut self) -> Result<()> {
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+
+        if project.path_missing {
+            self.set_warning(format!("Project path not found: {}", project.path));
+            return Ok(());
+        }
+
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::PickProjectWorktree(PickProjectWorktreePrompt {
+            project: project.clone(),
+            entries: Vec::new(),
+            loading: true,
+            selected: None,
+            error: None,
+        });
+        self.spawn_project_worktrees_worker(project);
+        self.set_busy("Loading git worktrees for the selected project...");
+        Ok(())
+    }
+
     pub(crate) fn fork_selected_session(&mut self) -> Result<()> {
         let Some(source_session) = self.selected_session().cloned() else {
             self.set_error("Select an agent session first to fork.");
@@ -266,20 +291,31 @@ impl App {
     }
 
     pub(crate) fn open_name_new_agent_prompt(&mut self, request: CreateAgentRequest) -> Result<()> {
-        let explicit_name = match &request {
+        let initial_name = match &request {
             CreateAgentRequest::NewProject { custom_name, .. }
-            | CreateAgentRequest::ForkSession { custom_name, .. } => custom_name.clone(),
+            | CreateAgentRequest::ForkSession { custom_name, .. }
+            | CreateAgentRequest::ForkExternalWorktree { custom_name, .. } => custom_name.clone(),
             CreateAgentRequest::PullRequest {
                 custom_name,
                 head_branch,
                 ..
             } => custom_name.clone().or_else(|| Some(head_branch.clone())),
+            CreateAgentRequest::ExistingManagedWorktree {
+                custom_name,
+                worktree_path,
+                ..
+            } => custom_name.clone().or_else(|| {
+                worktree_path
+                    .file_name()
+                    .and_then(|part| part.to_str())
+                    .map(str::to_string)
+            }),
         };
         let randomize_name =
-            explicit_name.is_none() && self.config.defaults.enable_randomized_pet_name_by_default;
+            initial_name.is_none() && self.config.defaults.enable_randomized_pet_name_by_default;
         let mut input = TextInput::new().with_char_map(crate::git::agent_name_char_map);
         let mut randomized_name = None;
-        if let Some(name) = explicit_name {
+        if let Some(name) = initial_name {
             input.set_text(name);
         } else if randomize_name {
             let name = crate::git::docker_style_name();
@@ -297,6 +333,13 @@ impl App {
             focus: NameNewAgentFocus::Input,
         };
         Ok(())
+    }
+
+    pub(crate) fn open_name_new_agent_prompt_for_request(
+        &mut self,
+        request: CreateAgentRequest,
+    ) -> Result<()> {
+        self.open_name_new_agent_prompt(request)
     }
 
     /// Spawns a background worker that runs `git switch <target_branch>` in

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -258,6 +258,41 @@ impl App {
                         *selected = 0;
                     }
                 }
+                WorkerEvent::ProjectWorktreesReady { project_id, result } => {
+                    let mut status_after_update: Option<Result<&'static str, String>> = None;
+                    if let PromptState::PickProjectWorktree(prompt) = &mut self.prompt
+                        && prompt.project.id == project_id
+                    {
+                        prompt.loading = false;
+                        match result {
+                            Ok(entries) => {
+                                prompt.selected =
+                                    selectable_project_worktree_indices(&entries).into_iter().next();
+                                prompt.entries = entries;
+                                prompt.error = None;
+                                status_after_update = Some(Ok(
+                                    "Choose an available worktree to launch a new agent.",
+                                ));
+                            }
+                            Err(error) => {
+                                let project_name = prompt.project.name.clone();
+                                prompt.entries.clear();
+                                prompt.selected = None;
+                                prompt.error = Some(error.clone());
+                                status_after_update = Some(Err(format!(
+                                    "Failed to load worktrees for project \"{}\": {error}",
+                                    project_name
+                                )));
+                            }
+                        }
+                    }
+                    if let Some(status) = status_after_update {
+                        match status {
+                            Ok(message) => self.set_info(message),
+                            Err(message) => self.set_error(message),
+                        }
+                    }
+                }
                 WorkerEvent::WorktreeRemoveCompleted { session_id, result } => {
                     // Always clear the in-flight guard so the session is
                     // interactive again — whether we're about to remove it
@@ -865,6 +900,10 @@ impl App {
             self.providers.insert(session.id.clone(), client);
             self.sessions.insert(0, session.clone());
             self.mark_session_provider_started(&session.id);
+            if request.resume {
+                self.resume_fallback_candidates
+                    .insert(session.id.clone(), Instant::now());
+            }
             self.update_branch_sync_sessions();
             self.rebuild_left_items();
             self.selected_left = self
@@ -971,6 +1010,21 @@ impl App {
             let _ = tx.send(WorkerEvent::BrowserEntriesReady {
                 dir: dir.clone(),
                 entries,
+            });
+        });
+    }
+
+    pub(crate) fn spawn_project_worktrees_worker(&self, project: Project) {
+        let tx = self.worker_tx.clone();
+        let paths = self.paths.clone();
+        let sessions = self.sessions.clone();
+        thread::spawn(move || {
+            let result = git::list_worktrees(Path::new(&project.path))
+                .map(|worktrees| classify_project_worktrees(&project, &paths, &sessions, worktrees))
+                .map_err(|err| format!("{err:#}"));
+            let _ = tx.send(WorkerEvent::ProjectWorktreesReady {
+                project_id: project.id,
+                result,
             });
         });
     }
@@ -1515,6 +1569,8 @@ pub(crate) fn run_create_agent_job(
         branch_name,
         worktree_path,
         owns_worktree,
+        title,
+        launch_with_resume,
     ) = match request {
         CreateAgentRequest::NewProject {
             project,
@@ -1626,6 +1682,8 @@ pub(crate) fn run_create_agent_job(
                 branch_name,
                 worktree_path,
                 true,
+                None,
+                false,
             )
         }
         CreateAgentRequest::PullRequest {
@@ -1708,6 +1766,8 @@ pub(crate) fn run_create_agent_job(
                 branch_name,
                 worktree_path,
                 true,
+                None,
+                false,
             )
         }
         CreateAgentRequest::ForkSession {
@@ -1789,6 +1849,115 @@ pub(crate) fn run_create_agent_job(
                 branch_name,
                 worktree_path,
                 true,
+                None,
+                false,
+            )
+        }
+        CreateAgentRequest::ExistingManagedWorktree {
+            project,
+            worktree_path,
+            branch_name,
+            custom_name,
+        } => {
+            let agent_name = custom_name.clone().unwrap_or_else(|| branch_name.clone());
+            let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                "Launching {} in existing worktree \"{}\"...",
+                project.default_provider.as_str(),
+                worktree_path.display(),
+            )));
+            let status_message = format!(
+                "Imported {} agent \"{}\" from existing managed worktree for project \"{}\".",
+                project.default_provider.as_str(),
+                agent_name,
+                project.name
+            );
+            (
+                project.clone(),
+                project.default_provider.clone(),
+                branch_name.clone(),
+                status_message,
+                branch_name,
+                worktree_path,
+                false,
+                custom_name,
+                true,
+            )
+        }
+        CreateAgentRequest::ForkExternalWorktree {
+            project,
+            source_worktree_path,
+            source_label,
+            source_branch,
+            custom_name,
+        } => {
+            let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                "Creating a managed worktree from external worktree \"{source_label}\"...",
+            )));
+            let source_head = match git::head_commit(&source_worktree_path) {
+                Ok(head) => head,
+                Err(err) => {
+                    logger::error(&format!(
+                        "failed to resolve HEAD for {}: {err}",
+                        source_worktree_path.display()
+                    ));
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to inspect external worktree \"{source_label}\": {err}",
+                    )));
+                    return;
+                }
+            };
+            let repo_path = PathBuf::from(&project.path);
+            let (branch_name, worktree_path) = match git::create_worktree_from_start_point(
+                &repo_path,
+                &paths.worktrees_root,
+                &project.name,
+                Some(&source_head),
+                custom_name.as_deref(),
+            ) {
+                Ok(result) => result,
+                Err(err) => {
+                    logger::error(&format!(
+                        "external worktree fork creation failed for {}: {err}",
+                        project.path
+                    ));
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to create a managed worktree from external worktree \"{source_label}\": {err}",
+                    )));
+                    return;
+                }
+            };
+            let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                "Copying dirty and untracked files from external worktree \"{source_label}\"...",
+            )));
+            if let Err(err) = git::mirror_worktree_contents(&source_worktree_path, &worktree_path) {
+                logger::error(&format!(
+                    "failed to mirror external worktree {} into {}: {err}",
+                    source_worktree_path.display(),
+                    worktree_path.display()
+                ));
+                let _ = git::remove_worktree(&repo_path, &worktree_path, &branch_name);
+                let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                    "Failed to copy external worktree contents from \"{source_label}\": {err}",
+                )));
+                return;
+            }
+            let status_message = format!(
+                "Created {} agent \"{}\" from external worktree \"{}\" in project \"{}\". Dirty and untracked files were copied into the managed worktree.",
+                project.default_provider.as_str(),
+                branch_name,
+                source_label,
+                project.name
+            );
+            (
+                project.clone(),
+                project.default_provider.clone(),
+                source_branch,
+                status_message,
+                branch_name,
+                worktree_path,
+                true,
+                None,
+                false,
             )
         }
     };
@@ -1806,6 +1975,11 @@ pub(crate) fn run_create_agent_job(
             branch_name
         ));
     }
+    let started_providers = if launch_with_resume {
+        vec![provider.as_str().to_string()]
+    } else {
+        Vec::new()
+    };
     let session = AgentSession {
         id: Uuid::new_v4().to_string(),
         project_id: project.id.clone(),
@@ -1814,8 +1988,8 @@ pub(crate) fn run_create_agent_job(
         source_branch,
         branch_name,
         worktree_path: worktree_path.to_string_lossy().to_string(),
-        title: None,
-        started_providers: Vec::new(),
+        title,
+        started_providers,
         desired_running: true,
         auto_reopen_enabled: true,
         status: SessionStatus::Active,
@@ -1835,16 +2009,24 @@ pub(crate) fn run_create_agent_job(
         let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(hint));
         return;
     }
-    let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
-        "Launching {} in a fresh session...",
-        session.provider.as_str()
-    )));
+    let launch_message = if launch_with_resume {
+        format!(
+            "Continuing {} in the existing worktree...",
+            session.provider.as_str()
+        )
+    } else {
+        format!(
+            "Launching {} in a fresh session...",
+            session.provider.as_str()
+        )
+    };
+    let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(launch_message));
     // crossterm::terminal::size() returns (cols, rows).
     let (cols, rows) = term_size;
     let request = AgentLaunchRequest {
         session,
         provider_config: provider_cfg,
-        resume: false,
+        resume: launch_with_resume,
         pty_size: (rows, cols),
         scrollback_lines: config.ui.agent_scrollback_lines,
         kind: AgentLaunchKind::Create {

--- a/src/git.rs
+++ b/src/git.rs
@@ -11,6 +11,27 @@ use content_inspector::{ContentType, inspect};
 use crate::logger;
 use crate::model::ChangedFile;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitWorktree {
+    pub path: PathBuf,
+    pub head: Option<String>,
+    pub branch_name: Option<String>,
+    pub detached: bool,
+}
+
+impl GitWorktree {
+    pub fn label(&self) -> String {
+        if let Some(branch_name) = &self.branch_name {
+            return branch_name.clone();
+        }
+        if let Some(head) = &self.head {
+            let short = head.chars().take(7).collect::<String>();
+            return format!("detached {short}");
+        }
+        "detached HEAD".to_string()
+    }
+}
+
 /// Where a branch was found when checking for its existence.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BranchLocation {
@@ -93,6 +114,77 @@ pub fn is_git_repo(path: &Path) -> bool {
         .output()
         .map(|out| out.status.success())
         .unwrap_or(false)
+}
+
+pub fn list_worktrees(repo_path: &Path) -> Result<Vec<GitWorktree>> {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            repo_path.to_string_lossy().as_ref(),
+            "worktree",
+            "list",
+            "--porcelain",
+            "-z",
+        ])
+        .output()
+        .with_context(|| format!("failed to list worktrees for {}", repo_path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git worktree list failed for {}: {}",
+            repo_path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    parse_worktree_list_porcelain_z(&output.stdout)
+}
+
+pub fn parse_worktree_list_porcelain_z(bytes: &[u8]) -> Result<Vec<GitWorktree>> {
+    let mut worktrees = Vec::new();
+    let mut current: Option<GitWorktree> = None;
+
+    for raw in bytes.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            if let Some(entry) = current.take() {
+                worktrees.push(entry);
+            }
+            continue;
+        }
+        let token = String::from_utf8_lossy(raw);
+        if let Some(path) = token.strip_prefix("worktree ") {
+            if let Some(entry) = current.take() {
+                worktrees.push(entry);
+            }
+            current = Some(GitWorktree {
+                path: PathBuf::from(path),
+                head: None,
+                branch_name: None,
+                detached: false,
+            });
+        } else if let Some(head) = token.strip_prefix("HEAD ") {
+            if let Some(entry) = &mut current {
+                entry.head = Some(head.to_string());
+            }
+        } else if let Some(branch) = token.strip_prefix("branch ") {
+            if let Some(entry) = &mut current {
+                entry.branch_name = Some(
+                    branch
+                        .strip_prefix("refs/heads/")
+                        .unwrap_or(branch)
+                        .to_string(),
+                );
+            }
+        } else if token == "detached"
+            && let Some(entry) = &mut current
+        {
+            entry.detached = true;
+        }
+    }
+
+    if let Some(entry) = current {
+        worktrees.push(entry);
+    }
+
+    Ok(worktrees)
 }
 
 pub fn is_dirty(repo_path: &Path) -> Result<bool> {
@@ -1148,6 +1240,22 @@ mod tests {
             String::from_utf8_lossy(&out.stderr)
         );
         wt
+    }
+
+    #[test]
+    fn parse_worktree_list_porcelain_z_handles_branches_detached_and_spaces() {
+        let input = b"worktree /repo/main checkout\0HEAD 1111111111111111111111111111111111111111\0branch refs/heads/main\0\0worktree /repo/feature\0HEAD 2222222222222222222222222222222222222222\0branch refs/heads/feature/x\0\0worktree /repo/detached\0HEAD abcdef1234567890\0detached\0\0";
+
+        let entries = parse_worktree_list_porcelain_z(input).unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].path, PathBuf::from("/repo/main checkout"));
+        assert_eq!(entries[0].branch_name.as_deref(), Some("main"));
+        assert_eq!(entries[0].label(), "main");
+        assert_eq!(entries[1].branch_name.as_deref(), Some("feature/x"));
+        assert_eq!(entries[2].branch_name, None);
+        assert!(entries[2].detached);
+        assert_eq!(entries[2].label(), "detached abcdef1");
     }
 
     fn run_git(cwd: &Path, args: &[&str]) {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -11,6 +11,7 @@ pub enum Action {
     ToggleProject,
     NewAgent,
     NewAgentFromPr,
+    NewAgentFromWorktree,
     ForkAgent,
     ChangeAgentProvider,
     ChangeDefaultProvider,
@@ -194,6 +195,7 @@ impl Action {
             Action::ToggleProject => "toggle_project",
             Action::NewAgent => "new_agent",
             Action::NewAgentFromPr => "new_agent_from_pr",
+            Action::NewAgentFromWorktree => "new_agent_from_worktree",
             Action::ForkAgent => "fork_agent",
             Action::ChangeAgentProvider => "change_agent_provider",
             Action::ChangeDefaultProvider => "change_default_provider",
@@ -283,6 +285,7 @@ impl Action {
             Action::ToggleProject => "Collapse or expand the selected project.",
             Action::NewAgent => "Create a new agent session (worktree).",
             Action::NewAgentFromPr => "Create a new agent session from a GitHub pull request.",
+            Action::NewAgentFromWorktree => "Create a new agent from an existing git worktree.",
             Action::ForkAgent => "Fork the selected agent into a fresh worktree and session.",
             Action::ChangeAgentProvider => {
                 "Swap the selected agent worktree to a different provider."
@@ -395,6 +398,7 @@ impl Action {
             | Action::MoveUp
             | Action::ToggleProject
             | Action::NewAgent
+            | Action::NewAgentFromWorktree
             | Action::ForkAgent
             | Action::ChangeAgentProvider
             | Action::FocusAgent
@@ -585,6 +589,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "new-agent-from-pr",
             description: "Create a new agent from a GitHub pull request",
+        }),
+    },
+    BindingDef {
+        action: Action::NewAgentFromWorktree,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "new-agent-from-worktree",
+            description: "Create a new agent from an existing git worktree",
         }),
     },
     BindingDef {


### PR DESCRIPTION
This adds a command-palette flow for starting an agent from one of the selected project's existing Git worktrees. The picker separates available worktrees from ones that already have agents, keeps the main checkout separate, and makes the branch label explicit in the list.

Managed dux worktrees are reused and launched as continuable sessions. External worktrees are copied into a fresh managed dux worktree first, preserving dirty and untracked files while leaving the original checkout alone.