### PR TITLE
Improve typed project path adding

### DIFF
--- a/src/app/components/button.rs
+++ b/src/app/components/button.rs
@@ -98,6 +98,7 @@ pub(crate) enum ButtonPressedTarget {
     ConfirmUseExistingBranchUse,
     ConfigReloadFailedClose,
     ConfigReloadFailedApply,
+    AddProjectFailedOk,
 }
 
 /// In-flight state for a button the user is currently pressing. `target`

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1987,28 +1987,31 @@ impl App {
                                 tab_completions.clear();
                                 *tab_index = 0;
                             }
-                            KeyCode::Tab | KeyCode::BackTab => {
+                            KeyCode::Tab | KeyCode::BackTab | KeyCode::Up | KeyCode::Down => {
                                 if tab_completions.is_empty() {
                                     *tab_completions =
                                         Self::path_editor_completion_candidates(&path_input.text);
                                     *tab_index = 0;
-                                } else if is_reverse_tab(key) {
+                                } else if key.code == KeyCode::Up || is_reverse_tab(key) {
                                     if *tab_index == 0 {
                                         *tab_index = tab_completions.len().saturating_sub(1);
                                     } else {
                                         *tab_index -= 1;
                                     }
-                                } else {
+                                } else if key.code == KeyCode::Down {
                                     *tab_index = (*tab_index + 1) % tab_completions.len();
                                 }
-                                if let Some(completion) = tab_completions.get(*tab_index) {
+                                if key.code == KeyCode::Tab
+                                    && !is_reverse_tab(key)
+                                    && let Some(completion) = tab_completions.get(*tab_index)
+                                {
                                     path_input.set_text(completion.clone());
+                                    refresh_completions = true;
                                 }
                             }
                             KeyCode::Enter => {
                                 add_path = Some(path_input.text.trim().to_string());
                             }
-                            KeyCode::Up | KeyCode::Down => {}
                             _ => {
                                 if path_input.handle_key(key) {
                                     refresh_completions = true;
@@ -8590,13 +8593,15 @@ cyan = "#00ffff"
     }
 
     #[test]
-    fn project_browser_typed_tab_cycles_displayed_completions() {
+    fn project_browser_typed_arrows_select_and_tab_applies_completion() {
         let mut app = test_app(default_bindings());
         let root = PathBuf::from(&app.projects[0].path);
         let alpha = root.join("alpha");
         let alpine = root.join("alpine");
         std::fs::create_dir_all(&alpha).expect("alpha dir");
         std::fs::create_dir_all(&alpine).expect("alpine dir");
+        std::fs::create_dir_all(alpha.join("child")).expect("child dir");
+        let typed = root.join("al").to_string_lossy().to_string();
         app.prompt = PromptState::BrowseProjects {
             current_dir: root.clone(),
             entries: Vec::new(),
@@ -8605,41 +8610,65 @@ cyan = "#00ffff"
             filter: TextInput::new(),
             searching: false,
             editing_path: true,
-            path_input: TextInput::with_text(root.join("al").to_string_lossy().to_string()),
+            path_input: TextInput::with_text(typed.clone()),
             tab_completions: Vec::new(),
             tab_index: 0,
         };
 
-        app.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE))
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
             .unwrap();
         match &app.prompt {
             PromptState::BrowseProjects {
-                tab_completions, ..
+                path_input,
+                tab_completions,
+                tab_index,
+                ..
             } => {
                 assert_eq!(tab_completions.len(), 2);
+                assert_eq!(*tab_index, 0);
+                assert_eq!(path_input.text, typed);
+            }
+            other => panic!("expected browser prompt, got {other:?}"),
+        }
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                path_input,
+                tab_index,
+                ..
+            } => {
+                assert_eq!(*tab_index, 1);
+                assert_eq!(path_input.text, typed);
             }
             other => panic!("expected browser prompt, got {other:?}"),
         }
 
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
             .unwrap();
-        let first = match &app.prompt {
-            PromptState::BrowseProjects { path_input, .. } => path_input.text.clone(),
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                path_input,
+                tab_completions,
+                tab_index,
+                ..
+            } => {
+                assert!(
+                    path_input.text.ends_with("alpha/") || path_input.text.ends_with("alpine/")
+                );
+                assert_eq!(*tab_index, 0);
+                if path_input.text.ends_with("alpha/") {
+                    assert_eq!(tab_completions.len(), 1);
+                    assert!(tab_completions[0].ends_with("child/"));
+                }
+            }
             other => panic!("expected browser prompt, got {other:?}"),
-        };
-        assert!(first.ends_with("alpha/") || first.ends_with("alpine/"));
-
-        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
-            .unwrap();
-        let second = match &app.prompt {
-            PromptState::BrowseProjects { path_input, .. } => path_input.text.clone(),
-            other => panic!("expected browser prompt, got {other:?}"),
-        };
-        assert_ne!(first, second);
+        }
     }
 
     #[test]
