### PR TITLE
Create agents from GitHub pull requests

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1752,14 +1752,16 @@ impl App {
                     self.prompt = PromptState::None;
                 }
                 Some(Action::MoveDown) => {
-                    if let PromptState::Command {
-                        input, selected, ..
-                    } = &mut self.prompt
-                    {
-                        let count = self.bindings.filtered_palette(&input.text).len();
-                        if *selected + 1 < count {
-                            *selected += 1;
+                    let count = match &self.prompt {
+                        PromptState::Command { input, .. } => {
+                            self.filtered_palette_commands(&input.text).len()
                         }
+                        _ => 0,
+                    };
+                    if let PromptState::Command { selected, .. } = &mut self.prompt
+                        && *selected + 1 < count
+                    {
+                        *selected += 1;
                     }
                 }
                 Some(Action::MoveUp) => {
@@ -1774,20 +1776,31 @@ impl App {
                 }
                 _ => {
                     // Text input fallback: Tab (autocomplete), then delegate to TextInput.
-                    if let PromptState::Command {
-                        input, selected, ..
-                    } = &mut self.prompt
-                    {
-                        if key.code == KeyCode::Tab {
-                            if let Some(binding) =
-                                self.bindings.filtered_palette(&input.text).get(*selected)
-                            {
-                                input.set_text(binding.palette_name.unwrap().to_string());
-                                *selected = 0;
-                            }
-                        } else if input.handle_key(key) {
+                    if key.code == KeyCode::Tab {
+                        let completion = match &self.prompt {
+                            PromptState::Command {
+                                input, selected, ..
+                            } => self
+                                .filtered_palette_commands(&input.text)
+                                .get(*selected)
+                                .and_then(|binding| binding.palette_name)
+                                .map(str::to_string),
+                            _ => None,
+                        };
+                        if let Some(completion) = completion
+                            && let PromptState::Command {
+                                input, selected, ..
+                            } = &mut self.prompt
+                        {
+                            input.set_text(completion);
                             *selected = 0;
                         }
+                    } else if let PromptState::Command {
+                        input, selected, ..
+                    } = &mut self.prompt
+                        && input.handle_key(key)
+                    {
+                        *selected = 0;
                     }
                 }
             }
@@ -2668,6 +2681,37 @@ impl App {
             return Ok(false);
         }
 
+        if matches!(self.prompt, PromptState::PullRequestInput { .. }) {
+            let is_plain_char = matches!(key.code, KeyCode::Char(_))
+                && !key.modifiers.contains(KeyModifiers::CONTROL);
+            let action = if is_plain_char {
+                None
+            } else {
+                self.bindings.lookup(&key, BindingScope::Dialog)
+            };
+
+            match action {
+                Some(Action::CloseOverlay) => {
+                    self.prompt = PromptState::None;
+                }
+                Some(Action::Confirm) => {
+                    let (project, raw_input) = match &self.prompt {
+                        PromptState::PullRequestInput { project, input } => {
+                            (project.clone(), input.text.trim().to_string())
+                        }
+                        _ => unreachable!(),
+                    };
+                    self.dispatch_pull_request_lookup(project, raw_input)?;
+                }
+                _ => {
+                    if let PromptState::PullRequestInput { input, .. } = &mut self.prompt {
+                        input.handle_key(key);
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         if matches!(self.prompt, PromptState::NameNewAgent { .. }) {
             let is_plain_char = matches!(key.code, KeyCode::Char(_))
                 && !key.modifiers.contains(KeyModifiers::CONTROL);
@@ -2712,16 +2756,10 @@ impl App {
 
                     // For NewProject requests, check whether the branch already
                     // exists locally or on the remote before creating a new one.
-                    if let CreateAgentRequest::NewProject { ref project, .. } = request {
+                    if let Some(project) = create_agent_request_project(&request) {
                         let repo_path = std::path::PathBuf::from(&project.path);
                         if let Some(location) = git::branch_exists(&repo_path, &name) {
-                            if let CreateAgentRequest::NewProject {
-                                ref mut custom_name,
-                                ..
-                            } = request
-                            {
-                                *custom_name = Some(name.clone());
-                            }
+                            set_create_agent_request_custom_name(&mut request, name.clone());
                             self.prompt = PromptState::ConfirmUseExistingBranch {
                                 request,
                                 branch_name: name,
@@ -2739,18 +2777,21 @@ impl App {
                                 project.name
                             )
                         }
+                        CreateAgentRequest::PullRequest {
+                            project, number, ..
+                        } => {
+                            format!(
+                                "Creating a new agent worktree \"{name}\" from PR #{number} for project \"{}\" and launching a fresh session...",
+                                project.name
+                            )
+                        }
                         CreateAgentRequest::ForkSession { source_label, .. } => {
                             format!(
                                 "Forking agent \"{source_label}\" as \"{name}\" by cloning its current worktree contents into a fresh session...",
                             )
                         }
                     };
-                    match &mut request {
-                        CreateAgentRequest::NewProject { custom_name, .. }
-                        | CreateAgentRequest::ForkSession { custom_name, .. } => {
-                            *custom_name = Some(name);
-                        }
-                    }
+                    set_create_agent_request_custom_name(&mut request, name);
                     self.dispatch_create_agent_request(request, msg)?;
                 }
                 _ => {
@@ -3564,7 +3605,7 @@ impl App {
 
     fn set_command_palette_selection(&mut self, index: usize) {
         let count = match &self.prompt {
-            PromptState::Command { input, .. } => self.bindings.filtered_palette(&input.text).len(),
+            PromptState::Command { input, .. } => self.filtered_palette_commands(&input.text).len(),
             _ => 0,
         };
         if count == 0 {
@@ -3592,7 +3633,7 @@ impl App {
             input, selected, ..
         } = &self.prompt
         {
-            if let Some(binding) = self.bindings.filtered_palette(&input.text).get(*selected) {
+            if let Some(binding) = self.filtered_palette_commands(&input.text).get(*selected) {
                 binding.palette_name.unwrap().to_string()
             } else {
                 input.text.trim().to_string()
@@ -4126,17 +4167,23 @@ impl App {
         if let CreateAgentRequest::NewProject {
             use_existing_branch,
             ..
+        }
+        | CreateAgentRequest::PullRequest {
+            use_existing_branch,
+            ..
         } = &mut request
         {
             *use_existing_branch = true;
         }
-        let msg = if let CreateAgentRequest::NewProject { ref project, .. } = request {
-            format!(
-                "Attaching to existing branch \"{branch_name}\" for project \"{}\" and launching a fresh session...",
-                project.name
-            )
-        } else {
-            unreachable!()
+        let msg = match &request {
+            CreateAgentRequest::NewProject { project, .. }
+            | CreateAgentRequest::PullRequest { project, .. } => {
+                format!(
+                    "Attaching to existing branch \"{branch_name}\" for project \"{}\" and launching a fresh session...",
+                    project.name
+                )
+            }
+            CreateAgentRequest::ForkSession { .. } => unreachable!(),
         };
         if let Err(e) = self.dispatch_create_agent_request(request, msg) {
             self.set_error(format!("{e:#}"));
@@ -5315,6 +5362,24 @@ impl App {
     }
 }
 
+fn create_agent_request_project(request: &CreateAgentRequest) -> Option<&Project> {
+    match request {
+        CreateAgentRequest::NewProject { project, .. }
+        | CreateAgentRequest::PullRequest { project, .. } => Some(project),
+        CreateAgentRequest::ForkSession { .. } => None,
+    }
+}
+
+fn set_create_agent_request_custom_name(request: &mut CreateAgentRequest, name: String) {
+    match request {
+        CreateAgentRequest::NewProject { custom_name, .. }
+        | CreateAgentRequest::ForkSession { custom_name, .. }
+        | CreateAgentRequest::PullRequest { custom_name, .. } => {
+            *custom_name = Some(name);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -5330,8 +5395,8 @@ mod tests {
         KillRunningFooterAction, KillRunningPrompt, KillableRuntime, KillableRuntimeKind, LeftItem,
         LeftSection, MacroBarState, MouseClickTarget, MouseLayoutState, NameNewAgentFocus,
         NonDefaultBranchAction, OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout,
-        OverlayMouseLayoutState, ProcessInfo, PromptState, PullTarget, ResourceStats, RightSection,
-        RuntimeTargetId, TextInput, WorkerEvent,
+        OverlayMouseLayoutState, ProcessInfo, PromptState, PullTarget, ResolvedPullRequest,
+        ResourceStats, RightSection, RuntimeTargetId, TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -7809,6 +7874,77 @@ not_a_real_action = ["x"]
                 assert_eq!(input.text, "jk");
             }
             other => panic!("expected command prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn command_palette_gates_new_agent_from_pr_on_github_availability() {
+        let mut app = test_app(default_bindings());
+
+        app.github_integration_enabled = true;
+        app.gh_status = crate::model::GhStatus::NotInstalled;
+        let unavailable_names = app
+            .filtered_palette_commands("pr")
+            .into_iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(!unavailable_names.contains(&"new-agent-from-pr"));
+
+        app.gh_status = crate::model::GhStatus::Available;
+        let available_names = app
+            .filtered_palette_commands("pr")
+            .into_iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(available_names.contains(&"new-agent-from-pr"));
+
+        app.github_integration_enabled = false;
+        let disabled_names = app
+            .filtered_palette_commands("pr")
+            .into_iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(!disabled_names.contains(&"new-agent-from-pr"));
+    }
+
+    #[test]
+    fn resolved_pull_request_prefills_name_prompt_with_head_branch() {
+        let mut app = test_app(default_bindings());
+        let project = app.projects[0].clone();
+
+        app.worker_tx
+            .send(WorkerEvent::PullRequestResolved {
+                result: Ok(ResolvedPullRequest {
+                    project,
+                    host: "github.com".to_string(),
+                    owner_repo: "octocat/Hello-World".to_string(),
+                    number: 42,
+                    title: "Fix issue".to_string(),
+                    state: "OPEN".to_string(),
+                    head_ref_name: "feature/pr-42".to_string(),
+                }),
+            })
+            .expect("send PR resolution");
+        app.drain_events();
+
+        match &app.prompt {
+            PromptState::NameNewAgent { input, request, .. } => {
+                assert_eq!(input.text, "feature/pr-42");
+                match request {
+                    CreateAgentRequest::PullRequest {
+                        number,
+                        head_branch,
+                        custom_name,
+                        ..
+                    } => {
+                        assert_eq!(*number, 42);
+                        assert_eq!(head_branch, "feature/pr-42");
+                        assert_eq!(custom_name.as_deref(), Some("feature/pr-42"));
+                    }
+                    other => panic!("expected PullRequest request, got {other:?}"),
+                }
+            }
+            other => panic!("expected name-new-agent prompt, got {other:?}"),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -525,6 +525,24 @@ pub(crate) enum NameNewAgentFocus {
     Checkbox,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PullRequestLookup {
+    pub(crate) host: String,
+    pub(crate) owner_repo: String,
+    pub(crate) number: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedPullRequest {
+    pub(crate) project: Project,
+    pub(crate) host: String,
+    pub(crate) owner_repo: String,
+    pub(crate) number: u64,
+    pub(crate) title: String,
+    pub(crate) state: String,
+    pub(crate) head_ref_name: String,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum PromptState {
     None,
@@ -584,6 +602,10 @@ pub(crate) enum PromptState {
         session_id: String,
         input: TextInput,
         rename_branch: bool,
+    },
+    PullRequestInput {
+        project: Project,
+        input: TextInput,
     },
     NameNewAgent {
         request: CreateAgentRequest,
@@ -1052,6 +1074,17 @@ pub(crate) enum CreateAgentRequest {
         custom_name: Option<String>,
         use_existing_branch: bool,
     },
+    PullRequest {
+        project: Project,
+        host: String,
+        owner_repo: String,
+        number: u64,
+        title: String,
+        state: String,
+        head_branch: String,
+        custom_name: Option<String>,
+        use_existing_branch: bool,
+    },
     ForkSession {
         project: Project,
         source_session: Box<AgentSession>,
@@ -1095,6 +1128,9 @@ pub(crate) enum WorkerEvent {
     ResourceStatsReady(Vec<ResourceStats>),
     GhStatusChecked(crate::model::GhStatus),
     PrStatusReady(Vec<(String, Option<crate::model::PrInfo>)>),
+    PullRequestResolved {
+        result: Result<ResolvedPullRequest, String>,
+    },
     RefsChanged(String),
     /// Background `git worktree remove` for a session-initiated delete has
     /// finished. On `Ok`, the boolean indicates whether the branch was
@@ -1494,6 +1530,7 @@ impl App {
                     number: pr.pr_number,
                     state,
                     title: pr.title,
+                    host: pr.host,
                     owner_repo: pr.owner_repo,
                 },
             );
@@ -1683,10 +1720,29 @@ impl App {
         });
     }
 
+    pub(crate) fn github_pr_agent_command_available(&self) -> bool {
+        self.github_integration_enabled
+            && matches!(self.gh_status, crate::model::GhStatus::Available)
+    }
+
+    pub(crate) fn filtered_palette_commands(
+        &self,
+        input: &str,
+    ) -> Vec<&crate::keybindings::RuntimeBinding> {
+        self.bindings
+            .filtered_palette(input)
+            .into_iter()
+            .filter(|binding| {
+                binding.action != Action::NewAgentFromPr || self.github_pr_agent_command_available()
+            })
+            .collect()
+    }
+
     pub(crate) fn execute_command(&mut self, command: String) -> Result<()> {
         let command = command.trim();
         match command {
             "new-agent" => self.create_agent_for_selected_project(),
+            "new-agent-from-pr" => self.open_new_agent_from_pr_prompt(),
             "fork-agent" => self.fork_selected_session(),
             "change-agent-provider" => self.open_change_agent_provider_prompt(),
             "change-default-provider" => self.open_change_default_provider_prompt(),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2253,7 +2253,7 @@ impl App {
                 self.render_dim_overlay(frame);
                 let popup = centered_rect(72, 40, frame.area());
                 self.clear_overlay_area(frame, popup);
-                let commands = self.bindings.filtered_palette(&input.text);
+                let commands = self.filtered_palette_commands(&input.text);
                 let items = if commands.is_empty() {
                     vec![ListItem::new("No matching commands.")]
                 } else {
@@ -5013,6 +5013,84 @@ impl App {
                         rect: checkbox_rect,
                     }),
                 };
+            }
+            PromptState::PullRequestInput { project, input } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect_exact(64, 8, frame.area());
+                self.clear_overlay_area(frame, area);
+
+                let outer = self.themed_overlay_block("Create Agent From PR");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [label_area, input_area, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(2),
+                        Constraint::Length(3),
+                        Constraint::Min(1),
+                    ])
+                    .areas(inner);
+
+                Paragraph::new(vec![
+                    Line::from(Span::styled(
+                        format!(" Project: {}", project.name),
+                        Style::default().fg(self.theme.input_label_fg),
+                    )),
+                    Line::from(Span::styled(
+                        " Paste a GitHub PR URL or enter a PR number:",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )),
+                ])
+                .render(label_area, frame.buffer_mut());
+
+                let display = if input.cursor < input.text.len() {
+                    let (before, after) = input.text.split_at(input.cursor);
+                    let (cursor_char, rest) = after.split_at(1);
+                    Line::from(vec![
+                        Span::raw(format!(" {before}")),
+                        Span::styled(
+                            cursor_char.to_string(),
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                        Span::raw(rest.to_string()),
+                    ])
+                } else {
+                    Line::from(vec![
+                        Span::raw(format!(" {}", &input.text)),
+                        Span::styled(
+                            " ",
+                            Style::default()
+                                .fg(self.theme.input_cursor_fg)
+                                .bg(self.theme.input_cursor_bg),
+                        ),
+                    ])
+                };
+                let input_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                Paragraph::new(display)
+                    .block(input_block)
+                    .render(input_area, frame.buffer_mut());
+
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let mut hints = vec![Span::raw(" ")];
+                hints.extend(self.theme.key_badge_default(&confirm_key));
+                hints.push(Span::styled(
+                    " resolve  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                hints.extend(self.theme.key_badge_default(&close_key));
+                hints.push(Span::styled(
+                    " cancel",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                self.overlay_layout.active = OverlayMouseLayout::None;
             }
             PromptState::None => {}
         }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -201,11 +201,65 @@ impl App {
         })
     }
 
+    pub(crate) fn open_new_agent_from_pr_prompt(&mut self) -> Result<()> {
+        if !self.github_pr_agent_command_available() {
+            self.set_error(
+                "GitHub PR agent creation requires GitHub integration and an authenticated gh CLI.",
+            );
+            return Ok(());
+        }
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first to create an agent from a PR.");
+            return Ok(());
+        };
+        if project.path_missing {
+            self.set_warning(format!(
+                "Cannot create an agent from a PR: path not found for \"{}\"",
+                project.name
+            ));
+            return Ok(());
+        }
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::PullRequestInput {
+            project,
+            input: TextInput::new(),
+        };
+        self.set_info("Paste a GitHub PR URL or enter a PR number for the selected project.");
+        Ok(())
+    }
+
+    pub(crate) fn dispatch_pull_request_lookup(
+        &mut self,
+        project: Project,
+        raw_input: String,
+    ) -> Result<()> {
+        self.prompt = PromptState::None;
+        self.set_busy(format!("Resolving PR for project \"{}\"...", project.name));
+        let worker_tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            super::workers::run_pull_request_lookup_job(project, raw_input, worker_tx);
+        });
+        Ok(())
+    }
+
     pub(crate) fn open_name_new_agent_prompt(&mut self, request: CreateAgentRequest) -> Result<()> {
-        let randomize_name = self.config.defaults.enable_randomized_pet_name_by_default;
+        let explicit_name = match &request {
+            CreateAgentRequest::NewProject { custom_name, .. }
+            | CreateAgentRequest::ForkSession { custom_name, .. } => custom_name.clone(),
+            CreateAgentRequest::PullRequest {
+                custom_name,
+                head_branch,
+                ..
+            } => custom_name.clone().or_else(|| Some(head_branch.clone())),
+        };
+        let randomize_name =
+            explicit_name.is_none() && self.config.defaults.enable_randomized_pet_name_by_default;
         let mut input = TextInput::new().with_char_map(crate::git::agent_name_char_map);
         let mut randomized_name = None;
-        if randomize_name {
+        if let Some(name) = explicit_name {
+            input.set_text(name);
+        } else if randomize_name {
             let name = crate::git::docker_style_name();
             input.set_text(name.clone());
             randomized_name = Some(name);
@@ -2023,6 +2077,68 @@ impl App {
     }
 }
 
+pub(crate) fn parse_pull_request_lookup(
+    raw_input: &str,
+    selected_host: &str,
+    selected_owner_repo: &str,
+) -> Result<PullRequestLookup, String> {
+    let input = raw_input.trim();
+    if input.is_empty() {
+        return Err("Enter a GitHub PR URL or PR number.".to_string());
+    }
+
+    if let Ok(number) = input.strip_prefix('#').unwrap_or(input).parse::<u64>() {
+        return Ok(PullRequestLookup {
+            host: selected_host.to_string(),
+            owner_repo: selected_owner_repo.to_string(),
+            number,
+        });
+    }
+
+    let Some((host, rest)) = parse_github_pull_url_parts(input) else {
+        return Err("Enter a PR number, #number, or a GitHub PR URL.".to_string());
+    };
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() < 4 || parts[2] != "pull" {
+        return Err(
+            "GitHub PR URLs must look like https://github.com/owner/repo/pull/123.".to_string(),
+        );
+    }
+    let owner_repo = format!("{}/{}", parts[0], parts[1]);
+    if !host.eq_ignore_ascii_case(selected_host)
+        || !owner_repo.eq_ignore_ascii_case(selected_owner_repo)
+    {
+        return Err(format!(
+            "PR belongs to {host}/{owner_repo}, but the selected project uses {selected_host}/{selected_owner_repo}."
+        ));
+    }
+    let number = parts[3]
+        .parse::<u64>()
+        .map_err(|_| "GitHub PR URL does not contain a valid PR number.".to_string())?;
+    Ok(PullRequestLookup {
+        host,
+        owner_repo,
+        number,
+    })
+}
+
+fn parse_github_pull_url_parts(input: &str) -> Option<(String, String)> {
+    let without_scheme = input
+        .strip_prefix("https://")
+        .or_else(|| input.strip_prefix("http://"))?;
+    let (host, rest) = without_scheme.split_once('/')?;
+    if host != "github.com" && !host.starts_with("github.") {
+        return None;
+    }
+    let rest = rest
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(rest)
+        .trim_end_matches('/')
+        .to_string();
+    Some((host.to_string(), rest))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2795,5 +2911,58 @@ mod tests {
             msg.contains("not a git repository"),
             "error should include the git error, got: {msg}",
         );
+    }
+
+    #[test]
+    fn parse_pull_request_lookup_accepts_number_and_hash_number() {
+        let plain = super::parse_pull_request_lookup("123", "github.com", "octocat/Hello-World")
+            .expect("plain number");
+        assert_eq!(plain.host, "github.com");
+        assert_eq!(plain.owner_repo, "octocat/Hello-World");
+        assert_eq!(plain.number, 123);
+
+        let hashed =
+            super::parse_pull_request_lookup("#456", "github.example.com", "octocat/Hello-World")
+                .expect("hash number");
+        assert_eq!(hashed.host, "github.example.com");
+        assert_eq!(hashed.owner_repo, "octocat/Hello-World");
+        assert_eq!(hashed.number, 456);
+    }
+
+    #[test]
+    fn parse_pull_request_lookup_accepts_matching_github_url() {
+        let lookup = super::parse_pull_request_lookup(
+            "https://github.com/octocat/Hello-World/pull/789?foo=bar",
+            "github.com",
+            "octocat/Hello-World",
+        )
+        .expect("matching URL");
+        assert_eq!(lookup.host, "github.com");
+        assert_eq!(lookup.owner_repo, "octocat/Hello-World");
+        assert_eq!(lookup.number, 789);
+    }
+
+    #[test]
+    fn parse_pull_request_lookup_accepts_matching_enterprise_url() {
+        let lookup = super::parse_pull_request_lookup(
+            "https://github.example.com/octocat/Hello-World/pull/789",
+            "github.example.com",
+            "octocat/Hello-World",
+        )
+        .expect("matching enterprise URL");
+        assert_eq!(lookup.host, "github.example.com");
+        assert_eq!(lookup.owner_repo, "octocat/Hello-World");
+        assert_eq!(lookup.number, 789);
+    }
+
+    #[test]
+    fn parse_pull_request_lookup_rejects_mismatched_github_url() {
+        let err = super::parse_pull_request_lookup(
+            "https://github.com/other/repo/pull/12",
+            "github.com",
+            "octocat/Hello-World",
+        )
+        .expect_err("mismatched repo");
+        assert!(err.contains("selected project uses github.com/octocat/Hello-World"));
     }
 }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -219,6 +219,7 @@ impl App {
                                 let _ = self.session_store.upsert_pr(
                                     &session_id,
                                     pr.number,
+                                    &pr.host,
                                     &pr.owner_repo,
                                     state_str,
                                     &pr.title,
@@ -239,6 +240,32 @@ impl App {
                         self.rebuild_left_items();
                     }
                 }
+                WorkerEvent::PullRequestResolved { result } => match result {
+                    Ok(pr) => {
+                        let request = CreateAgentRequest::PullRequest {
+                            project: pr.project.clone(),
+                            host: pr.host.clone(),
+                            owner_repo: pr.owner_repo.clone(),
+                            number: pr.number,
+                            title: pr.title.clone(),
+                            state: pr.state.clone(),
+                            head_branch: pr.head_ref_name.clone(),
+                            custom_name: Some(pr.head_ref_name.clone()),
+                            use_existing_branch: false,
+                        };
+                        if let Err(err) = self.open_name_new_agent_prompt(request) {
+                            self.set_error(format!("{err:#}"));
+                        } else {
+                            self.set_info(format!(
+                                "Resolved PR #{}: {}. Confirm or edit the branch name.",
+                                pr.number, pr.title
+                            ));
+                        }
+                    }
+                    Err(message) => {
+                        self.set_error(message);
+                    }
+                },
                 WorkerEvent::RefsChanged(session_id) => {
                     logger::debug(&format!(
                         "[gh-integration] refs watcher: triggering PR check for session {}",
@@ -1158,6 +1185,60 @@ pub(crate) fn run_checkout_project_default_branch_inspection_job(
     let _ = worker_tx.send(WorkerEvent::CheckoutProjectDefaultBranchInspected { project, result });
 }
 
+pub(crate) fn run_pull_request_lookup_job(
+    project: Project,
+    raw_input: String,
+    worker_tx: Sender<WorkerEvent>,
+) {
+    let lookup = match git::remote_github_repo(Path::new(&project.path)) {
+        Some(remote) => {
+            super::sessions::parse_pull_request_lookup(&raw_input, &remote.host, &remote.owner_repo)
+        }
+        None => Err(format!(
+            "Project \"{}\" does not have a GitHub origin remote.",
+            project.name
+        )),
+    };
+    let lookup = match lookup {
+        Ok(lookup) => lookup,
+        Err(message) => {
+            let _ = worker_tx.send(WorkerEvent::PullRequestResolved {
+                result: Err(message),
+            });
+            return;
+        }
+    };
+
+    let repo = gh_repo_arg(&lookup.host, &lookup.owner_repo);
+    let output = std::process::Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &lookup.number.to_string(),
+            "--repo",
+            &repo,
+            "--json",
+            "number,title,state,headRefName",
+        ])
+        .output();
+    let result = match output {
+        Ok(output) if output.status.success() => parse_resolved_pull_request_json(
+            &String::from_utf8_lossy(&output.stdout),
+            project,
+            &lookup.host,
+            &lookup.owner_repo,
+        ),
+        Ok(output) => Err(format!(
+            "Failed to resolve PR #{} from {}: {}",
+            lookup.number,
+            lookup.owner_repo,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )),
+        Err(err) => Err(format!("Failed to run gh pr view: {err}")),
+    };
+    let _ = worker_tx.send(WorkerEvent::PullRequestResolved { result });
+}
+
 pub(crate) fn run_create_agent_job(
     request: CreateAgentRequest,
     paths: DuxPaths,
@@ -1260,6 +1341,88 @@ pub(crate) fn run_create_agent_job(
                     project.name
                 )
             };
+            (
+                project.clone(),
+                project.default_provider.clone(),
+                project.current_branch.clone(),
+                status_message,
+                branch_name,
+                worktree_path,
+                true,
+            )
+        }
+        CreateAgentRequest::PullRequest {
+            project,
+            host,
+            owner_repo,
+            number,
+            title,
+            state,
+            head_branch,
+            custom_name,
+            use_existing_branch,
+        } => {
+            let repo_path = PathBuf::from(&project.path);
+            let resolved_name = custom_name.unwrap_or_else(|| head_branch.clone());
+            let attach_existing =
+                use_existing_branch || git::branch_exists(&repo_path, &resolved_name).is_some();
+
+            if attach_existing {
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                    "Attaching to existing branch \"{}\" for PR #{} in project \"{}\"...",
+                    resolved_name, number, project.name
+                )));
+            } else {
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                    "Fetching PR #{} from {} into branch \"{}\"...",
+                    number, owner_repo, resolved_name
+                )));
+                if let Err(err) = git::fetch_pull_request_head(&repo_path, number, &resolved_name) {
+                    logger::error(&format!(
+                        "PR worktree fetch failed for {} #{}: {err}",
+                        owner_repo, number
+                    ));
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to fetch PR #{} from {}: {err}",
+                        number, owner_repo
+                    )));
+                    return;
+                }
+            }
+
+            let (branch_name, worktree_path) = match git::create_worktree_existing_branch(
+                &repo_path,
+                &paths.worktrees_root,
+                &project.name,
+                &resolved_name,
+            ) {
+                Ok(result) => result,
+                Err(err) => {
+                    logger::error(&format!(
+                        "PR worktree creation failed for {} #{}: {err}",
+                        owner_repo, number
+                    ));
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to create a worktree for PR #{} in project \"{}\": {err}",
+                        number, project.name
+                    )));
+                    return;
+                }
+            };
+            let status_message = format!(
+                "Created {} agent \"{}\" from PR #{} ({}) in project \"{}\".",
+                project.default_provider.as_str(),
+                branch_name,
+                number,
+                title,
+                project.name
+            );
+            logger::info(&format!(
+                "created PR worktree from {} #{} ({state}) {}",
+                owner_repo,
+                number,
+                pull_request_url(&host, &owner_repo, number)
+            ));
             (
                 project.clone(),
                 project.default_provider.clone(),
@@ -1505,8 +1668,14 @@ fn run_pr_sync(
 /// no reason to check for newer PRs. This reduces API calls from O(sessions)
 /// to O(active_sessions) for repos with many completed agents.
 fn check_pr_for_entry(entry: &PrSyncEntry) -> Option<crate::model::PrInfo> {
-    let owner_repo = git::remote_owner_repo(Path::new(&entry.worktree_path))
-        .or_else(|| entry.known_pr.as_ref().map(|pr| pr.owner_repo.clone()))?;
+    let remote = git::remote_github_repo(Path::new(&entry.worktree_path));
+    let (host, owner_repo) = if let Some(remote) = remote {
+        (remote.host, remote.owner_repo)
+    } else if let Some(known) = &entry.known_pr {
+        (known.host.clone(), known.owner_repo.clone())
+    } else {
+        return None;
+    };
 
     if let Some(ref known) = entry.known_pr {
         let is_terminal = known.state == "MERGED" || known.state == "CLOSED";
@@ -1522,7 +1691,7 @@ fn check_pr_for_entry(entry: &PrSyncEntry) -> Option<crate::model::PrInfo> {
             // Terminal PR but agent is still running — it might push new commits
             // and open a follow-up PR, so we still check for newer PRs.
             if let Some(newer) =
-                discover_pr_by_branch(&entry.branch_name, &owner_repo, &entry.session_id)
+                discover_pr_by_branch(&entry.branch_name, &host, &owner_repo, &entry.session_id)
                 && newer.number > known.pr_number
             {
                 return Some(newer);
@@ -1531,10 +1700,15 @@ fn check_pr_for_entry(entry: &PrSyncEntry) -> Option<crate::model::PrInfo> {
         }
 
         // Open PR: refresh its current state via `gh pr view`.
-        if let Some(pr) = view_pr_by_number(known.pr_number, &known.owner_repo, &entry.session_id) {
+        if let Some(pr) = view_pr_by_number(
+            known.pr_number,
+            &known.host,
+            &known.owner_repo,
+            &entry.session_id,
+        ) {
             // Also check if a newer PR was opened.
             if let Some(newer) =
-                discover_pr_by_branch(&entry.branch_name, &owner_repo, &entry.session_id)
+                discover_pr_by_branch(&entry.branch_name, &host, &owner_repo, &entry.session_id)
                 && newer.number > pr.number
             {
                 return Some(newer);
@@ -1544,7 +1718,7 @@ fn check_pr_for_entry(entry: &PrSyncEntry) -> Option<crate::model::PrInfo> {
     }
 
     // No known PR — discover by branch name.
-    discover_pr_by_branch(&entry.branch_name, &owner_repo, &entry.session_id)
+    discover_pr_by_branch(&entry.branch_name, &host, &owner_repo, &entry.session_id)
 }
 
 /// Reconstruct a PrInfo from stored data without a network call.
@@ -1561,6 +1735,7 @@ fn reconstruct_from_stored(stored: &crate::storage::StoredPr) -> Option<crate::m
         number: stored.pr_number,
         state,
         title: stored.title.clone(),
+        host: stored.host.clone(),
         owner_repo: stored.owner_repo.clone(),
     })
 }
@@ -1568,16 +1743,18 @@ fn reconstruct_from_stored(stored: &crate::storage::StoredPr) -> Option<crate::m
 /// Check a known PR by number using `gh pr view`.
 fn view_pr_by_number(
     number: u64,
+    host: &str,
     owner_repo: &str,
     session_id: &str,
 ) -> Option<crate::model::PrInfo> {
+    let repo = gh_repo_arg(host, owner_repo);
     let output = std::process::Command::new("gh")
         .args([
             "pr",
             "view",
             &number.to_string(),
             "--repo",
-            owner_repo,
+            &repo,
             "--json",
             "number,state,title",
         ])
@@ -1593,15 +1770,17 @@ fn view_pr_by_number(
     }
 
     let text = String::from_utf8_lossy(&output.stdout);
-    parse_pr_json_object(text.trim(), owner_repo)
+    parse_pr_json_object(text.trim(), host, owner_repo)
 }
 
 /// Discover a PR by branch name using `gh pr list --state all`.
 fn discover_pr_by_branch(
     branch: &str,
+    host: &str,
     owner_repo: &str,
     session_id: &str,
 ) -> Option<crate::model::PrInfo> {
+    let repo = gh_repo_arg(host, owner_repo);
     let output = std::process::Command::new("gh")
         .args([
             "pr",
@@ -1609,7 +1788,7 @@ fn discover_pr_by_branch(
             "--head",
             branch,
             "--repo",
-            owner_repo,
+            &repo,
             "--state",
             "all",
             "--json",
@@ -1631,17 +1810,21 @@ fn discover_pr_by_branch(
     let text = String::from_utf8_lossy(&output.stdout);
     let arr: Vec<serde_json::Value> = serde_json::from_str(text.trim()).ok()?;
     let obj = arr.first()?;
-    parse_pr_json_value(obj, owner_repo)
+    parse_pr_json_value(obj, host, owner_repo)
 }
 
 /// Parse a single PR JSON object (from `gh pr view` output).
-fn parse_pr_json_object(json: &str, owner_repo: &str) -> Option<crate::model::PrInfo> {
+fn parse_pr_json_object(json: &str, host: &str, owner_repo: &str) -> Option<crate::model::PrInfo> {
     let obj: serde_json::Value = serde_json::from_str(json).ok()?;
-    parse_pr_json_value(&obj, owner_repo)
+    parse_pr_json_value(&obj, host, owner_repo)
 }
 
 /// Extract PrInfo from a serde_json::Value.
-fn parse_pr_json_value(obj: &serde_json::Value, owner_repo: &str) -> Option<crate::model::PrInfo> {
+fn parse_pr_json_value(
+    obj: &serde_json::Value,
+    host: &str,
+    owner_repo: &str,
+) -> Option<crate::model::PrInfo> {
     use crate::model::{PrInfo, PrState};
 
     let number = obj.get("number")?.as_u64()?;
@@ -1662,6 +1845,95 @@ fn parse_pr_json_value(obj: &serde_json::Value, owner_repo: &str) -> Option<crat
         number,
         state,
         title,
+        host: normalize_github_host(host).to_string(),
         owner_repo: owner_repo.to_string(),
     })
+}
+
+fn parse_resolved_pull_request_json(
+    json: &str,
+    project: Project,
+    host: &str,
+    owner_repo: &str,
+) -> Result<ResolvedPullRequest, String> {
+    let obj: serde_json::Value = serde_json::from_str(json.trim())
+        .map_err(|err| format!("gh returned invalid PR JSON: {err}"))?;
+    let number = obj
+        .get("number")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| "gh PR response did not include a PR number.".to_string())?;
+    let title = obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let state = obj
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let head_ref_name = obj
+        .get("headRefName")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "gh PR response did not include a head branch.".to_string())?
+        .to_string();
+    Ok(ResolvedPullRequest {
+        project,
+        host: host.to_string(),
+        owner_repo: owner_repo.to_string(),
+        number,
+        title,
+        state,
+        head_ref_name,
+    })
+}
+
+fn pull_request_url(host: &str, owner_repo: &str, number: u64) -> String {
+    let host = normalize_github_host(host);
+    format!("https://{host}/{owner_repo}/pull/{number}")
+}
+
+fn gh_repo_arg(host: &str, owner_repo: &str) -> String {
+    let host = normalize_github_host(host);
+    if host == "github.com" {
+        owner_repo.to_string()
+    } else {
+        format!("{host}/{owner_repo}")
+    }
+}
+
+fn normalize_github_host(host: &str) -> &str {
+    if host.trim().is_empty() {
+        "github.com"
+    } else {
+        host
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gh_repo_arg_uses_owner_repo_for_github_dot_com() {
+        assert_eq!(gh_repo_arg("github.com", "owner/repo"), "owner/repo");
+        assert_eq!(gh_repo_arg("", "owner/repo"), "owner/repo");
+    }
+
+    #[test]
+    fn gh_repo_arg_includes_host_for_enterprise() {
+        assert_eq!(
+            gh_repo_arg("github.example.com", "owner/repo"),
+            "github.example.com/owner/repo"
+        );
+    }
+
+    #[test]
+    fn pull_request_url_defaults_empty_host_to_github_dot_com() {
+        assert_eq!(
+            pull_request_url("", "owner/repo", 12),
+            "https://github.com/owner/repo/pull/12"
+        );
+    }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -245,6 +245,21 @@ pub fn create_worktree(
     create_worktree_from_start_point(repo_path, worktrees_root, project_name, None, custom_name)
 }
 
+pub fn fetch_pull_request_head(repo_path: &Path, pr_number: u64, branch_name: &str) -> Result<()> {
+    let repo = repo_path.to_string_lossy();
+    let refspec = format!("pull/{pr_number}/head:refs/heads/{branch_name}");
+    let output = Command::new("git")
+        .args(["-C", repo.as_ref(), "fetch", "origin", &refspec])
+        .output()?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git fetch failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
 pub fn create_worktree_from_start_point(
     repo_path: &Path,
     worktrees_root: &Path,
@@ -852,9 +867,15 @@ pub fn agent_name_char_map(text: &str, cursor: usize, ch: char) -> Option<char> 
     Some(ch)
 }
 
-/// Returns `"owner/repo"` parsed from the `origin` remote URL, or `None` if
-/// the remote doesn't point to GitHub or the command fails.
-pub fn remote_owner_repo(worktree_path: &Path) -> Option<String> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GitHubRemote {
+    pub host: String,
+    pub owner_repo: String,
+}
+
+/// Returns the GitHub host and `"owner/repo"` parsed from the `origin` remote
+/// URL, or `None` if the remote doesn't point to GitHub or the command fails.
+pub fn remote_github_repo(worktree_path: &Path) -> Option<GitHubRemote> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -869,7 +890,7 @@ pub fn remote_owner_repo(worktree_path: &Path) -> Option<String> {
         return None;
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    parse_github_owner_repo(&url)
+    parse_github_remote(&url)
 }
 
 /// Extracts `"owner/repo"` from a GitHub remote URL.
@@ -877,26 +898,49 @@ pub fn remote_owner_repo(worktree_path: &Path) -> Option<String> {
 /// Supports SSH (`git@github.com:owner/repo.git`), HTTPS
 /// (`https://github.com/owner/repo.git`), and bare
 /// (`github.com/owner/repo`) forms.
+#[cfg(test)]
 fn parse_github_owner_repo(url: &str) -> Option<String> {
-    // SSH: git@github.com:owner/repo.git
-    if let Some(rest) = url.strip_prefix("git@github.com:") {
+    parse_github_remote(url).map(|remote| remote.owner_repo)
+}
+
+fn parse_github_remote(url: &str) -> Option<GitHubRemote> {
+    // SSH: git@github.com:owner/repo.git or git@github.example.com:owner/repo.git
+    if let Some(rest) = url.strip_prefix("git@") {
+        let (host, rest) = rest.split_once(':')?;
+        if !is_github_host(host) {
+            return None;
+        }
         let rest = rest.strip_suffix(".git").unwrap_or(rest);
         if rest.contains('/') {
-            return Some(rest.to_string());
+            return Some(GitHubRemote {
+                host: host.to_string(),
+                owner_repo: rest.to_string(),
+            });
         }
     }
+
     // HTTPS / plain: https://github.com/owner/repo.git or github.com/owner/repo
-    let needle = "github.com/";
-    if let Some(idx) = url.find(needle) {
-        let rest = &url[idx + needle.len()..];
-        let rest = rest.strip_suffix(".git").unwrap_or(rest);
-        // Expect exactly "owner/repo"
+    let without_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+    let parts: Vec<&str> = without_scheme.splitn(2, '/').collect();
+    if parts.len() == 2 && is_github_host(parts[0]) {
+        let host = parts[0];
+        let rest = parts[1].strip_suffix(".git").unwrap_or(parts[1]);
         let parts: Vec<&str> = rest.splitn(3, '/').collect();
         if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
-            return Some(format!("{}/{}", parts[0], parts[1]));
+            return Some(GitHubRemote {
+                host: host.to_string(),
+                owner_repo: format!("{}/{}", parts[0], parts[1]),
+            });
         }
     }
     None
+}
+
+fn is_github_host(host: &str) -> bool {
+    host == "github.com" || host.starts_with("github.")
 }
 
 fn sync_directory_contents(source: &Path, destination: &Path) -> Result<()> {
@@ -1737,6 +1781,28 @@ mod tests {
         assert_eq!(
             parse_github_owner_repo("https://github.com/octocat/Hello-World/tree/main"),
             Some("octocat/Hello-World".to_string()),
+        );
+    }
+
+    #[test]
+    fn parse_github_enterprise_https_url_preserves_host() {
+        assert_eq!(
+            parse_github_remote("https://github.example.com/octocat/Hello-World.git"),
+            Some(GitHubRemote {
+                host: "github.example.com".to_string(),
+                owner_repo: "octocat/Hello-World".to_string(),
+            }),
+        );
+    }
+
+    #[test]
+    fn parse_github_enterprise_ssh_url_preserves_host() {
+        assert_eq!(
+            parse_github_remote("git@github.example.com:octocat/Hello-World.git"),
+            Some(GitHubRemote {
+                host: "github.example.com".to_string(),
+                owner_repo: "octocat/Hello-World".to_string(),
+            }),
         );
     }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -10,6 +10,7 @@ pub enum Action {
     // Projects pane
     ToggleProject,
     NewAgent,
+    NewAgentFromPr,
     ForkAgent,
     ChangeAgentProvider,
     ChangeDefaultProvider,
@@ -188,6 +189,7 @@ impl Action {
             Action::MoveUp => "move_up",
             Action::ToggleProject => "toggle_project",
             Action::NewAgent => "new_agent",
+            Action::NewAgentFromPr => "new_agent_from_pr",
             Action::ForkAgent => "fork_agent",
             Action::ChangeAgentProvider => "change_agent_provider",
             Action::ChangeDefaultProvider => "change_default_provider",
@@ -272,6 +274,7 @@ impl Action {
             Action::MoveUp => "Navigate up through projects, sessions, files, and lists.",
             Action::ToggleProject => "Collapse or expand the selected project.",
             Action::NewAgent => "Create a new agent session (worktree).",
+            Action::NewAgentFromPr => "Create a new agent session from a GitHub pull request.",
             Action::ForkAgent => "Fork the selected agent into a fresh worktree and session.",
             Action::ChangeAgentProvider => {
                 "Swap the selected agent worktree to a different provider."
@@ -389,6 +392,7 @@ impl Action {
             | Action::ReconnectAgent
             | Action::DeleteSession
             | Action::DeleteTerminal => Some("Projects pane"),
+            Action::NewAgentFromPr => None,
             Action::ExitInteractive
             | Action::OpenMacroBar
             | Action::ToggleFullscreen
@@ -550,6 +554,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "new-agent",
             description: "Create a new agent for the selected project",
+        }),
+    },
+    BindingDef {
+        action: Action::NewAgentFromPr,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "new-agent-from-pr",
+            description: "Create a new agent from a GitHub pull request",
         }),
     },
     BindingDef {
@@ -2207,6 +2222,17 @@ mod tests {
             .filter_map(|binding| binding.palette_name)
             .collect::<Vec<_>>();
         assert!(names.contains(&"fork-agent"));
+    }
+
+    #[test]
+    fn filtered_palette_includes_new_agent_from_pr_command() {
+        let bindings = default_bindings();
+        let results = bindings.filtered_palette("pr");
+        let names = results
+            .iter()
+            .filter_map(|binding| binding.palette_name)
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"new-agent-from-pr"));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,6 +28,7 @@ pub struct PrInfo {
     pub number: u64,
     pub state: PrState,
     pub title: String,
+    pub host: String,
     pub owner_repo: String,
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,6 +9,7 @@ use crate::model::{AgentSession, SessionStatus};
 pub struct StoredPr {
     pub session_id: String,
     pub pr_number: u64,
+    pub host: String,
     pub owner_repo: String,
     pub state: String,
     pub title: String,
@@ -58,12 +59,19 @@ impl SessionStore {
             create table if not exists session_prs (
                 session_id text not null,
                 pr_number integer not null,
+                host text not null default 'github.com',
                 owner_repo text not null,
                 state text not null default 'OPEN',
                 primary key (session_id, pr_number),
                 foreign key (session_id) references agent_sessions(id) on delete cascade
             );
             "#,
+        )?;
+        ensure_column(
+            &self.conn,
+            "session_prs",
+            "host",
+            "text not null default 'github.com'",
         )?;
         ensure_column(
             &self.conn,
@@ -85,19 +93,22 @@ impl SessionStore {
         &self,
         session_id: &str,
         pr_number: u64,
+        host: &str,
         owner_repo: &str,
         state: &str,
         title: &str,
     ) -> Result<()> {
         self.conn.execute(
             r#"
-            insert into session_prs (session_id, pr_number, owner_repo, state, title)
-            values (?1, ?2, ?3, ?4, ?5)
+            insert into session_prs (session_id, pr_number, host, owner_repo, state, title)
+            values (?1, ?2, ?3, ?4, ?5, ?6)
             on conflict(session_id, pr_number) do update set
+                host=excluded.host,
+                owner_repo=excluded.owner_repo,
                 state=excluded.state,
                 title=excluded.title
             "#,
-            params![session_id, pr_number as i64, owner_repo, state, title],
+            params![session_id, pr_number as i64, host, owner_repo, state, title],
         )?;
         Ok(())
     }
@@ -106,7 +117,7 @@ impl SessionStore {
     pub fn load_prs(&self, session_id: &str) -> Result<Vec<StoredPr>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select pr_number, owner_repo, state, title
+            select pr_number, host, owner_repo, state, title
             from session_prs
             where session_id = ?1
             order by pr_number desc
@@ -117,9 +128,10 @@ impl SessionStore {
             Ok(StoredPr {
                 session_id: sid.clone(),
                 pr_number: row.get::<_, i64>(0)? as u64,
-                owner_repo: row.get(1)?,
-                state: row.get(2)?,
-                title: row.get(3)?,
+                host: row.get(1)?,
+                owner_repo: row.get(2)?,
+                state: row.get(3)?,
+                title: row.get(4)?,
             })
         })?;
         let mut prs = Vec::new();
@@ -133,7 +145,7 @@ impl SessionStore {
     pub fn load_all_latest_prs(&self) -> Result<Vec<StoredPr>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select session_id, pr_number, owner_repo, state, title
+            select session_id, pr_number, host, owner_repo, state, title
             from session_prs
             where (session_id, pr_number) in (
                 select session_id, max(pr_number) from session_prs group by session_id
@@ -144,9 +156,10 @@ impl SessionStore {
             Ok(StoredPr {
                 session_id: row.get(0)?,
                 pr_number: row.get::<_, i64>(1)? as u64,
-                owner_repo: row.get(2)?,
-                state: row.get(3)?,
-                title: row.get(4)?,
+                host: row.get(2)?,
+                owner_repo: row.get(3)?,
+                state: row.get(4)?,
+                title: row.get(5)?,
             })
         })?;
         let mut result = Vec::new();
@@ -352,6 +365,7 @@ mod pr_tests {
         StoredPr {
             session_id: sid.to_string(),
             pr_number: num,
+            host: "github.com".to_string(),
             owner_repo: repo.to_string(),
             state: state.to_string(),
             title: title.to_string(),
@@ -366,13 +380,13 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 10, "owner/repo", "OPEN", "First PR")
+            .upsert_pr("s1", 10, "github.com", "owner/repo", "OPEN", "First PR")
             .unwrap();
         store
-            .upsert_pr("s1", 20, "owner/repo", "OPEN", "Second PR")
+            .upsert_pr("s1", 20, "github.com", "owner/repo", "OPEN", "Second PR")
             .unwrap();
         store
-            .upsert_pr("s1", 15, "owner/repo", "MERGED", "Middle PR")
+            .upsert_pr("s1", 15, "github.com", "owner/repo", "MERGED", "Middle PR")
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
@@ -390,14 +404,22 @@ mod pr_tests {
         store.upsert_session(&s).unwrap();
 
         store
-            .upsert_pr("s1", 42, "owner/repo", "OPEN", "My PR")
+            .upsert_pr("s1", 42, "github.com", "owner/repo", "OPEN", "My PR")
             .unwrap();
         store
-            .upsert_pr("s1", 42, "owner/repo", "MERGED", "My PR (updated)")
+            .upsert_pr(
+                "s1",
+                42,
+                "github.example.com",
+                "owner/repo",
+                "MERGED",
+                "My PR (updated)",
+            )
             .unwrap();
 
         let prs = store.load_prs("s1").unwrap();
         assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].host, "github.example.com");
         assert_eq!(prs[0].state, "MERGED");
         assert_eq!(prs[0].title, "My PR (updated)");
     }
@@ -412,13 +434,13 @@ mod pr_tests {
         store.upsert_session(&s2).unwrap();
 
         store
-            .upsert_pr("s1", 10, "owner/repo", "CLOSED", "Old PR")
+            .upsert_pr("s1", 10, "github.com", "owner/repo", "CLOSED", "Old PR")
             .unwrap();
         store
-            .upsert_pr("s1", 20, "owner/repo", "MERGED", "Latest PR")
+            .upsert_pr("s1", 20, "github.com", "owner/repo", "MERGED", "Latest PR")
             .unwrap();
         store
-            .upsert_pr("s2", 5, "other/repo", "OPEN", "Other PR")
+            .upsert_pr("s2", 5, "github.com", "other/repo", "OPEN", "Other PR")
             .unwrap();
 
         let latest = store.load_all_latest_prs().unwrap();


### PR DESCRIPTION
Add a command-palette option for creating a new agent from a GitHub pull request when GitHub integration and an authenticated `gh` CLI are available.

The flow accepts a PR number or URL, resolves it with `gh pr view`, fetches the PR head into a local branch when needed, and opens the usual agent naming/worktree path from there.

PR metadata now keeps the GitHub host separately from `owner/repo`, so GitHub Enterprise remotes work for both this new flow and existing PR status checks. Older stored PR records continue to default to `github.com`.