### PR TITLE
Move project state out of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Switch providers from the command palette. dux sticks to one agent per worktree,
 
 The header shows `default provider: …` when the selected project inherits the global fallback. If a project has its own override, the header shows `project provider: …` plus `global default: …`. It also adds `current provider: …` when the selected agent is using a different one, so you always know which CLI you're talking to.
 
-You can also set a default per-project in the config file, which wins over the global default for that one project.
+Project-specific provider defaults are managed from inside dux with `change-project-default-provider`; `config.toml` only stores the global fallback.
 
 ### Macros
 
@@ -120,7 +120,7 @@ Each macro can be scoped to the agent pane, the companion terminal, or both.
 
 The right pane is a full git staging area. Stage and unstage files, view syntax-highlighted diffs, write commit messages, push, and pull, all without leaving dux.
 
-**AI commit messages:** Stage your changes, hit a key, and dux sends the diff to your provider in oneshot mode. It drafts a commit message using Conventional Commits, you tweak it (or don't), and commit. The prompt is fully customizable per-project.
+**AI commit messages:** Stage your changes, hit a key, and dux sends the diff to your provider in oneshot mode. It drafts a commit message using Conventional Commits, you tweak it (or don't), and commit. The prompt is customizable once in `config.toml` for the whole app.
 
 **PR tracking:** With the `gh` CLI installed, dux tracks pull requests for your agent branches and shows status pills right in the interface.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -982,8 +982,7 @@ impl App {
             return Ok(());
         };
         let worktree = PathBuf::from(&session.worktree_path);
-        let project_path = session.project_path.as_deref().unwrap_or("");
-        let base_prompt = self.config.commit_prompt_for_project(project_path);
+        let base_prompt = self.config.default_commit_prompt();
 
         // Capture the staged diff up-front so the provider does not need tool
         // access to inspect it. The diff is appended after the prompt text.
@@ -5543,12 +5542,22 @@ mod tests {
             id: "project-1".to_string(),
             name: "demo".to_string(),
             path: root.to_string_lossy().to_string(),
+            explicit_default_provider: None,
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
+        session_store
+            .upsert_project(&ProjectConfig {
+                id: project.id.clone(),
+                path: project.path.clone(),
+                name: Some(project.name.clone()),
+                default_provider: None,
+                leading_branch: project.leading_branch.clone(),
+            })
+            .expect("seed project");
         let session = AgentSession {
             id: "session-1".to_string(),
             project_id: project.id.clone(),
@@ -7570,6 +7579,7 @@ not_a_real_action = ["x"]
                 id: format!("empty-project-{idx}"),
                 name: format!("empty {idx}"),
                 path: path.clone(),
+                explicit_default_provider: None,
                 default_provider: ProviderKind::from_str("codex"),
                 leading_branch: Some("main".to_string()),
                 current_branch: "main".to_string(),
@@ -11374,35 +11384,27 @@ cyan = "#00ffff"
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
 
-        // project-1 inherits the global default (no explicit override).
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: None,
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
-
         // project-2 pins itself to "gemini" and must not be touched.
         let pinned = Project {
             id: "project-2".to_string(),
             name: "pinned".to_string(),
             path: app.paths.root.join("pinned").display().to_string(),
+            explicit_default_provider: Some(ProviderKind::from_str("gemini")),
             default_provider: ProviderKind::from_str("gemini"),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
-        app.config.projects.push(ProjectConfig {
-            id: pinned.id.clone(),
-            path: pinned.path.clone(),
-            name: Some(pinned.name.clone()),
-            default_provider: Some("gemini".to_string()),
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
+        app.session_store
+            .upsert_project(&ProjectConfig {
+                id: pinned.id.clone(),
+                path: pinned.path.clone(),
+                name: Some(pinned.name.clone()),
+                default_provider: Some("gemini".to_string()),
+                leading_branch: Some("main".to_string()),
+            })
+            .expect("seed pinned project");
         app.projects.push(pinned);
 
         let original_session_provider = app.sessions[0].provider.clone();
@@ -11459,14 +11461,6 @@ cyan = "#00ffff"
     fn change_default_provider_rejects_current_selection_without_mutating_config() {
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: None,
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
 
         app.open_change_default_provider_prompt()
             .expect("open default provider picker");
@@ -11497,33 +11491,27 @@ cyan = "#00ffff"
     fn change_project_default_provider_updates_selected_project_only() {
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: None,
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
 
         let pinned = Project {
             id: "project-2".to_string(),
             name: "pinned".to_string(),
             path: app.paths.root.join("pinned").display().to_string(),
+            explicit_default_provider: Some(ProviderKind::from_str("gemini")),
             default_provider: ProviderKind::from_str("gemini"),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
         };
-        app.config.projects.push(ProjectConfig {
-            id: pinned.id.clone(),
-            path: pinned.path.clone(),
-            name: Some(pinned.name.clone()),
-            default_provider: Some("gemini".to_string()),
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
+        app.session_store
+            .upsert_project(&ProjectConfig {
+                id: pinned.id.clone(),
+                path: pinned.path.clone(),
+                name: Some(pinned.name.clone()),
+                default_provider: Some("gemini".to_string()),
+                leading_branch: Some("main".to_string()),
+            })
+            .expect("seed pinned project");
         app.projects.push(pinned);
 
         app.open_change_project_default_provider_prompt()
@@ -11547,18 +11535,18 @@ cyan = "#00ffff"
 
         app.apply_change_project_default_provider()
             .expect("apply project provider");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
 
         assert_eq!(app.config.defaults.provider, "codex");
-        let persisted = crate::config::ensure_config(&app.paths).expect("reload config");
+        let persisted = app.session_store.load_projects().expect("load projects");
         let inherited_cfg = persisted
-            .projects
             .iter()
             .find(|project| project.id == "project-1")
             .expect("project-1 config");
         assert_eq!(inherited_cfg.default_provider.as_deref(), Some("claude"));
 
         let pinned_cfg = persisted
-            .projects
             .iter()
             .find(|project| project.id == "project-2")
             .expect("project-2 config");
@@ -11582,14 +11570,10 @@ cyan = "#00ffff"
     fn change_project_default_provider_can_revert_to_global_default() {
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: Some("gemini".to_string()),
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
+        app.session_store
+            .update_project_default_provider(&app.projects[0].id, Some("gemini"))
+            .expect("seed project override");
+        app.projects[0].explicit_default_provider = Some(ProviderKind::from_str("gemini"));
         app.projects[0].default_provider = ProviderKind::from_str("gemini");
 
         app.open_change_project_default_provider_prompt()
@@ -11607,10 +11591,11 @@ cyan = "#00ffff"
 
         app.apply_change_project_default_provider()
             .expect("apply inherit global");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
 
-        let persisted = crate::config::ensure_config(&app.paths).expect("reload config");
+        let persisted = app.session_store.load_projects().expect("load projects");
         let config = persisted
-            .projects
             .iter()
             .find(|project| project.id == "project-1")
             .expect("project-1 config");
@@ -11655,14 +11640,7 @@ cyan = "#00ffff"
 
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "claude".to_string();
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: Some("codex".to_string()),
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
+        app.projects[0].explicit_default_provider = Some(ProviderKind::from_str("codex"));
         app.projects[0].default_provider = ProviderKind::from_str("codex");
         app.sessions[0].provider = ProviderKind::from_str("gemini");
         app.rebuild_left_items();
@@ -11706,14 +11684,7 @@ cyan = "#00ffff"
 
         let mut app = test_app(default_bindings());
         app.config.defaults.provider = "codex".to_string();
-        app.config.projects.push(ProjectConfig {
-            id: app.projects[0].id.clone(),
-            path: app.projects[0].path.clone(),
-            name: Some(app.projects[0].name.clone()),
-            default_provider: None,
-            leading_branch: Some("main".to_string()),
-            commit_prompt: None,
-        });
+        app.projects[0].explicit_default_provider = None;
         app.projects[0].default_provider = ProviderKind::from_str("codex");
         app.sessions[0].provider = ProviderKind::from_str("codex");
         app.rebuild_left_items();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,8 +27,8 @@ use uuid::Uuid;
 
 use crate::clipboard::Clipboard;
 use crate::config::{
-    Config, DuxPaths, MacroSurface, ProjectConfig, ProviderCommandConfig, check_provider_available,
-    ensure_config, save_config, validate_keys,
+    Config, DuxPaths, MacroSurface, ProviderCommandConfig, check_provider_available, ensure_config,
+    save_config, validate_keys,
 };
 use crate::diff::SyntaxCache;
 use crate::editor::DetectedEditor;
@@ -1263,6 +1263,10 @@ pub(crate) enum WorkerEvent {
     },
     ConfigReloadReady(Box<Result<Config, String>>),
     ConfigRecoverCompleted(Result<(), String>),
+    ProjectPersistenceCompleted {
+        action: ProjectPersistenceAction,
+        result: Result<(), String>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1272,6 +1276,28 @@ pub(crate) enum PullTarget {
         project_name: String,
     },
     Session,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ProjectPersistenceAction {
+    Add {
+        project: Project,
+        status_message: String,
+    },
+    Remove {
+        project_id: String,
+        project_name: String,
+    },
+    Delete {
+        project_id: String,
+        project_name: String,
+    },
+    UpdateDefaultProvider {
+        project_id: String,
+        project_name: String,
+        provider: Option<ProviderKind>,
+        global_default: ProviderKind,
+    },
 }
 
 mod components;
@@ -1290,7 +1316,7 @@ impl App {
         paths: DuxPaths,
         single_instance_lock: SingleInstanceLock,
     ) -> Result<Self> {
-        let config = ensure_config(&paths)?;
+        let mut config = ensure_config(&paths)?;
 
         logger::init(&config.logging, &paths);
         logger::info("bootstrapping dux");
@@ -1312,7 +1338,8 @@ impl App {
         signal_hook::flag::register(signal_hook::consts::SIGWINCH, Arc::clone(&sigwinch_flag))?;
 
         let session_store = SessionStore::open(&paths.sessions_db_path)?;
-        let projects = load_projects(&config);
+        migrate_config_projects_to_store(&mut config, &paths, &bindings, &session_store)?;
+        let projects = load_projects(&session_store.load_projects()?, &config);
         let sessions = session_store.load_sessions()?;
         let (worker_tx, worker_rx) = mpsc::channel();
         let watched_worktree: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
@@ -2063,7 +2090,7 @@ impl App {
         self.pr_banner_at_bottom = config.ui.pr_banner_position == "bottom";
         self.config = config;
 
-        self.projects = load_projects(&self.config);
+        refresh_project_defaults(&mut self.projects, &self.config);
         self.selected_left = self
             .selected_left
             .min(self.projects.len().saturating_sub(1));
@@ -2255,27 +2282,14 @@ impl App {
         }
     }
 
-    pub(crate) fn project_config(&self, project_id: &str) -> Option<&ProjectConfig> {
-        self.config
-            .projects
-            .iter()
-            .find(|project| project.id == project_id)
-    }
-
-    pub(crate) fn project_config_mut(&mut self, project_id: &str) -> Option<&mut ProjectConfig> {
-        self.config
-            .projects
-            .iter_mut()
-            .find(|project| project.id == project_id)
-    }
-
     pub(crate) fn project_explicit_default_provider(
         &self,
         project_id: &str,
     ) -> Option<ProviderKind> {
-        self.project_config(project_id)
-            .and_then(|project| project.default_provider.as_deref())
-            .map(ProviderKind::from_str)
+        self.projects
+            .iter()
+            .find(|project| project.id == project_id)
+            .and_then(|project| project.explicit_default_provider.clone())
     }
 
     pub(crate) fn project_uses_explicit_default_provider(&self, project_id: &str) -> bool {
@@ -2691,19 +2705,19 @@ impl App {
 pub(crate) fn refresh_project_defaults(projects: &mut [Project], config: &Config) {
     let fallback = config.default_provider();
     for project in projects.iter_mut() {
-        let explicit = config
-            .projects
-            .iter()
-            .find(|cfg| cfg.id == project.id)
-            .and_then(|cfg| cfg.default_provider.as_deref())
-            .map(ProviderKind::from_str);
-        project.default_provider = explicit.unwrap_or_else(|| fallback.clone());
+        project.default_provider = project
+            .explicit_default_provider
+            .clone()
+            .unwrap_or_else(|| fallback.clone());
     }
 }
 
-pub(crate) fn load_projects(config: &Config) -> Vec<Project> {
+pub(crate) fn load_projects(
+    project_configs: &[crate::config::ProjectConfig],
+    config: &Config,
+) -> Vec<Project> {
     let mut projects = Vec::new();
-    for project in config.projects.iter() {
+    for project in project_configs {
         let (path, missing) = match crate::config::expand_path(&project.path) {
             Some(expanded) => {
                 let p = PathBuf::from(&expanded);
@@ -2738,6 +2752,10 @@ pub(crate) fn load_projects(config: &Config) -> Vec<Project> {
                     .to_string()
             }),
             path: path.to_string_lossy().to_string(),
+            explicit_default_provider: project
+                .default_provider
+                .as_deref()
+                .map(ProviderKind::from_str),
             default_provider: provider,
             leading_branch,
             current_branch,
@@ -2746,6 +2764,23 @@ pub(crate) fn load_projects(config: &Config) -> Vec<Project> {
         });
     }
     projects
+}
+
+pub(crate) fn migrate_config_projects_to_store(
+    config: &mut Config,
+    paths: &DuxPaths,
+    bindings: &RuntimeBindings,
+    session_store: &SessionStore,
+) -> Result<()> {
+    if config.projects.is_empty() {
+        return Ok(());
+    }
+
+    for (index, project) in config.projects.iter().enumerate() {
+        session_store.upsert_project_at(project, index as i64)?;
+    }
+    config.projects.clear();
+    save_config(&paths.config_path, config, bindings)
 }
 
 // ── Resource monitor helpers ───────────────────────────────────────────────
@@ -2880,6 +2915,7 @@ mod tests {
             id: id.to_string(),
             name: id.to_string(),
             path: format!("/tmp/{id}"),
+            explicit_default_provider: None,
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),
@@ -3043,6 +3079,55 @@ mod tests {
 
         assert!(!items.contains(&LeftItem::EmptyProjectsSeparator));
         assert_eq!(items[0], LeftItem::Project(0));
+    }
+
+    #[test]
+    fn migrates_legacy_config_projects_to_sqlite_and_strips_config() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+            root: root.clone(),
+        };
+        std::fs::create_dir_all(&paths.worktrees_root).expect("worktrees");
+        std::fs::write(
+            &paths.config_path,
+            r#"
+[defaults]
+provider = "codex"
+
+[[projects]]
+id = "project-1"
+path = "$CODE/dux"
+name = "dux"
+default_provider = "claude"
+leading_branch = "main"
+"#,
+        )
+        .expect("write config");
+
+        let mut config = ensure_config(&paths).expect("load config");
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let store = SessionStore::open(&paths.sessions_db_path).expect("store");
+
+        migrate_config_projects_to_store(&mut config, &paths, &bindings, &store)
+            .expect("migrate projects");
+
+        assert!(config.projects.is_empty());
+        let projects = store.load_projects().expect("load projects");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].id, "project-1");
+        assert_eq!(projects[0].path, "$CODE/dux");
+        assert_eq!(projects[0].name.as_deref(), Some("dux"));
+        assert_eq!(projects[0].default_provider.as_deref(), Some("claude"));
+        assert_eq!(projects[0].leading_branch.as_deref(), Some("main"));
+
+        let saved = std::fs::read_to_string(&paths.config_path).expect("read config");
+        assert!(!saved.contains("[[projects]]"));
+        assert!(!saved.contains("project-1"));
     }
 
     #[test]

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -91,7 +91,8 @@ impl App {
         self.finish_add_project(path_str, name, branch, leading_branch)
     }
 
-    /// Saves the project to config and adds it to the runtime project list.
+    /// Starts saving the project to SQLite and adds it to the runtime project
+    /// list only after the worker confirms the write.
     /// Called directly when no branch warning is needed, or after the user
     /// confirms "Add Anyway" in the non-default-branch dialog.
     pub(crate) fn finish_add_project(
@@ -111,29 +112,46 @@ impl App {
         } else {
             name.trim().to_string()
         };
+        let status_message = format!("Added project \"{display_name}\" to workspace");
+        self.finish_add_project_with_status(path, name, branch, leading_branch, status_message)
+    }
+
+    pub(crate) fn finish_add_project_with_status(
+        &mut self,
+        path: String,
+        name: String,
+        branch: String,
+        leading_branch: String,
+        status_message: String,
+    ) -> Result<()> {
+        let path_buf = PathBuf::from(&path);
+        let display_name = if name.trim().is_empty() {
+            path_buf
+                .file_name()
+                .and_then(|part| part.to_str())
+                .unwrap_or("project")
+                .to_string()
+        } else {
+            name.trim().to_string()
+        };
         let project_id = Uuid::new_v4().to_string();
-        self.config.projects.push(ProjectConfig {
-            id: project_id.clone(),
-            path: path.clone(),
-            name: Some(display_name.clone()),
-            default_provider: None,
-            leading_branch: Some(leading_branch.clone()),
-            commit_prompt: None,
-        });
-        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
-        self.projects.push(Project {
+        let project = Project {
             id: project_id,
             name: display_name.clone(),
-            path,
+            path: path.clone(),
+            explicit_default_provider: None,
             default_provider: self.config.default_provider(),
             leading_branch: Some(leading_branch),
             current_branch: branch,
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
-        });
-        self.rebuild_left_items();
+        };
         logger::info(&format!("registered project {}", path_buf.display()));
-        self.set_info(format!("Added project \"{display_name}\" to workspace"));
+        self.spawn_project_persistence(ProjectPersistenceAction::Add {
+            project,
+            status_message,
+        });
+        self.set_busy(format!("Saving project \"{display_name}\" to workspace..."));
         Ok(())
     }
 
@@ -1198,9 +1216,6 @@ impl App {
             return Ok(());
         };
         self.prompt = PromptState::None;
-        let previous = self
-            .project_config(&prompt.project_id)
-            .and_then(|project| project.default_provider.clone());
         if selected.is_current {
             let message = match selected.provider {
                 Some(provider) => format!(
@@ -1218,40 +1233,28 @@ impl App {
             return Ok(());
         }
 
-        let Some(project_config) = self.project_config_mut(&prompt.project_id) else {
+        if !self
+            .projects
+            .iter()
+            .any(|project| project.id == prompt.project_id)
+        {
             self.set_error(format!(
-                "Could not find config for project \"{}\".",
+                "Could not find project \"{}\".",
                 prompt.project_name
-            ));
-            return Ok(());
-        };
-        project_config.default_provider =
-            selected.provider.as_ref().map(|p| p.as_str().to_string());
-        if let Err(err) = save_config(&self.paths.config_path, &self.config, &self.bindings) {
-            if let Some(project_config) = self.project_config_mut(&prompt.project_id) {
-                project_config.default_provider = previous;
-            }
-            self.set_error(format!(
-                "Couldn't persist the project provider change: {err:#}"
             ));
             return Ok(());
         }
 
-        refresh_project_defaults(&mut self.projects, &self.config);
-        self.rebuild_left_items();
-        let message = match selected.provider {
-            Some(provider) => format!(
-                "Project provider for \"{}\" changed to {}. Future agents in this project will use it; existing agents keep their current provider.",
-                prompt.project_name,
-                provider.as_str(),
-            ),
-            None => format!(
-                "\"{}\" now inherits the global default provider ({}). Future agents in this project will use it unless you add a project override again.",
-                prompt.project_name,
-                prompt.global_default.as_str(),
-            ),
-        };
-        self.set_info(message);
+        self.spawn_project_persistence(ProjectPersistenceAction::UpdateDefaultProvider {
+            project_id: prompt.project_id,
+            project_name: prompt.project_name.clone(),
+            provider: selected.provider,
+            global_default: prompt.global_default,
+        });
+        self.set_busy(format!(
+            "Saving provider preference for project \"{}\"...",
+            prompt.project_name
+        ));
         Ok(())
     }
 
@@ -1373,14 +1376,14 @@ impl App {
             self.set_error("Delete all agents in this project first.");
             return Ok(());
         }
-        self.projects.retain(|p| p.id != project.id);
-        self.config
-            .projects
-            .retain(|p| Path::new(&p.path) != Path::new(&project.path));
-        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
-        self.rebuild_left_items();
-        self.selected_left = self.selected_left.saturating_sub(1);
-        self.set_info(format!("Removed project \"{}\" from app", project.name));
+        self.spawn_project_persistence(ProjectPersistenceAction::Remove {
+            project_id: project.id.clone(),
+            project_name: project.name.clone(),
+        });
+        self.set_busy(format!(
+            "Removing project \"{}\" from workspace...",
+            project.name
+        ));
         Ok(())
     }
 
@@ -1433,16 +1436,12 @@ impl App {
                 self.do_delete_session(&session_id, true)?;
             }
         }
-        self.projects.retain(|candidate| candidate.id != project.id);
-        self.config
-            .projects
-            .retain(|candidate| Path::new(&candidate.path) != Path::new(&project.path));
-        save_config(&self.paths.config_path, &self.config, &self.bindings)?;
-        self.rebuild_left_items();
-        self.selected_left = self.selected_left.saturating_sub(1);
-        self.reload_changed_files();
-        self.set_info(format!(
-            "Deleted project \"{}\" and all its agents",
+        self.spawn_project_persistence(ProjectPersistenceAction::Delete {
+            project_id: project.id.clone(),
+            project_name: project.name.clone(),
+        });
+        self.set_busy(format!(
+            "Finishing deletion for project \"{}\" after removing its agents...",
             project.name
         ));
         Ok(())
@@ -2327,6 +2326,7 @@ mod tests {
             id: id.to_string(),
             name: "demo".to_string(),
             path: "/tmp/project".to_string(),
+            explicit_default_provider: Some(ProviderKind::from_str(provider)),
             default_provider: ProviderKind::from_str(provider),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),
@@ -2478,6 +2478,7 @@ mod tests {
             id: id.to_string(),
             name: "demo".to_string(),
             path: path.to_string(),
+            explicit_default_provider: Some(ProviderKind::from_str(provider)),
             default_provider: ProviderKind::from_str(provider),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -404,22 +404,17 @@ impl App {
                             } else {
                                 name.trim().to_string()
                             };
-                            if let Err(e) =
-                                self.finish_add_project(
-                                    path,
-                                    name,
-                                    target_branch.clone(),
-                                    leading_branch,
-                                )
-                            {
+                            let status_message = format!(
+                                "Checked out \"{target_branch}\" and added project \"{display_name}\" to workspace."
+                            );
+                            if let Err(e) = self.finish_add_project_with_status(
+                                path,
+                                name,
+                                target_branch.clone(),
+                                leading_branch,
+                                status_message,
+                            ) {
                                 self.set_error(format!("{e:#}"));
-                            } else {
-                                // Override the generic "Added project" status from
-                                // finish_add_project with the more informative
-                                // two-step message.
-                                self.set_info(format!(
-                                    "Checked out \"{target_branch}\" and added project \"{display_name}\" to workspace."
-                                ));
                             }
                         }
                         NonDefaultBranchAction::CheckoutProjectDefault { project } => {
@@ -523,7 +518,7 @@ impl App {
                             project.name
                         )),
                     }
-                }
+                },
                 WorkerEvent::ConfigReloadReady(result) => match *result {
                     Ok(config) => {
                         if let Err(err) = self.apply_reloaded_config(config) {
@@ -555,6 +550,9 @@ impl App {
                         ));
                     }
                 },
+                WorkerEvent::ProjectPersistenceCompleted { action, result } => {
+                    self.apply_project_persistence_result(action, result);
+                }
             }
         }
         self.retry_hung_resume_sessions();
@@ -703,6 +701,141 @@ impl App {
         // Keep the poller's interval flag in sync with whether any runtime PTY is alive.
         self.has_active_processes
             .store(self.running_process_count() > 0, Ordering::Relaxed);
+    }
+
+    fn apply_project_persistence_result(
+        &mut self,
+        action: ProjectPersistenceAction,
+        result: Result<(), String>,
+    ) {
+        if let Err(err) = result {
+            match action {
+                ProjectPersistenceAction::Add { project, .. } => {
+                    self.set_error(format!(
+                        "Could not save project \"{}\" to the database: {err}",
+                        project.name
+                    ));
+                }
+                ProjectPersistenceAction::Remove { project_name, .. } => {
+                    self.set_error(format!(
+                        "Could not remove project \"{project_name}\" from the database: {err}"
+                    ));
+                }
+                ProjectPersistenceAction::Delete { project_name, .. } => {
+                    self.set_error(format!(
+                        "Could not finish deleting project \"{project_name}\" from the database: {err}"
+                    ));
+                }
+                ProjectPersistenceAction::UpdateDefaultProvider { project_name, .. } => {
+                    self.set_error(format!(
+                        "Could not save the provider change for project \"{project_name}\": {err}"
+                    ));
+                }
+            }
+            return;
+        }
+
+        match action {
+            ProjectPersistenceAction::Add {
+                project,
+                status_message,
+            } => {
+                self.projects.push(project);
+                self.rebuild_left_items();
+                self.set_info(status_message);
+            }
+            ProjectPersistenceAction::Remove {
+                project_id,
+                project_name,
+            } => {
+                self.projects.retain(|project| project.id != project_id);
+                self.rebuild_left_items();
+                self.selected_left = self.selected_left.saturating_sub(1);
+                self.set_info(format!("Removed project \"{project_name}\" from app"));
+            }
+            ProjectPersistenceAction::Delete {
+                project_id,
+                project_name,
+            } => {
+                self.projects.retain(|project| project.id != project_id);
+                self.rebuild_left_items();
+                self.selected_left = self.selected_left.saturating_sub(1);
+                self.reload_changed_files();
+                self.set_info(format!(
+                    "Deleted project \"{project_name}\" and all its agents"
+                ));
+            }
+            ProjectPersistenceAction::UpdateDefaultProvider {
+                project_id,
+                project_name,
+                provider,
+                global_default,
+            } => {
+                if let Some(project) = self
+                    .projects
+                    .iter_mut()
+                    .find(|project| project.id == project_id)
+                {
+                    project.explicit_default_provider = provider.clone();
+                }
+                refresh_project_defaults(&mut self.projects, &self.config);
+                self.rebuild_left_items();
+                let message = match provider {
+                    Some(provider) => format!(
+                        "Project provider for \"{}\" changed to {}. Future agents in this project will use it; existing agents keep their current provider.",
+                        project_name,
+                        provider.as_str(),
+                    ),
+                    None => format!(
+                        "\"{}\" now inherits the global default provider ({}). Future agents in this project will use it; existing agents keep their current provider.",
+                        project_name,
+                        global_default.as_str(),
+                    ),
+                };
+                self.set_info(message);
+            }
+        }
+    }
+
+    pub(crate) fn spawn_project_persistence(&self, action: ProjectPersistenceAction) {
+        let db_path = self.paths.sessions_db_path.clone();
+        let tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            let result = (|| -> Result<()> {
+                let store = SessionStore::open(&db_path)?;
+                match &action {
+                    ProjectPersistenceAction::Add { project, .. } => {
+                        store.upsert_project(&crate::config::ProjectConfig {
+                            id: project.id.clone(),
+                            path: project.path.clone(),
+                            name: Some(project.name.clone()),
+                            default_provider: project
+                                .explicit_default_provider
+                                .as_ref()
+                                .map(|provider| provider.as_str().to_string()),
+                            leading_branch: project.leading_branch.clone(),
+                        })?;
+                    }
+                    ProjectPersistenceAction::Remove { project_id, .. }
+                    | ProjectPersistenceAction::Delete { project_id, .. } => {
+                        store.delete_project(project_id)?;
+                    }
+                    ProjectPersistenceAction::UpdateDefaultProvider {
+                        project_id,
+                        provider,
+                        ..
+                    } => {
+                        store.update_project_default_provider(
+                            project_id,
+                            provider.as_ref().map(|provider| provider.as_str()),
+                        )?;
+                    }
+                }
+                Ok(())
+            })()
+            .map_err(|err| format!("{err:#}"));
+            let _ = tx.send(WorkerEvent::ProjectPersistenceCompleted { action, result });
+        });
     }
 
     pub(crate) fn spawn_browser_entries(&self, dir: &Path) {
@@ -1978,6 +2111,7 @@ mod tests {
             id: "project-1".to_string(),
             name: "demo".to_string(),
             path: tmp.path().to_string_lossy().to_string(),
+            explicit_default_provider: None,
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             current_branch: "main".to_string(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,14 +273,6 @@ fn run_diff_summary(current: &Config) -> Result<()> {
     // [providers.*]
     diff_providers(&mut changes, &defaults, current);
 
-    // [[projects]]
-    if !current.projects.is_empty() {
-        changes.push(format!(
-            "projects: {} project(s) configured",
-            current.projects.len()
-        ));
-    }
-
     // [macros]
     if !current.macros.entries.is_empty() {
         changes.push(format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,7 @@ pub struct ProviderCommandConfig {
     pub forward_scroll: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectConfig {
     #[serde(default = "new_project_id")]
     pub id: String,
@@ -176,7 +176,6 @@ pub struct ProjectConfig {
     pub name: Option<String>,
     pub default_provider: Option<String>,
     pub leading_branch: Option<String>,
-    pub commit_prompt: Option<String>,
 }
 
 fn new_project_id() -> String {
@@ -361,15 +360,7 @@ impl Config {
         ProviderKind::from_str(&self.defaults.provider)
     }
 
-    /// Returns the effective commit prompt for a project, checking project-level
-    /// override first, then system default, then the hardcoded fallback.
-    pub fn commit_prompt_for_project(&self, project_path: &str) -> String {
-        if let Some(project) = self.projects.iter().find(|p| p.path == project_path)
-            && let Some(ref prompt) = project.commit_prompt
-            && !prompt.is_empty()
-        {
-            return prompt.clone();
-        }
+    pub fn default_commit_prompt(&self) -> String {
         self.defaults
             .commit_prompt
             .as_ref()
@@ -588,8 +579,6 @@ enum ConfigEntry {
     Providers,
     /// Renders the `[terminal]` section.
     Terminal,
-    /// Renders the `[[projects]]` array.
-    Projects,
     /// Renders the `[keys]` section with all keybindings.
     Keys,
     /// Renders the `[macros]` section with text macros.
@@ -607,7 +596,8 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
         ConfigEntry::Field {
             key: "provider",
             comment: Some(CommentSource::Static(
-                "# Which provider new sessions use unless a project overrides it.",
+                "# Global fallback provider for new sessions.\n\
+                 # Project-specific provider overrides are managed inside dux, not in this file.",
             )),
             value_fn: |c| FieldValue::Str(c.defaults.provider.clone()),
         },
@@ -624,7 +614,7 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             comment: Some(CommentSource::Dynamic(format!(
                 "# Prompt sent to the AI provider when generating commit messages ({generate_commit_key}).\n\
                  # The staged diff is appended automatically after the prompt text.\n\
-                 # Override per-project by adding commit_prompt in a [[projects]] entry.",
+                 # This is app-wide; projects do not carry their own commit prompts.",
             ))),
             value_fn: |c| FieldValue::MultilineStr(c.defaults.commit_prompt.clone()),
         },
@@ -763,8 +753,6 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
         ConfigEntry::Keys,
         ConfigEntry::Blank,
         ConfigEntry::Macros,
-        ConfigEntry::Blank,
-        ConfigEntry::Projects,
     ]
 }
 
@@ -823,7 +811,6 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
             ConfigEntry::Terminal => render_terminal_config(&mut out, &config.terminal),
-            ConfigEntry::Projects => render_projects(&mut out, &config.projects),
             ConfigEntry::Keys => render_keys_config(&mut out, &config.keys, bindings),
             ConfigEntry::Macros => render_macros_config(&mut out, &config.macros, bindings),
         }
@@ -992,8 +979,10 @@ pub fn save_config(
     // --- [providers.*] ---
     patch_providers(&mut doc, &config.providers);
 
-    // --- [[projects]] ---
-    patch_projects(&mut doc, &config.projects);
+    // --- legacy [[projects]] ---
+    // Projects now live in SQLite. Saving config always strips any legacy
+    // project declarations after they have been migrated by the app bootstrap.
+    let _ = doc.remove("projects");
 
     // --- [macros] ---
     patch_macros(&mut doc, &config.macros);
@@ -1132,41 +1121,6 @@ fn patch_providers(doc: &mut DocumentMut, providers: &ProvidersConfig) {
     }
 }
 
-fn patch_projects(doc: &mut DocumentMut, projects: &[ProjectConfig]) {
-    // Remove existing [[projects]] array-of-tables and rebuild it.
-    let _ = doc.remove("projects");
-
-    if projects.is_empty() {
-        return;
-    }
-
-    let mut arr = toml_edit::ArrayOfTables::new();
-    for project in projects {
-        let mut tbl = Table::new();
-        tbl["id"] = toml_edit::value(&project.id);
-        tbl["path"] = toml_edit::value(&project.path);
-        if let Some(name) = &project.name {
-            tbl["name"] = toml_edit::value(name.as_str());
-        }
-        if let Some(provider) = &project.default_provider {
-            tbl["default_provider"] = toml_edit::value(provider.as_str());
-        }
-        if let Some(prompt) = &project.commit_prompt {
-            let escaped = escape_toml_multiline(prompt);
-            let snippet = format!("v = \"\"\"\n{escaped}\"\"\"");
-            if let Ok(mini) = snippet.parse::<DocumentMut>() {
-                if let Some(item) = mini.get("v") {
-                    tbl["commit_prompt"] = item.clone();
-                }
-            } else {
-                tbl["commit_prompt"] = toml_edit::value(prompt.as_str());
-            }
-        }
-        arr.push(tbl);
-    }
-    doc["projects"] = Item::ArrayOfTables(arr);
-}
-
 fn patch_macros(doc: &mut DocumentMut, macros: &MacrosConfig) {
     let table = ensure_table(doc, "macros");
 
@@ -1300,44 +1254,6 @@ fn render_macros_config(
                 text,
                 surface
             );
-        }
-    }
-}
-
-fn render_projects(out: &mut String, projects: &[ProjectConfig]) {
-    out.push_str(
-        "# Projects are registered here by the UI. The folder name is used when name is omitted.\n",
-    );
-    out.push_str("# default_provider can override the global default for one project.\n");
-    out.push_str(
-        "# Paths support environment variables ($HOME, ${USER}) and tilde (~) expansion.\n",
-    );
-    if projects.is_empty() {
-        out.push_str("# [[projects]]\n");
-        out.push_str("# path = \"$HOME/projects/your-repo\"\n");
-    } else {
-        for project in projects {
-            out.push_str("[[projects]]\n");
-            let _ = writeln!(out, "id = \"{}\"", escape_toml_string(&project.id));
-            let _ = writeln!(out, "path = \"{}\"", escape_toml_string(&project.path));
-            if let Some(name) = &project.name {
-                let _ = writeln!(out, "name = \"{}\"", escape_toml_string(name));
-            }
-            if let Some(provider) = &project.default_provider {
-                let _ = writeln!(
-                    out,
-                    "default_provider = \"{}\"",
-                    escape_toml_string(provider)
-                );
-            }
-            if let Some(branch) = &project.leading_branch {
-                let _ = writeln!(out, "leading_branch = \"{}\"", escape_toml_string(branch));
-            }
-            if let Some(prompt) = &project.commit_prompt {
-                let escaped = escape_toml_multiline(prompt);
-                let _ = writeln!(out, "commit_prompt = \"\"\"\n{escaped}\"\"\"");
-            }
-            out.push('\n');
         }
     }
 }
@@ -1834,38 +1750,73 @@ mod tests {
     }
 
     #[test]
-    fn render_config_escapes_special_chars() {
+    fn render_config_omits_legacy_projects() {
         let mut config = Config::default();
         config.projects.push(ProjectConfig {
             id: new_project_id(),
-            path: r#"/home/user/"test"\project"#.to_string(),
-            name: Some(r#"te"st"#.to_string()),
+            path: "/home/user/project".to_string(),
+            name: Some("test".to_string()),
             default_provider: None,
             leading_branch: Some("main".to_string()),
-            commit_prompt: None,
         });
         let rendered = render_config_default(&config);
+        assert!(!rendered.contains("[[projects]]"));
         let parsed: Config = toml::from_str(&rendered).expect("should parse back");
-        assert_eq!(parsed.projects[0].path, config.projects[0].path);
-        assert_eq!(parsed.projects[0].name, config.projects[0].name);
-        assert_eq!(parsed.projects[0].leading_branch, Some("main".to_string()));
+        assert!(parsed.projects.is_empty());
     }
 
     #[test]
-    fn render_config_escapes_newlines_and_control_chars() {
+    fn legacy_projects_still_parse_for_migration() {
+        let parsed: Config = toml::from_str(
+            r#"
+[[projects]]
+id = "project-1"
+path = "/home/user/project"
+name = "test"
+default_provider = "codex"
+leading_branch = "main"
+"#,
+        )
+        .expect("legacy projects should parse");
+        assert_eq!(parsed.projects.len(), 1);
+        assert_eq!(parsed.projects[0].id, "project-1");
+        assert_eq!(parsed.projects[0].path, "/home/user/project");
+        assert_eq!(
+            parsed.projects[0].default_provider.as_deref(),
+            Some("codex")
+        );
+        assert_eq!(parsed.projects[0].leading_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn save_config_strips_legacy_projects() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"
+[[projects]]
+id = "project-1"
+path = "/home/user/project"
+name = "test"
+"#,
+        )
+        .expect("write config");
+
         let mut config = Config::default();
         config.projects.push(ProjectConfig {
-            id: new_project_id(),
+            id: "project-1".to_string(),
             path: "/home/user/path\nwith\nnewlines".to_string(),
             name: Some("name\twith\ttabs".to_string()),
             default_provider: None,
             leading_branch: None,
-            commit_prompt: None,
         });
-        let rendered = render_config_default(&config);
-        let parsed: Config = toml::from_str(&rendered).expect("should parse back");
-        assert_eq!(parsed.projects[0].path, config.projects[0].path);
-        assert_eq!(parsed.projects[0].name, config.projects[0].name);
+        let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
+        save_config(&config_path, &config, &bindings).expect("save config");
+
+        let saved = fs::read_to_string(config_path).expect("read config");
+        assert!(!saved.contains("[[projects]]"));
+        assert!(!saved.contains("project-1"));
     }
 
     #[test]
@@ -2291,59 +2242,18 @@ oneshot_output = "stdout"
     }
 
     #[test]
-    fn commit_prompt_resolution_uses_project_override() {
-        let mut config = Config::default();
-        config.projects.push(ProjectConfig {
-            id: new_project_id(),
-            path: "/my/project".to_string(),
-            name: Some("test".to_string()),
-            default_provider: None,
-            leading_branch: None,
-            commit_prompt: Some("custom project prompt".to_string()),
-        });
-
-        // Project override takes precedence.
-        assert_eq!(
-            config.commit_prompt_for_project("/my/project"),
-            "custom project prompt"
-        );
-
-        // Unknown project falls back to system default.
-        assert_eq!(
-            config.commit_prompt_for_project("/other/project"),
-            DEFAULT_COMMIT_PROMPT
-        );
-
-        // Empty project prompt falls back to system default.
-        config.projects[0].commit_prompt = Some(String::new());
-        assert_eq!(
-            config.commit_prompt_for_project("/my/project"),
-            DEFAULT_COMMIT_PROMPT
-        );
-    }
-
-    #[test]
-    fn commit_prompt_resolution_uses_system_default() {
+    fn default_commit_prompt_uses_system_default() {
         let mut config = Config::default();
         config.defaults.commit_prompt = Some("custom system prompt".to_string());
-        assert_eq!(
-            config.commit_prompt_for_project("/any/project"),
-            "custom system prompt"
-        );
+        assert_eq!(config.default_commit_prompt(), "custom system prompt");
 
         // Empty system prompt falls back to hardcoded constant.
         config.defaults.commit_prompt = Some(String::new());
-        assert_eq!(
-            config.commit_prompt_for_project("/any/project"),
-            DEFAULT_COMMIT_PROMPT
-        );
+        assert_eq!(config.default_commit_prompt(), DEFAULT_COMMIT_PROMPT);
 
         // None falls back to hardcoded constant.
         config.defaults.commit_prompt = None;
-        assert_eq!(
-            config.commit_prompt_for_project("/any/project"),
-            DEFAULT_COMMIT_PROMPT
-        );
+        assert_eq!(config.default_commit_prompt(), DEFAULT_COMMIT_PROMPT);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,6 +55,7 @@ pub struct Project {
     pub id: String,
     pub name: String,
     pub path: String,
+    pub explicit_default_provider: Option<ProviderKind>,
     pub default_provider: ProviderKind,
     pub leading_branch: Option<String>,
     pub current_branch: String,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
 
+use crate::config::ProjectConfig;
 use crate::model::{AgentSession, SessionStatus};
 
 /// A stored PR association loaded from the database.
@@ -47,6 +48,41 @@ impl SessionStore {
             );
             "#,
         )?;
+        self.conn.execute_batch(
+            r#"
+            create table if not exists projects (
+                id text primary key,
+                path text not null unique,
+                name text,
+                default_provider text,
+                leading_branch text,
+                sort_order integer not null default 0,
+                created_at text not null,
+                updated_at text not null
+            );
+            "#,
+        )?;
+        ensure_column(&self.conn, "projects", "name", "text")?;
+        ensure_column(&self.conn, "projects", "default_provider", "text")?;
+        ensure_column(&self.conn, "projects", "leading_branch", "text")?;
+        ensure_column(
+            &self.conn,
+            "projects",
+            "sort_order",
+            "integer not null default 0",
+        )?;
+        ensure_column(
+            &self.conn,
+            "projects",
+            "created_at",
+            "text not null default ''",
+        )?;
+        ensure_column(
+            &self.conn,
+            "projects",
+            "updated_at",
+            "text not null default ''",
+        )?;
         ensure_column(&self.conn, "agent_sessions", "title", "text")?;
         ensure_column(&self.conn, "agent_sessions", "project_path", "text")?;
         ensure_column(
@@ -87,6 +123,125 @@ impl SessionStore {
             "text not null default ''",
         )?;
         ensure_column(&self.conn, "session_prs", "url", "text not null default ''")?;
+        Ok(())
+    }
+
+    /// Insert or update a project. If a project with the same path already
+    /// exists under a different id, keep the existing id so sessions remain
+    /// attached and refresh the editable metadata.
+    pub fn upsert_project(&self, project: &ProjectConfig) -> Result<()> {
+        let sort_order = self.next_project_sort_order()?;
+        self.upsert_project_at(project, sort_order)
+    }
+
+    pub fn upsert_project_at(&self, project: &ProjectConfig, sort_order: i64) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            r#"
+            update projects
+            set path = ?2,
+                name = ?3,
+                default_provider = ?4,
+                leading_branch = ?5,
+                sort_order = ?6,
+                updated_at = ?7
+            where id = ?1
+            "#,
+            params![
+                project.id,
+                project.path,
+                project.name,
+                project.default_provider,
+                project.leading_branch,
+                sort_order,
+                now,
+            ],
+        )?;
+        if updated > 0 {
+            return Ok(());
+        }
+
+        self.conn.execute(
+            r#"
+            insert into projects
+                (id, path, name, default_provider, leading_branch, sort_order, created_at, updated_at)
+            values
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+            on conflict(path) do update set
+                name=excluded.name,
+                default_provider=excluded.default_provider,
+                leading_branch=excluded.leading_branch,
+                sort_order=excluded.sort_order,
+                updated_at=excluded.updated_at
+            "#,
+            params![
+                project.id,
+                project.path,
+                project.name,
+                project.default_provider,
+                project.leading_branch,
+                sort_order,
+                now,
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn next_project_sort_order(&self) -> Result<i64> {
+        self.conn
+            .query_row(
+                "select coalesce(max(sort_order) + 1, 0) from projects",
+                [],
+                |row| row.get(0),
+            )
+            .context("failed to compute next project sort order")
+    }
+
+    pub fn load_projects(&self) -> Result<Vec<ProjectConfig>> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            select id, path, name, default_provider, leading_branch
+            from projects
+            order by sort_order, name collate nocase, path collate nocase
+            "#,
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ProjectConfig {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                name: row.get(2)?,
+                default_provider: row.get(3)?,
+                leading_branch: row.get(4)?,
+            })
+        })?;
+
+        let mut projects = Vec::new();
+        for row in rows {
+            projects.push(row?);
+        }
+        Ok(projects)
+    }
+
+    pub fn update_project_default_provider(
+        &self,
+        project_id: &str,
+        default_provider: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            r#"
+            update projects
+            set default_provider = ?2,
+                updated_at = ?3
+            where id = ?1
+            "#,
+            params![project_id, default_provider, Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_project(&self, id: &str) -> Result<()> {
+        self.conn
+            .execute("delete from projects where id = ?1", params![id])?;
         Ok(())
     }
 
@@ -381,6 +536,54 @@ mod tests {
             loaded[0].started_providers,
             vec!["claude".to_string(), "codex".to_string()]
         );
+    }
+
+    #[test]
+    fn projects_round_trip_all_project_fields() {
+        let store = test_store();
+        let project = ProjectConfig {
+            id: "project-1".to_string(),
+            path: "$CODE/dux".to_string(),
+            name: Some("dux".to_string()),
+            default_provider: Some("codex".to_string()),
+            leading_branch: Some("main".to_string()),
+        };
+
+        store.upsert_project(&project).unwrap();
+
+        let loaded = store.load_projects().unwrap();
+        assert_eq!(loaded, vec![project]);
+    }
+
+    #[test]
+    fn project_path_conflict_keeps_existing_id() {
+        let store = test_store();
+        store
+            .upsert_project(&ProjectConfig {
+                id: "stable-id".to_string(),
+                path: "/repo".to_string(),
+                name: Some("old".to_string()),
+                default_provider: None,
+                leading_branch: Some("main".to_string()),
+            })
+            .unwrap();
+
+        store
+            .upsert_project(&ProjectConfig {
+                id: "new-id".to_string(),
+                path: "/repo".to_string(),
+                name: Some("new".to_string()),
+                default_provider: Some("claude".to_string()),
+                leading_branch: Some("trunk".to_string()),
+            })
+            .unwrap();
+
+        let loaded = store.load_projects().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "stable-id");
+        assert_eq!(loaded[0].name.as_deref(), Some("new"));
+        assert_eq!(loaded[0].default_provider.as_deref(), Some("claude"));
+        assert_eq!(loaded[0].leading_branch.as_deref(), Some("trunk"));
     }
 }
 


### PR DESCRIPTION
This moves project records and project-specific provider preferences out of `config.toml` and into the existing SQLite state database. Legacy `[[projects]]` entries still parse so dux can migrate them automatically, then the generated and saved config no longer documents or preserves that deprecated surface.

The commit prompt is now clearly app-wide through `defaults.commit_prompt`; per-project commit prompts are removed. README and generated config comments now describe the new split: config is for app-wide settings, while projects are managed inside dux.

Project add, remove, delete, and provider-preference updates now persist through background workers, and the status line reports the final saved state after each multi-step project change.