-    fn project_browser_typed_up_down_preserves_completions() {
+    fn project_browser_typed_up_down_select_completions_without_applying() {
         let mut app = test_app(default_bindings());
         let root = PathBuf::from(&app.projects[0].path);
         app.prompt = PromptState::BrowseProjects {
@@ -8657,17 +8686,31 @@ cyan = "#00ffff"
 
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
             .unwrap();
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                path_input,
+                tab_index,
+                ..
+            } => {
+                assert_eq!(*tab_index, 0);
+                assert_eq!(path_input.text, "/tmp/demo");
+            }
+            other => panic!("expected browser prompt, got {other:?}"),
+        }
+
         app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
             .unwrap();
 
         match &app.prompt {
             PromptState::BrowseProjects {
+                path_input,
                 tab_completions,
                 tab_index,
                 ..
             } => {
                 assert_eq!(tab_completions.len(), 2);
                 assert_eq!(*tab_index, 1);
+                assert_eq!(path_input.text, "/tmp/demo");
             }
             other => panic!("expected browser prompt, got {other:?}"),
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2008,10 +2008,7 @@ impl App {
                             KeyCode::Enter => {
                                 add_path = Some(path_input.text.trim().to_string());
                             }
-                            KeyCode::Up | KeyCode::Down => {
-                                tab_completions.clear();
-                                *tab_index = 0;
-                            }
+                            KeyCode::Up | KeyCode::Down => {}
                             _ => {
                                 if path_input.handle_key(key) {
                                     refresh_completions = true;
@@ -8570,6 +8567,29 @@ cyan = "#00ffff"
     }
 
     #[test]
+    fn added_project_is_selected_after_save_completes() {
+        let mut app = test_app(default_bindings());
+        let project_dir = app.paths.root.join("second-project");
+        std::fs::create_dir_all(&project_dir).expect("project dir");
+        init_test_repo(&project_dir);
+
+        app.add_project(project_dir.to_string_lossy().to_string(), String::new())
+            .expect("add project");
+        drain_until(&mut app, |app| {
+            app.status
+                .text()
+                .contains("Added project \"second-project\" to workspace")
+        });
+
+        let selected = app.selected_project().expect("selected project");
+        assert_eq!(selected.name, "second-project");
+        assert_eq!(
+            PathBuf::from(&selected.path).canonicalize().unwrap(),
+            project_dir.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
     fn project_browser_typed_tab_cycles_displayed_completions() {
         let mut app = test_app(default_bindings());
         let root = PathBuf::from(&app.projects[0].path);
@@ -8616,6 +8636,41 @@ cyan = "#00ffff"
             other => panic!("expected browser prompt, got {other:?}"),
         };
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn project_browser_typed_up_down_preserves_completions() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root,
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            editing_path: true,
+            path_input: TextInput::with_text("/tmp/demo".to_string()),
+            tab_completions: vec!["/tmp/demo/".to_string(), "/tmp/demo-two/".to_string()],
+            tab_index: 1,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                tab_completions,
+                tab_index,
+                ..
+            } => {
+                assert_eq!(tab_completions.len(), 2);
+                assert_eq!(*tab_index, 1);
+            }
+            other => panic!("expected browser prompt, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -125,6 +125,7 @@ enum PromptMouseTarget {
     ConfirmUseExistingBranchUse,
     ConfigReloadFailedClose,
     ConfigReloadFailedApply,
+    AddProjectFailedOk,
     Checkbox(OverlayCheckboxId),
     RenameInput,
     NameNewAgentInput,
@@ -207,6 +208,7 @@ impl ButtonPressedTarget {
             PromptMouseTarget::ConfigReloadFailedApply => {
                 Some(ButtonPressedTarget::ConfigReloadFailedApply)
             }
+            PromptMouseTarget::AddProjectFailedOk => Some(ButtonPressedTarget::AddProjectFailedOk),
             PromptMouseTarget::CommandInput
             | PromptMouseTarget::CommandItem(_)
             | PromptMouseTarget::BrowseProjectInput
@@ -1953,14 +1955,17 @@ impl App {
             let is_plain_char = matches!(key.code, KeyCode::Char(_))
                 && !key.modifiers.contains(KeyModifiers::CONTROL);
 
-            // Path editor is pure text input — keep hardcoded KeyCode matches.
+            // Path editor keeps text editing local, with one browser-scoped
+            // escape hatch back to directory browsing.
             if is_editing_path {
+                let path_editor_action = if is_plain_char {
+                    None
+                } else {
+                    self.bindings.lookup(&key, BindingScope::Browser)
+                };
+                let mut add_path: Option<String> = None;
+                let mut refresh_completions = false;
                 if let PromptState::BrowseProjects {
-                    current_dir,
-                    entries,
-                    loading,
-                    selected,
-                    filter,
                     editing_path,
                     path_input,
                     tab_completions,
@@ -1968,105 +1973,58 @@ impl App {
                     ..
                 } = &mut self.prompt
                 {
-                    let mut browse_to: Option<PathBuf> = None;
-                    let mut error_msg = None;
-                    match key.code {
-                        KeyCode::Esc => {
+                    match path_editor_action {
+                        Some(Action::ExitPathEditorOnProjectAdd) => {
                             *editing_path = false;
                             path_input.clear();
                             tab_completions.clear();
                             *tab_index = 0;
                         }
-                        KeyCode::Tab | KeyCode::BackTab => {
-                            if tab_completions.is_empty() {
-                                let input_path = PathBuf::from(path_input.text.as_str());
-                                let (search_dir, prefix) =
-                                    if input_path.is_dir() && path_input.text.ends_with('/') {
-                                        (input_path.clone(), String::new())
-                                    } else {
-                                        let parent = input_path
-                                            .parent()
-                                            .unwrap_or_else(|| std::path::Path::new("/"));
-                                        let file_name = input_path
-                                            .file_name()
-                                            .map(|f| f.to_string_lossy().to_string())
-                                            .unwrap_or_default();
-                                        (parent.to_path_buf(), file_name)
-                                    };
-                                if let Ok(read) = std::fs::read_dir(&search_dir) {
-                                    let prefix_lower = prefix.to_lowercase();
-                                    let mut candidates: Vec<String> = read
-                                        .filter_map(|e| e.ok())
-                                        .filter(|e| {
-                                            e.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
-                                        })
-                                        .filter(|e| {
-                                            let name =
-                                                e.file_name().to_string_lossy().to_lowercase();
-                                            !name.starts_with('.')
-                                                && name.starts_with(&prefix_lower)
-                                        })
-                                        .map(|e| {
-                                            let mut full = search_dir
-                                                .join(e.file_name())
-                                                .to_string_lossy()
-                                                .to_string();
-                                            full.push('/');
-                                            full
-                                        })
-                                        .collect();
-                                    candidates.sort();
-                                    *tab_completions = candidates;
-                                    *tab_index = 0;
-                                }
-                            } else if is_reverse_tab(key) {
-                                if *tab_index == 0 {
-                                    *tab_index = tab_completions.len().saturating_sub(1);
-                                } else {
-                                    *tab_index -= 1;
-                                }
-                            } else {
-                                *tab_index = (*tab_index + 1) % tab_completions.len();
-                            }
-                            if let Some(completion) = tab_completions.get(*tab_index) {
-                                path_input.set_text(completion.clone());
-                            }
-                        }
-                        KeyCode::Enter => {
-                            let new_dir = PathBuf::from(path_input.text.trim());
-                            if new_dir.is_dir() {
-                                *current_dir = new_dir.clone();
-                                entries.clear();
-                                *loading = true;
-                                *selected = 0;
-                                filter.clear();
-                                browse_to = Some(new_dir);
-                            } else {
-                                error_msg =
-                                    Some(format!("{} is not a directory.", path_input.text.trim()));
-                            }
-                            *editing_path = false;
-                            path_input.clear();
-                            tab_completions.clear();
-                            *tab_index = 0;
-                        }
-                        KeyCode::Up | KeyCode::Down => {
-                            tab_completions.clear();
-                            *tab_index = 0;
-                        }
-                        _ => {
-                            if path_input.handle_key(key) {
+                        _ => match key.code {
+                            KeyCode::Esc => {
+                                *editing_path = false;
+                                path_input.clear();
                                 tab_completions.clear();
                                 *tab_index = 0;
                             }
-                        }
+                            KeyCode::Tab | KeyCode::BackTab => {
+                                if tab_completions.is_empty() {
+                                    *tab_completions =
+                                        Self::path_editor_completion_candidates(&path_input.text);
+                                    *tab_index = 0;
+                                } else if is_reverse_tab(key) {
+                                    if *tab_index == 0 {
+                                        *tab_index = tab_completions.len().saturating_sub(1);
+                                    } else {
+                                        *tab_index -= 1;
+                                    }
+                                } else {
+                                    *tab_index = (*tab_index + 1) % tab_completions.len();
+                                }
+                                if let Some(completion) = tab_completions.get(*tab_index) {
+                                    path_input.set_text(completion.clone());
+                                }
+                            }
+                            KeyCode::Enter => {
+                                add_path = Some(path_input.text.trim().to_string());
+                            }
+                            KeyCode::Up | KeyCode::Down => {
+                                tab_completions.clear();
+                                *tab_index = 0;
+                            }
+                            _ => {
+                                if path_input.handle_key(key) {
+                                    refresh_completions = true;
+                                }
+                            }
+                        },
                     }
-                    if let Some(msg) = error_msg {
-                        self.set_error(msg);
-                    }
-                    if let Some(dir) = browse_to {
-                        self.spawn_browser_entries(&dir);
-                    }
+                }
+                if refresh_completions {
+                    self.refresh_path_editor_completions();
+                }
+                if let Some(path) = add_path {
+                    self.add_project_from_browser_path(path);
                 }
                 return Ok(false);
             }
@@ -2150,6 +2108,7 @@ impl App {
                         }
                         path_input.set_text(p);
                     }
+                    self.refresh_path_editor_completions();
                 }
                 Some(Action::Confirm) if is_searching => {
                     if let PromptState::BrowseProjects { searching, .. } = &mut self.prompt {
@@ -2162,10 +2121,7 @@ impl App {
                 Some(Action::AddCurrentDir) if !is_searching => {
                     if let PromptState::BrowseProjects { current_dir, .. } = &self.prompt {
                         let path = current_dir.to_string_lossy().to_string();
-                        self.prompt = PromptState::None;
-                        if let Err(e) = self.add_project(path, String::new()) {
-                            self.set_error(format!("{e:#}"));
-                        }
+                        self.add_project_from_browser_path(path);
                     }
                 }
                 _ => {
@@ -2438,6 +2394,15 @@ impl App {
                     }
                 },
                 _ => {}
+            }
+            return Ok(false);
+        }
+
+        if matches!(self.prompt, PromptState::AddProjectFailed { .. }) {
+            let action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let is_space = key.code == KeyCode::Char(' ');
+            if matches!(action, Some(Action::Confirm | Action::CloseOverlay)) || is_space {
+                self.resolve_add_project_failed();
             }
             return Ok(false);
         }
@@ -3407,6 +3372,13 @@ impl App {
                     None
                 }
             }
+            OverlayMouseLayout::AddProjectFailed { ok_button } => {
+                if contains_point(ok_button, column, row) {
+                    Some(PromptMouseTarget::AddProjectFailedOk)
+                } else {
+                    None
+                }
+            }
             OverlayMouseLayout::RenameSession { input, checkbox } => {
                 if checkbox.is_some_and(|checkbox| contains_point(checkbox.rect, column, row)) {
                     checkbox.map(|checkbox| PromptMouseTarget::Checkbox(checkbox.id))
@@ -3891,6 +3863,97 @@ impl App {
         if let Some(dir) = browse_to {
             self.spawn_browser_entries(&dir);
         }
+    }
+
+    fn path_editor_completion_candidates(input: &str) -> Vec<String> {
+        let input_path = PathBuf::from(input);
+        let (search_dir, prefix) = if input_path.is_dir() && input.ends_with('/') {
+            (input_path, String::new())
+        } else {
+            let parent = input_path
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("/"));
+            let file_name = input_path
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
+            (parent.to_path_buf(), file_name)
+        };
+
+        let Ok(read) = std::fs::read_dir(search_dir.clone()) else {
+            return Vec::new();
+        };
+        let prefix_lower = prefix.to_lowercase();
+        let mut candidates: Vec<String> = read
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
+            .filter(|entry| {
+                let name = entry.file_name().to_string_lossy().to_lowercase();
+                !name.starts_with('.') && name.starts_with(&prefix_lower)
+            })
+            .map(|entry| {
+                let mut full = search_dir
+                    .join(entry.file_name())
+                    .to_string_lossy()
+                    .to_string();
+                full.push('/');
+                full
+            })
+            .collect();
+        candidates.sort();
+        candidates
+    }
+
+    fn refresh_path_editor_completions(&mut self) {
+        let input = match &self.prompt {
+            PromptState::BrowseProjects {
+                editing_path: true,
+                path_input,
+                ..
+            } => path_input.text.clone(),
+            _ => return,
+        };
+        let candidates = Self::path_editor_completion_candidates(&input);
+        if let PromptState::BrowseProjects {
+            tab_completions,
+            tab_index,
+            ..
+        } = &mut self.prompt
+        {
+            *tab_completions = candidates;
+            *tab_index = 0;
+        }
+    }
+
+    fn add_project_from_browser_path(&mut self, path: String) {
+        let return_prompt = self.prompt.clone();
+        if let Err(message) = self.validate_project_add_path(&path) {
+            self.open_add_project_failed_modal(message, return_prompt);
+            return;
+        }
+        self.prompt = PromptState::None;
+        if let Err(error) = self.add_project(path, String::new()) {
+            self.open_add_project_failed_modal(format!("{error:#}"), return_prompt);
+        }
+    }
+
+    fn open_add_project_failed_modal(&mut self, message: String, return_prompt: PromptState) {
+        self.prompt = PromptState::AddProjectFailed {
+            message,
+            return_prompt: Box::new(return_prompt),
+        };
+    }
+
+    fn resolve_add_project_failed(&mut self) -> bool {
+        let return_prompt = match std::mem::replace(&mut self.prompt, PromptState::None) {
+            PromptState::AddProjectFailed { return_prompt, .. } => *return_prompt,
+            other => {
+                self.prompt = other;
+                return false;
+            }
+        };
+        self.prompt = return_prompt;
+        false
     }
 
     fn set_pick_editor_selection(&mut self, index: usize) {
@@ -4587,7 +4650,8 @@ impl App {
             | PromptMouseTarget::ConfirmUseExistingBranchCancel
             | PromptMouseTarget::ConfirmUseExistingBranchUse
             | PromptMouseTarget::ConfigReloadFailedClose
-            | PromptMouseTarget::ConfigReloadFailedApply => {
+            | PromptMouseTarget::ConfigReloadFailedApply
+            | PromptMouseTarget::AddProjectFailedOk => {
                 debug_assert!(
                     false,
                     "button target {:?} should be dispatched via activate_button, not \
@@ -4707,6 +4771,7 @@ impl App {
                 self.resolve_config_reload_failed(false)
             }
             ButtonPressedTarget::ConfigReloadFailedApply => self.resolve_config_reload_failed(true),
+            ButtonPressedTarget::AddProjectFailedOk => self.resolve_add_project_failed(),
         }
     }
 
@@ -8427,6 +8492,164 @@ cyan = "#00ffff"
                 assert_eq!(path_input.cursor, 2);
             }
             other => panic!("expected browse projects prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_browser_typed_enter_failure_opens_modal_and_restores_path() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        let outside = tempdir().expect("outside tempdir");
+        let typed = outside.path().join("not-a-repo");
+        std::fs::create_dir_all(&typed).expect("typed dir");
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root,
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            editing_path: true,
+            path_input: TextInput::with_text(typed.to_string_lossy().to_string()),
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::AddProjectFailed { message, .. } => {
+                assert!(message.contains("not a git repository"));
+            }
+            other => panic!("expected add-project failure modal, got {other:?}"),
+        }
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                editing_path,
+                path_input,
+                ..
+            } => {
+                assert!(*editing_path);
+                assert_eq!(path_input.text, typed.to_string_lossy());
+            }
+            other => panic!("expected browser prompt restored, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_browser_typed_enter_duplicate_failure_restores_path() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root.clone(),
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            editing_path: true,
+            path_input: TextInput::with_text(root.to_string_lossy().to_string()),
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::AddProjectFailed { message, .. } => {
+                assert!(message.contains("already registered"));
+            }
+            other => panic!("expected add-project failure modal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_browser_typed_tab_cycles_displayed_completions() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        let alpha = root.join("alpha");
+        let alpine = root.join("alpine");
+        std::fs::create_dir_all(&alpha).expect("alpha dir");
+        std::fs::create_dir_all(&alpine).expect("alpine dir");
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root.clone(),
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            editing_path: true,
+            path_input: TextInput::with_text(root.join("al").to_string_lossy().to_string()),
+            tab_completions: Vec::new(),
+            tab_index: 0,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                tab_completions, ..
+            } => {
+                assert_eq!(tab_completions.len(), 2);
+            }
+            other => panic!("expected browser prompt, got {other:?}"),
+        }
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        let first = match &app.prompt {
+            PromptState::BrowseProjects { path_input, .. } => path_input.text.clone(),
+            other => panic!("expected browser prompt, got {other:?}"),
+        };
+        assert!(first.ends_with("alpha/") || first.ends_with("alpine/"));
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        let second = match &app.prompt {
+            PromptState::BrowseProjects { path_input, .. } => path_input.text.clone(),
+            other => panic!("expected browser prompt, got {other:?}"),
+        };
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn project_browser_exit_path_editor_binding_returns_to_browse_mode() {
+        let mut app = test_app(default_bindings());
+        let root = PathBuf::from(&app.projects[0].path);
+        app.prompt = PromptState::BrowseProjects {
+            current_dir: root,
+            entries: Vec::new(),
+            loading: false,
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            editing_path: true,
+            path_input: TextInput::with_text("/tmp/demo".to_string()),
+            tab_completions: vec!["/tmp/demo/".to_string()],
+            tab_index: 0,
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::BrowseProjects {
+                editing_path,
+                path_input,
+                tab_completions,
+                ..
+            } => {
+                assert!(!*editing_path);
+                assert!(path_input.is_empty());
+                assert!(tab_completions.is_empty());
+            }
+            other => panic!("expected browser prompt, got {other:?}"),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -563,6 +563,10 @@ pub(crate) enum PromptState {
         tab_completions: Vec<String>,
         tab_index: usize,
     },
+    AddProjectFailed {
+        message: String,
+        return_prompt: Box<PromptState>,
+    },
     ChangeAgentProvider(ChangeAgentProviderPrompt),
     ChangeDefaultProvider(ChangeDefaultProviderPrompt),
     ChangeProjectDefaultProvider(ChangeProjectDefaultProviderPrompt),
@@ -937,6 +941,9 @@ pub(crate) enum OverlayMouseLayout {
         list: Rect,
         items: usize,
         offset: usize,
+    },
+    AddProjectFailed {
+        ok_button: Rect,
     },
     ChangeAgentProvider {
         list: Rect,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3,6 +3,7 @@ use super::components::{
     shared_button_width,
 };
 use super::*;
+use std::path::Path;
 
 /// ASCII art logo displayed in the agent pane when no content is active.
 const ASCII_LOGO: &[&str] = &[
@@ -2386,7 +2387,7 @@ impl App {
                     .iter()
                     .map(|completion| {
                         ListItem::new(Line::from(vec![Span::styled(
-                            completion.clone(),
+                            path_completion_display_label(completion),
                             Style::default().fg(self.theme.text_fg),
                         )]))
                     })
@@ -6266,6 +6267,15 @@ fn scrollback_indicator_label(scrolled: usize, total: usize) -> Option<String> {
     Some(format!(" {scrolled}/{total} {noun} "))
 }
 
+fn path_completion_display_label(completion: &str) -> String {
+    let trimmed = completion.trim_end_matches('/');
+    let folder = Path::new(trimmed)
+        .file_name()
+        .and_then(|part| part.to_str())
+        .unwrap_or(trimmed);
+    format!(".../{folder}/")
+}
+
 impl App {
     /// Render the GitHub PR pill as a single-line pill using Unicode
     /// half-block characters for the caps and a solid background:
@@ -6740,6 +6750,14 @@ mod tests {
     fn format_bytes_gib_range() {
         assert_eq!(format_bytes(1024 * 1024 * 1024), "1.0 GiB");
         assert_eq!(format_bytes(1024 * 1024 * 1024 * 3), "3.0 GiB");
+    }
+
+    #[test]
+    fn path_completion_display_label_shows_folder_only() {
+        assert_eq!(
+            path_completion_display_label("/Users/patrick/project/"),
+            ".../project/"
+        );
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2367,7 +2367,8 @@ impl App {
                 searching,
                 editing_path,
                 path_input,
-                ..
+                tab_completions,
+                tab_index,
             } => {
                 self.render_dim_overlay(frame);
                 let area = centered_rect(72, 70, frame.area());
@@ -2381,7 +2382,22 @@ impl App {
                         .filter(|e| e.label.to_lowercase().contains(&needle))
                         .collect()
                 };
-                let items = if *loading {
+                let completion_items = tab_completions
+                    .iter()
+                    .map(|completion| {
+                        ListItem::new(Line::from(vec![Span::styled(
+                            completion.clone(),
+                            Style::default().fg(self.theme.text_fg),
+                        )]))
+                    })
+                    .collect::<Vec<_>>();
+                let items = if *editing_path {
+                    if completion_items.is_empty() {
+                        vec![ListItem::new("No matching directories.")]
+                    } else {
+                        completion_items
+                    }
+                } else if *loading {
                     let idx = self.spinner_frame_index();
                     let spinner = crate::theme::SPINNER_FRAMES[idx];
                     vec![ListItem::new(Line::from(vec![
@@ -2423,8 +2439,14 @@ impl App {
                         })
                         .collect::<Vec<_>>()
                 };
+                let item_count = if *editing_path {
+                    tab_completions.len()
+                } else {
+                    visible.len()
+                };
+                let selected_index = if *editing_path { *tab_index } else { *selected };
                 let mut state = ListState::default()
-                    .with_selected(Some((*selected).min(visible.len().saturating_sub(1))));
+                    .with_selected(Some(selected_index.min(item_count.saturating_sub(1))));
                 let has_filter = !filter.is_empty();
                 let show_top_input = *searching || has_filter || *editing_path;
                 let (top_areas, list_render_area) = if show_top_input {
@@ -2459,9 +2481,10 @@ impl App {
                     let search_key = self.bindings.label_for(Action::SearchToggle);
                     let open_key = self.bindings.label_for(Action::OpenEntry);
                     let goto_key = self.bindings.label_for(Action::GoToPath);
+                    let exit_path_key = self.bindings.label_for(Action::ExitPathEditorOnProjectAdd);
                     let mut bottom_spans = vec![Span::raw(" ")];
                     if *editing_path {
-                        // Path editor: Tab/Enter/Esc are text-input controls, not rebindable.
+                        // Path editor: Tab/Enter are text-input controls, not rebindable.
                         bottom_spans.extend(self.theme.key_badge_default("Tab"));
                         bottom_spans.push(Span::styled(
                             " complete  ",
@@ -2469,12 +2492,12 @@ impl App {
                         ));
                         bottom_spans.extend(self.theme.key_badge_default("Enter"));
                         bottom_spans.push(Span::styled(
-                            " go  ",
+                            " add  ",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
-                        bottom_spans.extend(self.theme.key_badge_default("Esc"));
+                        bottom_spans.extend(self.theme.key_badge_default(&exit_path_key));
                         bottom_spans.push(Span::styled(
-                            " cancel",
+                            " browse",
                             Style::default().fg(self.theme.hint_desc_fg),
                         ));
                     } else if *searching {
@@ -2527,7 +2550,7 @@ impl App {
                     self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
                         input: Some(input_inner),
                         list: list_inner,
-                        items: visible.len(),
+                        items: item_count,
                         offset: state.offset(),
                     };
                 } else {
@@ -2578,7 +2601,7 @@ impl App {
                     self.overlay_layout.active = OverlayMouseLayout::BrowseProjects {
                         input: None,
                         list: list_inner,
-                        items: visible.len(),
+                        items: item_count,
                         offset: state.offset(),
                     };
                 }
@@ -3922,6 +3945,58 @@ impl App {
                     apply_button: apply_area,
                     checkbox,
                 };
+            }
+            PromptState::AddProjectFailed { message, .. } => {
+                self.render_dim_overlay(frame);
+                let dialog_width = 68.min(frame.area().width.max(1));
+                let inner_width = dialog_width.saturating_sub(2);
+                let mut body_lines = vec![
+                    Line::from(""),
+                    Line::from(Span::styled(
+                        " The project could not be added.",
+                        Style::default().fg(self.theme.warning_fg),
+                    )),
+                    Line::from(""),
+                ];
+                for line in message.lines().take(6) {
+                    body_lines.push(Line::from(format!(" {line}")));
+                }
+                let body_height = wrapped_line_count(&body_lines, inner_width, false);
+                let area = centered_rect_exact(dialog_width, 2 + body_height + 3, frame.area());
+                self.clear_overlay_area(frame, area);
+                let outer = self.themed_overlay_block("Add Project Failed");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+
+                let [body_area, buttons_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(body_height), Constraint::Length(3)])
+                    .areas(inner);
+
+                Paragraph::new(body_lines)
+                    .wrap(Wrap { trim: false })
+                    .render(body_area, frame.buffer_mut());
+
+                let btn_width = shared_button_width(&["OK"]);
+                let ok_area = Rect {
+                    x: buttons_area.x + buttons_area.width.saturating_sub(btn_width) / 2,
+                    y: buttons_area.y,
+                    width: btn_width,
+                    height: 3,
+                };
+
+                Button::new("OK")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::AddProjectFailedOk,
+                        self.pressed_button,
+                        true,
+                        true,
+                    ))
+                    .render(frame, ok_area, &self.theme);
+
+                self.overlay_layout.active =
+                    OverlayMouseLayout::AddProjectFailed { ok_button: ok_area };
             }
             PromptState::ConfirmDeleteAgent {
                 branch_name,

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -44,26 +44,14 @@ impl App {
     }
 
     pub(crate) fn add_project(&mut self, raw_path: String, name: String) -> Result<()> {
-        let path = PathBuf::from(raw_path.trim())
-            .canonicalize()
-            .unwrap_or_else(|_| PathBuf::from(raw_path.trim()));
+        let path = match self.validate_project_add_path(&raw_path) {
+            Ok(path) => path,
+            Err(message) => {
+                self.set_error(message);
+                return Ok(());
+            }
+        };
         logger::info(&format!("attempting to add project {}", path.display()));
-        if !path.exists() || !git::is_git_repo(&path) {
-            logger::error(&format!("add project rejected for {}", path.display()));
-            self.set_error(format!("\"{}\" is not a git repository.", path.display()));
-            return Ok(());
-        }
-        if self
-            .projects
-            .iter()
-            .any(|project| Path::new(&project.path) == path.as_path())
-        {
-            self.set_error(format!(
-                "\"{}\" is already registered as a project.",
-                path.display()
-            ));
-            return Ok(());
-        }
         let branch = git::current_branch(&path)?;
         let leading_branch = leading_branch_for_project(&path, &branch);
 
@@ -89,6 +77,32 @@ impl App {
 
         let path_str = path.to_string_lossy().to_string();
         self.finish_add_project(path_str, name, branch, leading_branch)
+    }
+
+    pub(crate) fn validate_project_add_path(
+        &self,
+        raw_path: &str,
+    ) -> std::result::Result<PathBuf, String> {
+        let trimmed = raw_path.trim();
+        let path = PathBuf::from(trimmed)
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(trimmed));
+        if !path.exists() || !git::is_git_repo(&path) {
+            logger::error(&format!("add project rejected for {}", path.display()));
+            return Err(format!("\"{}\" is not a git repository.", path.display()));
+        }
+        if self.projects.iter().any(|project| {
+            PathBuf::from(&project.path)
+                .canonicalize()
+                .unwrap_or_else(|_| PathBuf::from(&project.path))
+                == path
+        }) {
+            return Err(format!(
+                "\"{}\" is already registered as a project.",
+                path.display()
+            ));
+        }
+        Ok(path)
     }
 
     /// Starts saving the project to SQLite and adds it to the runtime project

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -713,8 +713,14 @@ impl App {
                 project,
                 status_message,
             } => {
+                let project_id = project.id.clone();
                 self.projects.push(project);
                 self.rebuild_left_items();
+                if let Some(index) = self.left_items().iter().position(|item| {
+                    matches!(item, LeftItem::Project(project_index) if self.projects[*project_index].id == project_id)
+                }) {
+                    self.selected_left = index;
+                }
                 self.set_info(status_message);
             }
             ProjectPersistenceAction::Remove {

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -68,6 +68,7 @@ pub enum Action {
     // Overlays and dialogs
     SearchToggle,
     GoToPath,
+    ExitPathEditorOnProjectAdd,
     OpenEntry,
     AddCurrentDir,
     Confirm,
@@ -243,6 +244,7 @@ impl Action {
             Action::ResizeShrink => "resize_shrink",
             Action::SearchToggle => "search_toggle",
             Action::GoToPath => "go_to_path",
+            Action::ExitPathEditorOnProjectAdd => "exit_path_editor_on_project_add",
             Action::OpenEntry => "open_entry",
             Action::AddCurrentDir => "add_current_dir",
             Action::Confirm => "confirm",
@@ -348,6 +350,7 @@ impl Action {
             Action::ResizeShrink => "Shrink the left pane width.",
             Action::SearchToggle => "Toggle search mode in search-capable lists and overlays.",
             Action::GoToPath => "Open path editor in the project browser.",
+            Action::ExitPathEditorOnProjectAdd => "Exit typed-path mode in the project browser.",
             Action::OpenEntry => "Open or navigate into the selected entry in the project browser.",
             Action::AddCurrentDir => "Add the current directory as a project.",
             Action::Confirm => "Confirm the selected action in a dialog.",
@@ -442,6 +445,7 @@ impl Action {
             Action::ResizeGrow | Action::ResizeShrink => Some("Resize mode"),
             Action::SearchToggle
             | Action::GoToPath
+            | Action::ExitPathEditorOnProjectAdd
             | Action::OpenEntry
             | Action::AddCurrentDir
             | Action::Confirm
@@ -1303,6 +1307,17 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Open path editor in the project browser",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::ExitPathEditorOnProjectAdd,
+        default_keys: &[key!(ctrl - g)],
+        scopes: &[BindingScope::Browser],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Exit typed-path mode in the project browser",
         }),
         hint_contexts: &[],
         palette: None,
@@ -2469,6 +2484,7 @@ mod tests {
         assert!(actions_in_defs.contains(&Action::ExitCommitInput));
         assert!(actions_in_defs.contains(&Action::PushToRemote));
         assert!(actions_in_defs.contains(&Action::AddCurrentDir));
+        assert!(actions_in_defs.contains(&Action::ExitPathEditorOnProjectAdd));
         assert!(actions_in_defs.contains(&Action::SearchFiles));
         assert!(actions_in_defs.contains(&Action::SearchNext));
         assert!(actions_in_defs.contains(&Action::ForceRedraw));


### PR DESCRIPTION
This updates the project browser so typed paths can be completed and added directly with Enter, while normal folder browsing keeps its existing Enter-to-open behavior.

Typed-path mode now has a configurable escape action, `exit_path_editor_on_project_add`, and the completion list reflects the path being edited. Add-project failures from the browser now open an OK modal and preserve the typed path so the user can correct it without starting over.

The duplicate-project check now compares canonical paths so the same project cannot be added again through a differently written path.