### PR TITLE
Require fork names from the naming modal

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -6849,6 +6849,31 @@ not_a_real_action = ["x"]
     }
 
     #[test]
+    fn fork_agent_prefills_name_when_randomized_default_enabled() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.enable_randomized_pet_name_by_default = true;
+
+        app.fork_selected_session().unwrap();
+
+        match &app.prompt {
+            PromptState::NameNewAgent {
+                request,
+                input,
+                randomize_name,
+                randomized_name,
+                ..
+            } => {
+                assert!(matches!(request, CreateAgentRequest::ForkSession { .. }));
+                assert!(*randomize_name);
+                assert!(!input.text.is_empty());
+                assert_eq!(randomized_name.as_deref(), Some(input.text.as_str()));
+            }
+            other => panic!("expected name-new-agent prompt, got {other:?}"),
+        }
+        assert!(!app.create_agent_in_flight);
+    }
+
+    #[test]
     fn name_prompt_toggle_randomized_name_fills_and_clears_input() {
         let mut app = test_app(default_bindings());
         app.create_agent_for_selected_project().unwrap();

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -1440,6 +1440,12 @@ pub(crate) fn run_create_agent_job(
             source_label,
             custom_name,
         } => {
+            let Some(custom_name) = custom_name else {
+                let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(
+                    "Forking an agent requires choosing a name first.".to_string(),
+                ));
+                return;
+            };
             let source_worktree = PathBuf::from(&source_session.worktree_path);
             let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
                 "Creating a forked worktree from agent \"{source_label}\"...",
@@ -1463,7 +1469,7 @@ pub(crate) fn run_create_agent_job(
                 &paths.worktrees_root,
                 &project.name,
                 Some(&source_head),
-                custom_name.as_deref(),
+                Some(&custom_name),
             ) {
                 Ok(result) => result,
                 Err(err) => {
@@ -1921,8 +1927,71 @@ fn normalize_github_host(host: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+
+    use chrono::Utc;
+    use tempfile::tempdir;
+
     use super::*;
     use crate::model::PrState;
+
+    #[test]
+    fn fork_worker_requires_name_from_prompt() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = DuxPaths {
+            config_path: tmp.path().join("config.toml"),
+            sessions_db_path: tmp.path().join("sessions.sqlite3"),
+            worktrees_root: tmp.path().join("worktrees"),
+            lock_path: tmp.path().join("dux.lock"),
+            root: tmp.path().to_path_buf(),
+        };
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: tmp.path().to_string_lossy().to_string(),
+            default_provider: ProviderKind::from_str("codex"),
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
+            path_missing: false,
+        };
+        let now = Utc::now();
+        let source_session = AgentSession {
+            id: "session-1".to_string(),
+            project_id: project.id.clone(),
+            project_path: Some(project.path.clone()),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "agent-branch".to_string(),
+            worktree_path: tmp.path().join("source").to_string_lossy().to_string(),
+            title: None,
+            started_providers: Vec::new(),
+            status: SessionStatus::Active,
+            created_at: now,
+            updated_at: now,
+        };
+        let (worker_tx, worker_rx) = mpsc::channel();
+
+        run_create_agent_job(
+            CreateAgentRequest::ForkSession {
+                project,
+                source_session: Box::new(source_session),
+                source_label: "agent-branch".to_string(),
+                custom_name: None,
+            },
+            paths,
+            Config::default(),
+            worker_tx,
+            (80, 24),
+        );
+
+        match worker_rx.recv().expect("worker event") {
+            WorkerEvent::CreateAgentFailed(message) => {
+                assert_eq!(message, "Forking an agent requires choosing a name first.");
+            }
+            _ => panic!("expected missing-name failure"),
+        }
+        assert!(worker_rx.try_recv().is_err());
+    }
 
     #[test]
     fn gh_repo_arg_uses_owner_repo_for_github_dot_com() {


### PR DESCRIPTION
Forking an agent now depends on the same naming modal as creating a new agent. If the modal is configured to start with a randomized pet name, forks get that same prefilled option instead of bypassing the prompt.

The worker path now treats an unnamed fork request as an error, which prevents any fallback from silently generating a branch name outside the modal flow. Added focused coverage for both the modal behavior and the worker guard.