### PR TITLE
Return minimized agents to Projects

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -5559,6 +5559,7 @@ impl App {
     pub(crate) fn exit_interactive_mode(&mut self) {
         let return_to_terminal_list =
             matches!(self.input_target, InputTarget::Terminal) && self.terminal_return_to_list;
+        let return_to_projects = matches!(self.input_target, InputTarget::Agent);
         self.input_target = InputTarget::None;
         self.fullscreen_overlay = FullscreenOverlay::None;
         self.session_surface = SessionSurface::Agent;
@@ -5570,6 +5571,9 @@ impl App {
         if return_to_terminal_list {
             self.left_section = LeftSection::Terminals;
             self.clamp_terminal_cursor();
+            self.focus = FocusPane::Left;
+        } else if return_to_projects {
+            self.left_section = LeftSection::Projects;
             self.focus = FocusPane::Left;
         }
         self.set_info("Exited interactive mode.");
@@ -9847,6 +9851,61 @@ cyan = "#00ffff"
         assert_eq!(app.input_target, InputTarget::None);
         assert_eq!(app.left_section, LeftSection::Terminals);
         assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
+    fn exit_interactive_from_agent_overlay_returns_to_projects() {
+        let mut app = test_app(default_bindings());
+        app.focus = FocusPane::Center;
+        app.left_section = LeftSection::Terminals;
+        app.input_target = InputTarget::Agent;
+        app.session_surface = SessionSurface::Agent;
+        app.fullscreen_overlay = FullscreenOverlay::Agent;
+
+        app.process_raw_input_bytes(&[0x07]).unwrap();
+
+        assert_eq!(app.input_target, InputTarget::None);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        assert_eq!(app.session_surface, SessionSurface::Agent);
+        assert_eq!(app.left_section, LeftSection::Projects);
+        assert_eq!(app.focus, FocusPane::Left);
+    }
+
+    #[test]
+    fn custom_exit_interactive_key_reopens_minimized_agent_from_projects() {
+        let bindings = bindings_with_overrides(&[(Action::ExitInteractive, &["home"])]);
+        let mut app = test_app(bindings);
+        let session_id = app.sessions[0].id.clone();
+        app.providers.insert(
+            session_id,
+            PtyClient::spawn(
+                "sh",
+                &["-c".to_string(), "printf ready; sleep 0.2".to_string()],
+                std::path::Path::new("."),
+                10,
+                10,
+                100,
+            )
+            .expect("spawn pty"),
+        );
+
+        app.focus = FocusPane::Center;
+        app.input_target = InputTarget::Agent;
+        app.session_surface = SessionSurface::Agent;
+        app.fullscreen_overlay = FullscreenOverlay::Agent;
+
+        app.process_raw_input_bytes(b"\x1b[H").unwrap();
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+        assert_eq!(app.left_section, LeftSection::Projects);
+        assert_eq!(app.focus, FocusPane::Left);
+
+        app.handle_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE))
+            .unwrap();
+
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
+        assert_eq!(app.focus, FocusPane::Center);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #233.

When an agent exits interactive mode, focus now returns to the Projects list instead of staying on the agent pane. This matches the expected Projects workflow while leaving the existing terminal return behavior unchanged.

The same configured interactive-mode keybinding can still reopen the minimized agent from Projects, including custom bindings that replace Ctrl-g.