### PR TITLE
Add project startup commands for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 
 - **All settings are configurable.** Every single one. If a user can't change it, it shouldn't be hardcoded.
 - **The config file is the documentation.** It must clearly explain what each setting does through inline comments. A user should never need to leave the config file to understand an option.
+- **Project config is portable desired state, not runtime cache.** `[[projects]]` may store portable user intent such as `id`, env-expanded `path`, `name`, `default_provider`, `auto_reopen_agents`, and `startup_command`. Do not write runtime-derived git or agent state into config.
+- **Keep derived project state in SQLite.** Values such as `leading_branch`, `current_branch`, branch status, agent worktree paths, agent branch names, and provider process/session state belong in SQLite/runtime memory only. In particular, `leading_branch` may be parsed from older config files to repair SQLite, but saved/generated config must omit it so autodetection is not pinned into portable config.
+- **Startup command execution shell is global config, not project state.** Project config owns the command text; `[startup_command_terminal]` owns the system-wide shell and args used to run it. Keep this out of SQLite and UI-only state so shell behavior stays portable and reviewable in config.
+- **Config wins for explicit project preferences.** When a project exists in both config and SQLite, explicit config values for safe preference fields should update SQLite on startup/reload. SQLite may fill missing config fields, but should not override a value the user wrote in config. Reserve hard sync conflicts for project identity ambiguity: duplicate ids/paths, same id with different expanded paths, or same expanded path with different ids.
 
 ### UI and Navigation
 
@@ -32,6 +36,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 
 - **Worktrees are user data.** Never removed or mutated casually. Deletion requires explicit user confirmation.
 - **Git operations are conservative.** Source checkout refresh uses `--ff-only`. Destructive operations require confirmation.
+- **Commit messages are plain sentences.** Do not use conventional commit prefixes such as `feat:`, `fix:`, or `chore:`. Do not add structured commit trailers such as `Constraint:`, `Confidence:`, `Scope-risk:`, or `Tested:` unless the user explicitly asks for them.
 - **Prefer explicit failure over silent waiting.** If something fails, say so immediately with context.
 
 ### Tone

--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ The header shows `default provider: …` when the selected project inherits the 
 
 Project-specific provider defaults are managed from inside dux with `change-project-default-provider`; `config.toml` only stores the global fallback.
 
+### Startup Commands
+
+Some projects need a little ceremony before an agent is useful. JavaScript projects want `npm install`, Rust projects may want a cache warmup, and some repos come with a setup script because apparently suffering builds character. Configure a project startup command and dux runs it in the new agent worktree before launching the provider.
+
+```toml
+[[projects]]
+id = "00000000-0000-0000-0000-000000000000"
+path = "$HOME/projects/web-app"
+name = "web-app"
+startup_command = """
+npm install
+npm run build:types
+ln -sfn "$DUX_WORKTREE_PATH/.env.local" .env
+"""
+
+[startup_command_terminal]
+command = "$SHELL"
+args = ["-l", "-c"]
+```
+
+You can edit the command from the palette with `configure-startup-command`, or keep it in `config.toml` with the rest of your project intent. The multiline editor is not pretending to be fancy: dux passes the whole block as one script string to your configured shell, and shells already know that newlines separate commands. Put `npm install`, symlink setup, cache priming, or whatever tiny ritual your repo demands in there.
+
+Project paths support `$HOME`, `${HOME}`, and `~` so the file can travel between machines without hardcoding your username like a tiny portability crime. The startup command itself runs through your configured shell, so shell environment expansion works inside the command (`$HOME`, `${VAR}`, `$PATH`, `$EDITOR`, and friends). It runs with the agent worktree as the current directory, so relative paths point at the new checkout and normal shells report that through `$PWD`. dux also sets `DUX_PROJECT_PATH`, `DUX_WORKTREE_PATH`, `DUX_AGENT_ID`, `DUX_AGENT_BRANCH`, `DUX_PROVIDER`, and `DUX_STARTUP_COMMAND_LOG` for scripts that want to know where they are and who invited them.
+
+If the command fails, dux still creates the agent. The failure shows in the status line, because setup scripts are allowed to be dramatic but not allowed to block the show. Use `read-startup-command-logs` to open the latest log, and `rerun-startup-command-on-agent` when the fix is obvious and you want the machine to try again.
+
 ### Macros
 
 Tired of typing the same prompt over and over? Turn it into a macro. Macros are reusable text snippets you trigger from a quick-select bar. Search by name, hit enter, and the text gets sent to the active pane.

--- a/src/app/components/button.rs
+++ b/src/app/components/button.rs
@@ -99,6 +99,7 @@ pub(crate) enum ButtonPressedTarget {
     ConfigReloadFailedClose,
     ConfigReloadFailedApply,
     AddProjectFailedOk,
+    StartupCommandLogsClose,
 }
 
 /// In-flight state for a button the user is currently pressing. `target`
@@ -211,15 +212,15 @@ impl<'a> Button<'a> {
         if self.state != ButtonState::Disabled {
             label_style = label_style.add_modifier(Modifier::BOLD);
         }
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(border::ROUNDED)
+            .border_style(Style::default().fg(border_color));
+        let inner = block.inner(area);
+        block.render(area, frame.buffer_mut());
         Paragraph::new(Line::from(Span::styled(self.label, label_style)))
             .alignment(Alignment::Center)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_set(border::ROUNDED)
-                    .border_style(Style::default().fg(border_color)),
-            )
-            .render(area, frame.buffer_mut());
+            .render(inner, frame.buffer_mut());
     }
 }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -127,6 +127,9 @@ enum PromptMouseTarget {
     ConfigReloadFailedClose,
     ConfigReloadFailedApply,
     AddProjectFailedOk,
+    StartupCommandLogItem(usize),
+    StartupCommandLogsClose,
+    StartupCommandInput,
     Checkbox(OverlayCheckboxId),
     RenameInput,
     NameNewAgentInput,
@@ -210,12 +213,17 @@ impl ButtonPressedTarget {
                 Some(ButtonPressedTarget::ConfigReloadFailedApply)
             }
             PromptMouseTarget::AddProjectFailedOk => Some(ButtonPressedTarget::AddProjectFailedOk),
+            PromptMouseTarget::StartupCommandLogsClose => {
+                Some(ButtonPressedTarget::StartupCommandLogsClose)
+            }
             PromptMouseTarget::CommandInput
             | PromptMouseTarget::CommandItem(_)
             | PromptMouseTarget::BrowseProjectInput
             | PromptMouseTarget::BrowseProjectItem(_)
             | PromptMouseTarget::PickEditorItem(_)
             | PromptMouseTarget::PickProjectWorktreeItem(_)
+            | PromptMouseTarget::StartupCommandLogItem(_)
+            | PromptMouseTarget::StartupCommandInput
             | PromptMouseTarget::ChangeThemeItem(_)
             | PromptMouseTarget::ChangeAgentProviderItem(_)
             | PromptMouseTarget::ChangeDefaultProviderItem(_)
@@ -233,9 +241,24 @@ fn contains_point(rect: Rect, column: u16, row: u16) -> bool {
     rect.width > 0
         && rect.height > 0
         && column >= rect.x
-        && column < rect.x + rect.width
+        && column < rect.x.saturating_add(rect.width)
         && row >= rect.y
-        && row < rect.y + rect.height
+        && row < rect.y.saturating_add(rect.height)
+}
+
+fn relative_point(rect: Rect, column: u16, row: u16) -> Option<(u16, u16)> {
+    contains_point(rect, column, row)
+        .then_some((column.saturating_sub(rect.x), row.saturating_sub(rect.y)))
+}
+
+fn relative_point_clamped(rect: Rect, column: u16, row: u16) -> (u16, u16) {
+    let column = column
+        .max(rect.x)
+        .min(rect.x.saturating_add(rect.width.saturating_sub(1)));
+    let row = row
+        .max(rect.y)
+        .min(rect.y.saturating_add(rect.height.saturating_sub(1)));
+    (column.saturating_sub(rect.x), row.saturating_sub(rect.y))
 }
 
 fn cursor_from_single_line_position(
@@ -279,6 +302,49 @@ fn pct_from_columns(columns: u16, total_width: u16) -> u16 {
     (((u32::from(columns) * 100) + (u32::from(total_width) / 2)) / u32::from(total_width)) as u16
 }
 
+pub(crate) fn startup_command_log_visual_lines(content: &str, width: u16) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+    let width = usize::from(width);
+    let mut lines = Vec::new();
+    for line in content.split('\n') {
+        let chars = line.chars().collect::<Vec<_>>();
+        if chars.is_empty() {
+            lines.push(String::new());
+            continue;
+        }
+        for chunk in chars.chunks(width) {
+            lines.push(chunk.iter().collect());
+        }
+    }
+    lines
+}
+
+fn startup_command_log_max_scroll(content: &str, body: Option<Rect>) -> u16 {
+    let Some(body) = body else {
+        return u16::MAX;
+    };
+    u16::try_from(startup_command_log_visual_lines(content, body.width).len())
+        .unwrap_or(u16::MAX)
+        .saturating_sub(body.height)
+}
+
+fn scroll_startup_command_log(
+    prompt: &mut StartupCommandLogPrompt,
+    body: Option<Rect>,
+    delta: i16,
+) {
+    if delta >= 0 {
+        prompt.scroll_offset = prompt
+            .scroll_offset
+            .saturating_add(delta as u16)
+            .min(startup_command_log_max_scroll(&prompt.content, body));
+    } else {
+        prompt.scroll_offset = prompt.scroll_offset.saturating_sub(delta.unsigned_abs());
+    }
+}
+
 impl App {
     pub(crate) fn handle_key(&mut self, key: KeyEvent) -> Result<bool> {
         // Prompts take precedence over every other input target so modal text
@@ -286,6 +352,10 @@ impl App {
         // previously active.
         if !matches!(self.prompt, PromptState::None) {
             return self.handle_prompt_key(key);
+        }
+        if matches!(self.fullscreen_overlay, FullscreenOverlay::StartupLog) {
+            self.handle_startup_log_viewer_key(key);
+            return Ok(false);
         }
         // Macro bar consumes all keys when open.
         if self.macro_bar.is_some() {
@@ -348,6 +418,10 @@ impl App {
         // global shortcuts.
         if self.input_target == InputTarget::CommitMessage {
             self.handle_commit_input_key(key)?;
+            return Ok(false);
+        }
+        if self.input_target == InputTarget::StartupCommand {
+            self.handle_startup_command_input_key(key)?;
             return Ok(false);
         }
         // Check if a Global binding should defer to a pane-scoped binding.
@@ -766,6 +840,141 @@ impl App {
         }
     }
 
+    fn startup_log_viewer_max_scroll(&self) -> u16 {
+        let Some(viewer) = &self.startup_log_viewer else {
+            return 0;
+        };
+        let Some(area) = self.mouse_layout.agent_term else {
+            return 0;
+        };
+        u16::try_from(startup_command_log_visual_lines(&viewer.content, area.width).len())
+            .unwrap_or(u16::MAX)
+            .saturating_sub(area.height)
+    }
+
+    fn scroll_startup_log_viewer(&mut self, delta: i16) {
+        let max_scroll = self.startup_log_viewer_max_scroll();
+        let Some(viewer) = &mut self.startup_log_viewer else {
+            return;
+        };
+        if delta >= 0 {
+            viewer.scroll_offset = viewer
+                .scroll_offset
+                .saturating_add(delta as u16)
+                .min(max_scroll);
+        } else {
+            viewer.scroll_offset = viewer.scroll_offset.saturating_sub(delta.unsigned_abs());
+        }
+    }
+
+    fn update_startup_log_search_scroll(&mut self) {
+        let Some(viewer) = &mut self.startup_log_viewer else {
+            return;
+        };
+        let query = viewer.search.text.trim().to_lowercase();
+        if query.is_empty() {
+            viewer.scroll_offset = 0;
+            return;
+        }
+        let Some(width) = self.mouse_layout.agent_term.map(|area| area.width) else {
+            return;
+        };
+        if let Some(index) = startup_command_log_visual_lines(&viewer.content, width)
+            .iter()
+            .position(|line| line.to_lowercase().contains(&query))
+        {
+            viewer.scroll_offset = u16::try_from(index).unwrap_or(u16::MAX);
+        } else {
+            self.set_info("No startup command log search matches.");
+        }
+    }
+
+    fn handle_startup_log_viewer_key(&mut self, key: KeyEvent) {
+        let startup_action = self.bindings.lookup(&key, BindingScope::StartupCommandLogs);
+        let center_action = self.bindings.lookup(&key, BindingScope::Center);
+        let global_action = self.bindings.lookup(&key, BindingScope::Global);
+        let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+        let action = startup_action
+            .or(center_action)
+            .or(global_action)
+            .or(dialog_action);
+
+        if self
+            .startup_log_viewer
+            .as_ref()
+            .is_some_and(|viewer| viewer.searching)
+        {
+            match action {
+                Some(Action::CloseOverlay | Action::SearchToggle | Action::Confirm) => {
+                    if let Some(viewer) = &mut self.startup_log_viewer {
+                        viewer.searching = false;
+                    }
+                }
+                _ => {
+                    let changed = self
+                        .startup_log_viewer
+                        .as_mut()
+                        .is_some_and(|viewer| viewer.search.handle_key(key));
+                    if changed {
+                        self.update_startup_log_search_scroll();
+                    }
+                }
+            }
+            return;
+        }
+
+        match action {
+            Some(Action::CloseOverlay) => {
+                self.close_top_overlay();
+            }
+            Some(Action::SearchToggle) => {
+                if let Some(viewer) = &mut self.startup_log_viewer {
+                    viewer.searching = true;
+                }
+            }
+            Some(Action::ScrollPageDown) => {
+                let page = self
+                    .mouse_layout
+                    .agent_term
+                    .map(|area| area.height)
+                    .unwrap_or(10);
+                self.scroll_startup_log_viewer(page.max(1) as i16);
+            }
+            Some(Action::ScrollPageUp) => {
+                let page = self
+                    .mouse_layout
+                    .agent_term
+                    .map(|area| area.height)
+                    .unwrap_or(10);
+                self.scroll_startup_log_viewer(-(page.max(1) as i16));
+            }
+            Some(Action::ScrollLineDown | Action::MoveDown) => {
+                self.scroll_startup_log_viewer(1);
+            }
+            Some(Action::ScrollLineUp | Action::MoveUp) => {
+                self.scroll_startup_log_viewer(-1);
+            }
+            Some(Action::ScrollToBottom) => {
+                let max_scroll = self.startup_log_viewer_max_scroll();
+                if let Some(viewer) = &mut self.startup_log_viewer {
+                    viewer.scroll_offset = max_scroll;
+                }
+            }
+            Some(Action::ScrollToTop) => {
+                if let Some(viewer) = &mut self.startup_log_viewer {
+                    viewer.scroll_offset = 0;
+                }
+            }
+            Some(Action::OpenStartupCommandLogFile) => {
+                self.open_selected_startup_command_log();
+            }
+            Some(Action::OpenStartupCommandLogFolder) => {
+                self.open_selected_startup_command_log_folder();
+            }
+            _ => {}
+        }
+    }
+
     fn handle_files_search_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Esc => {
@@ -860,6 +1069,24 @@ impl App {
         // TextInput handles Enter (newline), Up/Down (line nav), and all
         // editing keys in multiline mode.
         self.commit_input.handle_key(key);
+        Ok(())
+    }
+
+    fn handle_startup_command_input_key(&mut self, key: KeyEvent) -> Result<()> {
+        if let Some(Action::ExitCommitInput) = self.bindings.lookup(&key, BindingScope::CommitInput)
+        {
+            self.input_target = InputTarget::None;
+            return Ok(());
+        }
+        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+            if key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                input.clear();
+            } else {
+                input.handle_key(key);
+            }
+        } else {
+            self.input_target = InputTarget::None;
+        }
         Ok(())
     }
 
@@ -2395,6 +2622,137 @@ impl App {
             return Ok(false);
         }
 
+        if matches!(self.prompt, PromptState::ConfigureStartupCommand { .. })
+            && self.input_target == InputTarget::StartupCommand
+        {
+            self.handle_startup_command_input_key(key)?;
+            return Ok(false);
+        }
+
+        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+            let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
+            let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let files_action = self.bindings.lookup(&key, BindingScope::Files);
+            if key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                input.clear();
+                return Ok(false);
+            }
+            match palette_action.or(dialog_action).or(files_action) {
+                Some(Action::CloseOverlay) => {
+                    self.prompt = PromptState::None;
+                    self.input_target = InputTarget::None;
+                }
+                Some(Action::Confirm) => {
+                    self.apply_configure_startup_command()?;
+                }
+                Some(Action::EngageCommitInput) => {
+                    self.input_target = InputTarget::StartupCommand;
+                    input.move_end();
+                }
+                _ => {
+                    if matches!(
+                        key.code,
+                        KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
+                    ) {
+                        self.input_target = InputTarget::StartupCommand;
+                        input.handle_key(key);
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
+        if let PromptState::StartupCommandLogs(prompt) = &mut self.prompt {
+            let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
+            let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
+            let center_action = self.bindings.lookup(&key, BindingScope::Center);
+            let help_action = self.bindings.lookup(&key, BindingScope::Help);
+            let startup_logs_action = self.bindings.lookup(&key, BindingScope::StartupCommandLogs);
+            let body = match self.overlay_layout.active {
+                OverlayMouseLayout::StartupCommandLogs { body, .. } if body.height > 0 => {
+                    Some(body)
+                }
+                _ => None,
+            };
+            let page = body.map(|body| body.height.max(1)).unwrap_or(10) as i16;
+            if prompt.searching {
+                let mut select_after_filter = None;
+                match startup_logs_action.or(dialog_action) {
+                    Some(Action::CloseOverlay | Action::SearchToggle | Action::Confirm) => {
+                        prompt.searching = false;
+                    }
+                    _ if matches!(
+                        key.code,
+                        KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
+                    ) =>
+                    {
+                        prompt.filter.handle_key(key);
+                        select_after_filter = Self::startup_command_log_filtered_indices(prompt)
+                            .first()
+                            .copied();
+                    }
+                    _ => {}
+                }
+                if let Some(index) = select_after_filter {
+                    self.select_startup_command_log(index);
+                }
+                return Ok(false);
+            }
+
+            match startup_logs_action
+                .or(palette_action)
+                .or(dialog_action)
+                .or(center_action)
+                .or(help_action)
+            {
+                Some(Action::CloseOverlay) => {
+                    self.prompt = PromptState::None;
+                    self.startup_log_selection = None;
+                }
+                Some(Action::SearchToggle) => {
+                    prompt.searching = true;
+                }
+                Some(Action::MoveDown) => {
+                    let visible = Self::startup_command_log_filtered_indices(prompt);
+                    let visual = Self::startup_command_log_selected_visual_index(prompt, &visible)
+                        .unwrap_or(0);
+                    if let Some(selected) = visible.get(visual + 1).copied() {
+                        self.select_startup_command_log(selected);
+                    }
+                }
+                Some(Action::MoveUp) => {
+                    let visible = Self::startup_command_log_filtered_indices(prompt);
+                    let visual = Self::startup_command_log_selected_visual_index(prompt, &visible)
+                        .unwrap_or(0);
+                    if visual > 0
+                        && let Some(selected) = visible.get(visual - 1).copied()
+                    {
+                        self.select_startup_command_log(selected);
+                    }
+                }
+                Some(Action::ScrollPageDown) => {
+                    scroll_startup_command_log(prompt, body, page);
+                }
+                Some(Action::ScrollPageUp) => {
+                    scroll_startup_command_log(prompt, body, -page);
+                }
+                Some(Action::ScrollLineDown) => {
+                    scroll_startup_command_log(prompt, body, 1);
+                }
+                Some(Action::ScrollLineUp) => {
+                    scroll_startup_command_log(prompt, body, -1);
+                }
+                Some(Action::OpenStartupCommandLogFile | Action::OpenEntry | Action::Confirm) => {
+                    self.open_selected_startup_command_log();
+                }
+                Some(Action::OpenStartupCommandLogFolder) => {
+                    self.open_selected_startup_command_log_folder();
+                }
+                _ => {}
+            }
+            return Ok(false);
+        }
+
         if let PromptState::ConfigReloadFailed {
             recover_old_config,
             focus,
@@ -3244,6 +3602,23 @@ impl App {
             } => Self::overlay_row_at(list, offset, items, column, row)
                 .map(PromptMouseTarget::PickProjectWorktreeItem),
             OverlayMouseLayout::ResourceMonitor { .. } => None,
+            OverlayMouseLayout::StartupCommandLogs {
+                list,
+                items,
+                offset,
+                close_button,
+                ..
+            } => {
+                if contains_point(close_button, column, row) {
+                    Some(PromptMouseTarget::StartupCommandLogsClose)
+                } else {
+                    Self::overlay_row_at(list, offset, items, column, row)
+                        .map(PromptMouseTarget::StartupCommandLogItem)
+                }
+            }
+            OverlayMouseLayout::ConfigureStartupCommand { input } => {
+                contains_point(input, column, row).then_some(PromptMouseTarget::StartupCommandInput)
+            }
             OverlayMouseLayout::ChangeTheme {
                 list,
                 items,
@@ -4445,6 +4820,18 @@ impl App {
         }
     }
 
+    fn set_startup_command_cursor_from_mouse(&mut self, column: u16, row: u16) {
+        let input_area = match self.overlay_layout.active {
+            OverlayMouseLayout::ConfigureStartupCommand { input } => input,
+            _ => return,
+        };
+        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+            let display_row = usize::from(row.saturating_sub(input_area.y));
+            let display_col = usize::from(column.saturating_sub(input_area.x));
+            input.set_cursor_from_display_pos(display_row, display_col);
+        }
+    }
+
     fn focus_next_name_new_agent_control(&mut self, forward: bool) {
         if let PromptState::NameNewAgent { focus, .. } = &mut self.prompt {
             *focus = match (*focus, forward) {
@@ -4636,6 +5023,45 @@ impl App {
             return false;
         }
 
+        if matches!(self.prompt, PromptState::StartupCommandLogs(_))
+            && let OverlayMouseLayout::StartupCommandLogs { area, body, .. } =
+                self.overlay_layout.active
+        {
+            match mouse.kind {
+                MouseEventKind::Down(MouseButton::Left)
+                    if !contains_point(area, mouse.column, mouse.row) =>
+                {
+                    self.prompt = PromptState::None;
+                    self.startup_log_selection = None;
+                    return false;
+                }
+                MouseEventKind::Down(MouseButton::Left)
+                | MouseEventKind::Drag(MouseButton::Left)
+                | MouseEventKind::Up(MouseButton::Left)
+                    if contains_point(body, mouse.column, mouse.row)
+                        || self
+                            .startup_log_selection
+                            .as_ref()
+                            .is_some_and(|selection| selection.dragging) =>
+                {
+                    return self.handle_startup_log_selection_mouse(mouse);
+                }
+                MouseEventKind::ScrollUp if contains_point(body, mouse.column, mouse.row) => {
+                    if let PromptState::StartupCommandLogs(prompt) = &mut self.prompt {
+                        scroll_startup_command_log(prompt, Some(body), -(MOUSE_WHEEL_LINES as i16));
+                    }
+                    return false;
+                }
+                MouseEventKind::ScrollDown if contains_point(body, mouse.column, mouse.row) => {
+                    if let PromptState::StartupCommandLogs(prompt) = &mut self.prompt {
+                        scroll_startup_command_log(prompt, Some(body), MOUSE_WHEEL_LINES as i16);
+                    }
+                    return false;
+                }
+                _ => {}
+            }
+        }
+
         // Watchdog: a press cannot outlive the modal it was made in. If
         // the prompt closed between Down and a follow-up event (e.g. via
         // a key handler), drop any stale press before doing anything
@@ -4748,6 +5174,14 @@ impl App {
                     self.set_error(format!("{err:#}"));
                 }
             }
+            PromptMouseTarget::StartupCommandLogItem(index) => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
+                self.select_startup_command_log_visual_index(index);
+                if double_click {
+                    self.open_selected_startup_command_log();
+                }
+            }
             PromptMouseTarget::ChangeThemeItem(index) => {
                 let double_click =
                     self.register_mouse_click(MouseClickTarget::CommandPalette, Some(index));
@@ -4806,6 +5240,14 @@ impl App {
             PromptMouseTarget::NameNewAgentInput => {
                 self.set_name_new_agent_cursor_from_mouse(mouse.column);
             }
+            PromptMouseTarget::StartupCommandInput => {
+                let double_click =
+                    self.register_mouse_click(MouseClickTarget::StartupCommandInput, None);
+                self.set_startup_command_cursor_from_mouse(mouse.column, mouse.row);
+                if double_click {
+                    self.input_target = InputTarget::StartupCommand;
+                }
+            }
             // Button targets are handled by `activate_button` and never
             // reach this path — `from_prompt_target` returns `Some(_)`
             // for all of them, sending mouse-down through the press
@@ -4838,7 +5280,8 @@ impl App {
             | PromptMouseTarget::ConfirmUseExistingBranchUse
             | PromptMouseTarget::ConfigReloadFailedClose
             | PromptMouseTarget::ConfigReloadFailedApply
-            | PromptMouseTarget::AddProjectFailedOk => {
+            | PromptMouseTarget::AddProjectFailedOk
+            | PromptMouseTarget::StartupCommandLogsClose => {
                 debug_assert!(
                     false,
                     "button target {:?} should be dispatched via activate_button, not \
@@ -4959,6 +5402,10 @@ impl App {
             }
             ButtonPressedTarget::ConfigReloadFailedApply => self.resolve_config_reload_failed(true),
             ButtonPressedTarget::AddProjectFailedOk => self.resolve_add_project_failed(),
+            ButtonPressedTarget::StartupCommandLogsClose => {
+                self.prompt = PromptState::None;
+                false
+            }
         }
     }
 
@@ -5303,6 +5750,39 @@ impl App {
             return false;
         }
 
+        if matches!(self.fullscreen_overlay, FullscreenOverlay::StartupLog) {
+            let inside_log = self
+                .mouse_layout
+                .agent_term
+                .is_some_and(|rect| contains_point(rect, mouse.column, mouse.row));
+            match mouse.kind {
+                MouseEventKind::Down(MouseButton::Left)
+                | MouseEventKind::Drag(MouseButton::Left)
+                | MouseEventKind::Up(MouseButton::Left)
+                    if inside_log
+                        || self
+                            .terminal_selection
+                            .as_ref()
+                            .is_some_and(|selection| selection.dragging) =>
+                {
+                    self.handle_terminal_selection_mouse(mouse);
+                }
+                MouseEventKind::Down(MouseButton::Left) if !inside_log => {
+                    self.close_top_overlay();
+                }
+                MouseEventKind::ScrollDown if inside_log => {
+                    self.terminal_selection = None;
+                    self.scroll_startup_log_viewer(MOUSE_WHEEL_LINES as i16);
+                }
+                MouseEventKind::ScrollUp if inside_log => {
+                    self.terminal_selection = None;
+                    self.scroll_startup_log_viewer(-(MOUSE_WHEEL_LINES as i16));
+                }
+                _ => {}
+            }
+            return false;
+        }
+
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
                 if let Some(drag) = self.resize_drag_at_mouse(mouse.column, mouse.row) {
@@ -5447,13 +5927,8 @@ impl App {
     /// Returns `None` if the point is outside the terminal area.
     fn screen_to_grid(&self, screen_col: u16, screen_row: u16) -> Option<TermGridPos> {
         let term_area = self.mouse_layout.agent_term?;
-        if !contains_point(term_area, screen_col, screen_row) {
-            return None;
-        }
-        Some(TermGridPos {
-            row: screen_row - term_area.y,
-            col: screen_col - term_area.x,
-        })
+        let (col, row) = relative_point(term_area, screen_col, screen_row)?;
+        Some(TermGridPos { row, col })
     }
 
     /// Map screen coordinates to terminal grid position, clamping to the
@@ -5461,14 +5936,7 @@ impl App {
     /// nearest boundary when the mouse leaves the terminal area.
     fn screen_to_grid_clamped(&self, screen_col: u16, screen_row: u16) -> Option<TermGridPos> {
         let term_area = self.mouse_layout.agent_term?;
-        let col = screen_col
-            .max(term_area.x)
-            .min(term_area.x + term_area.width.saturating_sub(1))
-            - term_area.x;
-        let row = screen_row
-            .max(term_area.y)
-            .min(term_area.y + term_area.height.saturating_sub(1))
-            - term_area.y;
+        let (col, row) = relative_point_clamped(term_area, screen_col, screen_row);
         Some(TermGridPos { row, col })
     }
 
@@ -5513,6 +5981,10 @@ impl App {
     /// Extract text from the terminal snapshot within the active selection
     /// and copy it to the system clipboard.
     fn copy_terminal_selection(&mut self) {
+        if matches!(self.fullscreen_overlay, FullscreenOverlay::StartupLog) {
+            self.copy_startup_log_selection();
+            return;
+        }
         let sel = match self.terminal_selection.clone() {
             Some(s) => s,
             None => return,
@@ -5573,6 +6045,142 @@ impl App {
             let _ = self.clipboard.copy_text(
                 &text,
                 "Terminal text copied to clipboard.",
+                &self.worker_tx,
+            );
+        }
+    }
+
+    fn screen_to_startup_log_grid(&self, screen_col: u16, screen_row: u16) -> Option<TermGridPos> {
+        let OverlayMouseLayout::StartupCommandLogs { body, .. } = self.overlay_layout.active else {
+            return None;
+        };
+        let (col, row) = relative_point(body, screen_col, screen_row)?;
+        let scroll_offset = match &self.prompt {
+            PromptState::StartupCommandLogs(prompt) => prompt.scroll_offset,
+            _ => 0,
+        };
+        Some(TermGridPos {
+            row: scroll_offset.saturating_add(row),
+            col,
+        })
+    }
+
+    fn screen_to_startup_log_grid_clamped(
+        &self,
+        screen_col: u16,
+        screen_row: u16,
+    ) -> Option<TermGridPos> {
+        let OverlayMouseLayout::StartupCommandLogs { body, .. } = self.overlay_layout.active else {
+            return None;
+        };
+        let scroll_offset = match &self.prompt {
+            PromptState::StartupCommandLogs(prompt) => prompt.scroll_offset,
+            _ => 0,
+        };
+        let (col, row) = relative_point_clamped(body, screen_col, screen_row);
+        Some(TermGridPos {
+            row: scroll_offset.saturating_add(row),
+            col,
+        })
+    }
+
+    fn handle_startup_log_selection_mouse(&mut self, mouse_ev: MouseEvent) -> bool {
+        match mouse_ev.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(pos) = self.screen_to_startup_log_grid(mouse_ev.column, mouse_ev.row) {
+                    self.startup_log_selection = Some(TerminalSelection {
+                        anchor: pos,
+                        end: pos,
+                        dragging: true,
+                    });
+                    return true;
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                let pos = self.screen_to_startup_log_grid_clamped(mouse_ev.column, mouse_ev.row);
+                if let Some(sel) = &mut self.startup_log_selection
+                    && sel.dragging
+                    && let Some(pos) = pos
+                {
+                    sel.end = pos;
+                    return true;
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(sel) = &mut self.startup_log_selection
+                    && sel.dragging
+                {
+                    sel.dragging = false;
+                    if sel.anchor == sel.end {
+                        self.startup_log_selection = None;
+                    } else {
+                        self.copy_startup_log_selection();
+                    }
+                    return true;
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn copy_startup_log_selection(&mut self) {
+        let (sel, content, width) = match (
+            self.fullscreen_overlay,
+            &self.startup_log_viewer,
+            self.mouse_layout.agent_term,
+            &self.prompt,
+            self.overlay_layout.active,
+        ) {
+            (FullscreenOverlay::StartupLog, Some(viewer), Some(body), _, _) => {
+                let Some(sel) = self.terminal_selection.clone() else {
+                    return;
+                };
+                (sel, viewer.content.clone(), body.width)
+            }
+            (
+                _,
+                _,
+                _,
+                PromptState::StartupCommandLogs(prompt),
+                OverlayMouseLayout::StartupCommandLogs { body, .. },
+            ) => {
+                let Some(sel) = self.startup_log_selection.clone() else {
+                    return;
+                };
+                (sel, prompt.content.clone(), body.width)
+            }
+            _ => return,
+        };
+        let lines = startup_command_log_visual_lines(&content, width);
+        let (start, end) = sel.ordered();
+        let mut selected = Vec::new();
+        for row in start.row..=end.row {
+            let Some(line) = lines.get(row as usize) else {
+                continue;
+            };
+            let start_col = if row == start.row {
+                start.col as usize
+            } else {
+                0
+            };
+            let end_col = if row == end.row {
+                end.col as usize + 1
+            } else {
+                line.chars().count()
+            };
+            let text = line
+                .chars()
+                .skip(start_col)
+                .take(end_col.saturating_sub(start_col))
+                .collect::<String>();
+            selected.push(text.trim_end().to_string());
+        }
+        let text = selected.join("\n");
+        if !text.is_empty() {
+            let _ = self.clipboard.copy_text(
+                &text,
+                "Startup command log text copied to clipboard.",
                 &self.worker_tx,
             );
         }
@@ -5665,7 +6273,8 @@ mod tests {
         MouseClickTarget, MouseLayoutState, NameNewAgentFocus, NonDefaultBranchAction,
         OverlayCheckbox, OverlayCheckboxId, OverlayMouseLayout, OverlayMouseLayoutState,
         PickProjectWorktreePrompt, ProcessInfo, ProjectWorktreeEntry, PromptState, PullTarget,
-        ResolvedPullRequest, ResourceStats, RightSection, RuntimeTargetId, TextInput, WorkerEvent,
+        ResolvedPullRequest, ResourceStats, RightSection, RuntimeTargetId, StartupCommandLogPrompt,
+        TextInput, WorkerEvent,
     };
     use crate::clipboard::Clipboard;
     use crate::config::{Config, DuxPaths, ProjectConfig};
@@ -5799,6 +6408,7 @@ mod tests {
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -5811,6 +6421,7 @@ mod tests {
                 default_provider: None,
                 leading_branch: project.leading_branch.clone(),
                 auto_reopen_agents: project.auto_reopen_agents,
+                startup_command: project.startup_command.clone(),
             })
             .expect("seed project");
         let session = AgentSession {
@@ -5867,6 +6478,7 @@ mod tests {
             last_help_height: 0,
             last_help_lines: 0,
             fullscreen_overlay: FullscreenOverlay::None,
+            startup_log_viewer: None,
             status: StatusLine::new("ready"),
             prompt: PromptState::None,
             input_target: InputTarget::None,
@@ -5933,6 +6545,7 @@ mod tests {
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            startup_log_selection: None,
             _single_instance_lock: single_instance_lock,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
@@ -5997,6 +6610,12 @@ mod tests {
             list: Rect::new(11, 9, 58, 10),
             items,
             offset: 0,
+        };
+    }
+
+    fn install_configure_startup_command_overlay(app: &mut App) {
+        app.overlay_layout.active = OverlayMouseLayout::ConfigureStartupCommand {
+            input: Rect::new(10, 6, 40, 4),
         };
     }
 
@@ -6129,6 +6748,43 @@ not_a_real_action = ["x"]
             items,
             offset: 0,
         };
+    }
+
+    fn install_startup_command_logs_overlay(app: &mut App, items: usize) {
+        app.overlay_layout.active = OverlayMouseLayout::StartupCommandLogs {
+            area: Rect::new(10, 3, 80, 18),
+            list: Rect::new(12, 5, 30, 12),
+            body: Rect::new(44, 5, 40, 12),
+            items,
+            offset: 0,
+            close_button: Rect::new(42, 18, 16, 3),
+        };
+    }
+
+    fn startup_command_logs_prompt() -> StartupCommandLogPrompt {
+        StartupCommandLogPrompt {
+            scope_label: "demo".to_string(),
+            entries: vec![
+                crate::startup::StartupCommandLogEntry {
+                    path: PathBuf::from("/tmp/startup-command.log"),
+                    display_name: "startup-command.log".to_string(),
+                    modified_at: None,
+                },
+                crate::startup::StartupCommandLogEntry {
+                    path: PathBuf::from("/tmp/install.log"),
+                    display_name: "install.log".to_string(),
+                    modified_at: None,
+                },
+            ],
+            selected: 0,
+            filter: TextInput::new(),
+            searching: false,
+            content: (0..30)
+                .map(|line| format!("startup command output line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            scroll_offset: 0,
+        }
     }
 
     fn install_confirm_delete_overlay(app: &mut App) {
@@ -6401,6 +7057,137 @@ not_a_real_action = ["x"]
         assert!(matches!(app.prompt, PromptState::RenameSession { .. }));
         assert_eq!(app.input_target, InputTarget::None);
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
+    }
+
+    #[test]
+    fn configure_startup_command_edit_mode_keeps_enter_in_input() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfigureStartupCommand {
+            project_id: "project-1".to_string(),
+            project_name: "demo".to_string(),
+            input: TextInput::with_text("npm install".to_string()).with_multiline(6),
+        };
+        app.input_target = InputTarget::StartupCommand;
+
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::ConfigureStartupCommand { input, .. } => {
+                assert_eq!(input.text, "npm install\nn");
+            }
+            other => panic!("expected configure startup command prompt, got {other:?}"),
+        }
+        assert_eq!(app.input_target, InputTarget::StartupCommand);
+    }
+
+    #[test]
+    fn configure_startup_command_escape_exits_edit_mode_only() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfigureStartupCommand {
+            project_id: "project-1".to_string(),
+            project_name: "demo".to_string(),
+            input: TextInput::with_text("npm install".to_string()).with_multiline(6),
+        };
+        app.input_target = InputTarget::StartupCommand;
+
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))
+            .unwrap();
+
+        assert!(matches!(
+            app.prompt,
+            PromptState::ConfigureStartupCommand { .. }
+        ));
+        assert_eq!(app.input_target, InputTarget::None);
+    }
+
+    #[test]
+    fn configure_startup_command_ctrl_d_clears_input() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfigureStartupCommand {
+            project_id: "project-1".to_string(),
+            project_name: "demo".to_string(),
+            input: TextInput::with_text("npm install".to_string()).with_multiline(6),
+        };
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::ConfigureStartupCommand { input, .. } => {
+                assert_eq!(input.text, "");
+                assert_eq!(input.cursor, 0);
+            }
+            other => panic!("expected configure startup command prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn configure_startup_command_double_click_enters_edit_mode() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfigureStartupCommand {
+            project_id: "project-1".to_string(),
+            project_name: "demo".to_string(),
+            input: TextInput::with_text("npm install\nnpm test".to_string()).with_multiline(6),
+        };
+        install_configure_startup_command_overlay(&mut app);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 14, 7));
+        assert_eq!(app.input_target, InputTarget::None);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 14, 7));
+
+        assert_eq!(app.input_target, InputTarget::StartupCommand);
+        match &app.prompt {
+            PromptState::ConfigureStartupCommand { input, .. } => {
+                assert!(input.cursor > 0);
+            }
+            other => panic!("expected configure startup command prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn configure_startup_command_empty_non_editing_shows_themed_placeholder() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::ConfigureStartupCommand {
+            project_id: "project-1".to_string(),
+            project_name: "demo".to_string(),
+            input: TextInput::new()
+                .with_multiline(6)
+                .with_placeholder("Enter startup command..."),
+        };
+        app.input_target = InputTarget::None;
+
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let buffer = terminal.backend().buffer();
+        let rendered: String = buffer.content.iter().map(|cell| cell.symbol()).collect();
+        assert!(
+            rendered.contains("Enter startup command..."),
+            "expected placeholder in non-editing mode, got: {rendered}"
+        );
+
+        let OverlayMouseLayout::ConfigureStartupCommand { input } = app.overlay_layout.active
+        else {
+            panic!("expected configure startup command overlay layout");
+        };
+        let placeholder_cell = (input.y..input.y + input.height)
+            .flat_map(|y| (input.x..input.x + input.width).map(move |x| (x, y)))
+            .find_map(|pos| {
+                let cell = buffer.cell(pos)?;
+                (cell.symbol() == "E").then_some(cell)
+            })
+            .expect("placeholder first cell");
+        assert_eq!(placeholder_cell.fg, app.theme.hint_desc_fg);
     }
 
     #[test]
@@ -7305,6 +8092,7 @@ not_a_real_action = ["x"]
                 status_message: "imported".to_string(),
                 repo_path: app.projects[0].path.clone(),
                 owns_worktree: false,
+                startup_result: None,
             },
         );
         app.worker_tx
@@ -8266,6 +9054,7 @@ not_a_real_action = ["x"]
                 default_provider: ProviderKind::from_str("codex"),
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
+                startup_command: None,
                 current_branch: "main".to_string(),
                 branch_status: ProjectBranchStatus::Unknown,
                 path_missing: false,
@@ -10589,6 +11378,308 @@ cyan = "#00ffff"
     }
 
     #[test]
+    fn startup_command_logs_click_outside_closes_modal() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 0, 0));
+
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn startup_command_logs_click_inside_does_not_close_modal() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 45, 6));
+
+        assert!(matches!(app.prompt, PromptState::StartupCommandLogs(_)));
+    }
+
+    #[test]
+    fn startup_command_logs_scroll_wheel_moves_output() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::ScrollDown, 45, 6));
+
+        match &app.prompt {
+            PromptState::StartupCommandLogs(prompt) => assert_eq!(prompt.scroll_offset, 3),
+            other => panic!("expected startup logs prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_command_logs_scroll_clamps_at_end() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        for _ in 0..20 {
+            app.handle_mouse(mouse(MouseEventKind::ScrollDown, 45, 6));
+        }
+
+        match &app.prompt {
+            PromptState::StartupCommandLogs(prompt) => assert_eq!(prompt.scroll_offset, 18),
+            other => panic!("expected startup logs prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_command_logs_page_scroll_uses_output_height() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        app.handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE))
+            .unwrap();
+
+        match &app.prompt {
+            PromptState::StartupCommandLogs(prompt) => assert_eq!(prompt.scroll_offset, 12),
+            other => panic!("expected startup logs prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn startup_command_logs_close_button_closes_modal() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 1);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 45, 19));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 45, 19));
+
+        assert!(matches!(app.prompt, PromptState::None));
+    }
+
+    #[test]
+    fn startup_command_logs_drag_selection_copies_text() {
+        let mut app = test_app(default_bindings());
+        app.clipboard = Clipboard::from_fn(clipboard_ok);
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 2);
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 44, 5));
+        app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 52, 5));
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 52, 5));
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+        assert_eq!(
+            app.status.text(),
+            "Startup command log text copied to clipboard."
+        );
+    }
+
+    #[test]
+    fn startup_command_logs_single_click_output_does_not_crash() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let body = match app.overlay_layout.active {
+            OverlayMouseLayout::StartupCommandLogs { body, .. } => body,
+            other => panic!("expected startup logs overlay, got {other:?}"),
+        };
+        let x = body.x;
+        let y = body.y;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame after down");
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x, y));
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame after up");
+
+        assert!(matches!(app.prompt, PromptState::StartupCommandLogs(_)));
+        assert!(app.startup_log_selection.is_none());
+    }
+
+    #[test]
+    fn startup_command_logs_prompt_disables_raw_input_routing() {
+        let mut app = test_app(default_bindings());
+        app.input_target = InputTarget::Agent;
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+
+        assert!(!app.should_poll_raw_input());
+    }
+
+    #[test]
+    fn startup_command_logs_single_click_run_does_not_crash() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let list = match app.overlay_layout.active {
+            OverlayMouseLayout::StartupCommandLogs { list, .. } => list,
+            other => panic!("expected startup logs overlay, got {other:?}"),
+        };
+        let x = list.x;
+        let y = list.y;
+
+        app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame after row click");
+
+        assert!(matches!(app.prompt, PromptState::StartupCommandLogs(_)));
+    }
+
+    #[test]
+    fn startup_command_logs_slash_filters_runs() {
+        let mut app = test_app(default_bindings());
+        app.prompt = PromptState::StartupCommandLogs(startup_command_logs_prompt());
+        install_startup_command_logs_overlay(&mut app, 2);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE))
+            .unwrap();
+        for ch in "install".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE))
+                .unwrap();
+        }
+
+        match &app.prompt {
+            PromptState::StartupCommandLogs(prompt) => {
+                assert!(prompt.searching);
+                assert_eq!(prompt.filter.text, "install");
+                assert_eq!(prompt.selected, 1);
+            }
+            other => panic!("expected startup logs prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_startup_command_logs_opens_latest_log_fullscreen() {
+        let mut app = test_app(default_bindings());
+        let log_dir = crate::startup::agent_log_dir(&app.paths, "project-1", "session-1");
+        std::fs::create_dir_all(&log_dir).expect("log dir");
+        std::fs::write(log_dir.join("20260515T010000Z-old.log"), "old log").expect("old log");
+        std::fs::write(log_dir.join("20260515T020000Z-new.log"), "new log").expect("new log");
+
+        app.open_startup_command_logs().expect("open logs");
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
+
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::StartupLog);
+        let viewer = app.startup_log_viewer.as_ref().expect("log viewer");
+        assert_eq!(viewer.display_name, "20260515T020000Z-new.log");
+        assert_eq!(viewer.content, "new log");
+    }
+
+    #[test]
+    fn startup_log_fullscreen_search_scrolls_to_match() {
+        let mut app = test_app(default_bindings());
+        app.startup_log_viewer = Some(crate::app::StartupLogViewer {
+            scope_label: "project \"demo\"".to_string(),
+            path: None,
+            display_name: "startup.log".to_string(),
+            content: (0..30)
+                .map(|line| {
+                    if line == 20 {
+                        "needle line".to_string()
+                    } else {
+                        format!("ordinary line {line}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+            scroll_offset: 0,
+            search: TextInput::new(),
+            searching: false,
+        });
+        app.fullscreen_overlay = FullscreenOverlay::StartupLog;
+        app.mouse_layout.agent_term = Some(Rect::new(0, 0, 80, 10));
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE))
+            .unwrap();
+        for ch in "needle".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE))
+                .unwrap();
+        }
+
+        let viewer = app.startup_log_viewer.as_ref().expect("log viewer");
+        assert!(viewer.searching);
+        assert_eq!(viewer.search.text, "needle");
+        assert_eq!(viewer.scroll_offset, 20);
+    }
+
+    #[test]
+    fn startup_log_fullscreen_drag_selection_copies_text() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        app.clipboard = Clipboard::from_fn(clipboard_ok);
+        app.startup_log_viewer = Some(crate::app::StartupLogViewer {
+            scope_label: "project \"demo\"".to_string(),
+            path: None,
+            display_name: "startup.log".to_string(),
+            content: "first line\nsecond line".to_string(),
+            scroll_offset: 0,
+            search: TextInput::new(),
+            searching: false,
+        });
+        app.fullscreen_overlay = FullscreenOverlay::StartupLog;
+
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+        let body = app.mouse_layout.agent_term.expect("log body");
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            body.x,
+            body.y,
+        ));
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            body.x + 4,
+            body.y,
+        ));
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame with selection");
+        app.handle_mouse(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            body.x + 4,
+            body.y,
+        ));
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        app.drain_events();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+        assert_eq!(
+            app.status.text(),
+            "Startup command log text copied to clipboard."
+        );
+    }
+
+    #[test]
     fn mouse_click_name_prompt_checkbox_toggles_randomized_name() {
         let mut app = test_app(default_bindings());
         app.create_agent_for_selected_project().unwrap();
@@ -12499,6 +13590,7 @@ cyan = "#00ffff"
             default_provider: ProviderKind::from_str("gemini"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -12511,6 +13603,7 @@ cyan = "#00ffff"
                 default_provider: Some("gemini".to_string()),
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
+                startup_command: None,
             })
             .expect("seed pinned project");
         app.projects.push(pinned);
@@ -12649,6 +13742,7 @@ cyan = "#00ffff"
             default_provider: ProviderKind::from_str("gemini"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -12661,6 +13755,7 @@ cyan = "#00ffff"
                 default_provider: Some("gemini".to_string()),
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
+                startup_command: None,
             })
             .expect("seed pinned project");
         app.projects.push(pinned);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,6 +83,7 @@ pub struct App {
     pub(crate) last_help_height: u16,
     pub(crate) last_help_lines: u16,
     pub(crate) fullscreen_overlay: FullscreenOverlay,
+    pub(crate) startup_log_viewer: Option<StartupLogViewer>,
     pub(crate) status: StatusLine,
     pub(crate) prompt: PromptState,
     pub(crate) input_target: InputTarget,
@@ -195,6 +196,8 @@ pub struct App {
     last_snapshot_id: Option<String>,
     /// Active text selection in the terminal viewport, if any.
     pub(crate) terminal_selection: Option<TerminalSelection>,
+    /// Active text selection in the startup command log output pane, if any.
+    pub(crate) startup_log_selection: Option<TerminalSelection>,
     /// Exclusive lock held for the lifetime of this `App` so only one dux
     /// instance runs against a given config directory. Released
     /// automatically on drop (including crashes), so there is nothing to
@@ -297,6 +300,7 @@ pub(crate) enum FullscreenOverlay {
     None,
     Agent,
     Terminal,
+    StartupLog,
 }
 
 #[derive(Clone, Debug)]
@@ -487,6 +491,28 @@ pub(crate) struct ChangeThemePrompt {
 }
 
 #[derive(Clone, Debug)]
+pub(crate) struct StartupCommandLogPrompt {
+    pub(crate) scope_label: String,
+    pub(crate) entries: Vec<crate::startup::StartupCommandLogEntry>,
+    pub(crate) selected: usize,
+    pub(crate) filter: TextInput,
+    pub(crate) searching: bool,
+    pub(crate) content: String,
+    pub(crate) scroll_offset: u16,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct StartupLogViewer {
+    pub(crate) scope_label: String,
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) display_name: String,
+    pub(crate) content: String,
+    pub(crate) scroll_offset: u16,
+    pub(crate) search: TextInput,
+    pub(crate) searching: bool,
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct ProjectWorktreeEntry {
     pub(crate) path: PathBuf,
     pub(crate) branch_name: String,
@@ -608,6 +634,13 @@ pub(crate) enum PromptState {
     ChangeDefaultProvider(ChangeDefaultProviderPrompt),
     ChangeProjectDefaultProvider(ChangeProjectDefaultProviderPrompt),
     ChangeTheme(ChangeThemePrompt),
+    ConfigureStartupCommand {
+        project_id: String,
+        project_name: String,
+        input: TextInput,
+    },
+    #[allow(dead_code)]
+    StartupCommandLogs(StartupCommandLogPrompt),
     PickProjectWorktree(PickProjectWorktreePrompt),
     KillRunning(KillRunningPrompt),
     ConfirmKillRunning(ConfirmKillRunningPrompt),
@@ -974,6 +1007,7 @@ pub(crate) enum InputTarget {
     Agent,
     Terminal,
     CommitMessage,
+    StartupCommand,
 }
 
 #[derive(Clone, Copy)]
@@ -1150,6 +1184,17 @@ pub(crate) enum OverlayMouseLayout {
         items: usize,
         offset: usize,
     },
+    StartupCommandLogs {
+        area: Rect,
+        list: Rect,
+        body: Rect,
+        items: usize,
+        offset: usize,
+        close_button: Rect,
+    },
+    ConfigureStartupCommand {
+        input: Rect,
+    },
     KillRunning {
         input: Option<Rect>,
         list: Rect,
@@ -1226,6 +1271,7 @@ pub(crate) enum MouseClickTarget {
     UnstagedPane,
     StagedPane,
     CommandPalette,
+    StartupCommandInput,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1343,6 +1389,7 @@ pub(crate) enum AgentLaunchKind {
         status_message: String,
         repo_path: String,
         owns_worktree: bool,
+        startup_result: Option<crate::startup::StartupCommandResult>,
     },
     Reconnect {
         status_message: String,
@@ -1498,6 +1545,15 @@ pub(crate) enum WorkerEvent {
         action: ProjectPersistenceAction,
         result: Result<(), String>,
     },
+    StartupCommandRerunCompleted(crate::startup::StartupCommandResult),
+    StartupCommandLogsLoaded {
+        scope_label: String,
+        result: Result<crate::startup::StartupCommandLatestLog, String>,
+    },
+    OpenPathCompleted {
+        target: String,
+        result: Result<(), String>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -1533,6 +1589,11 @@ pub(crate) enum ProjectPersistenceAction {
         project_id: String,
         project_name: String,
         auto_reopen_agents: Option<bool>,
+    },
+    UpdateStartupCommand {
+        project_id: String,
+        project_name: String,
+        startup_command: Option<String>,
     },
 }
 
@@ -1574,8 +1635,15 @@ impl App {
         signal_hook::flag::register(signal_hook::consts::SIGWINCH, Arc::clone(&sigwinch_flag))?;
 
         let session_store = SessionStore::open(&paths.sessions_db_path)?;
-        migrate_config_projects_to_store(&mut config, &paths, &bindings, &session_store)?;
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &session_store)?;
         let projects = load_projects(&session_store.load_projects()?, &config);
+        persist_runtime_projects_to_config_and_store(
+            &projects,
+            &mut config,
+            &paths,
+            &bindings,
+            &session_store,
+        )?;
         let sessions = session_store.load_sessions()?;
         let (worker_tx, worker_rx) = mpsc::channel();
         let watched_worktree: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
@@ -1627,6 +1695,7 @@ impl App {
             last_help_height: 0,
             last_help_lines: 0,
             fullscreen_overlay: FullscreenOverlay::None,
+            startup_log_viewer: None,
             status,
             prompt: PromptState::None,
             input_target: InputTarget::None,
@@ -1694,6 +1763,7 @@ impl App {
             snapshot_buf: TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            startup_log_selection: None,
             _single_instance_lock: single_instance_lock,
         };
         app.restore_sessions();
@@ -1742,10 +1812,7 @@ impl App {
                     continue;
                 }
 
-                if matches!(
-                    self.input_target,
-                    InputTarget::Agent | InputTarget::Terminal
-                ) {
+                if self.should_poll_raw_input() {
                     // Interactive mode: read raw stdin and forward to PTY.
                     // crossterm's event reader is not called — all bytes
                     // (keyboard, mouse, paste) go to the child process
@@ -1852,6 +1919,15 @@ impl App {
         result
     }
 
+    fn should_poll_raw_input(&self) -> bool {
+        matches!(self.prompt, PromptState::None)
+            && !matches!(self.fullscreen_overlay, FullscreenOverlay::StartupLog)
+            && matches!(
+                self.input_target,
+                InputTarget::Agent | InputTarget::Terminal
+            )
+    }
+
     fn restore_sessions(&mut self) {
         logger::info(&format!(
             "restoring {} persisted sessions",
@@ -1948,6 +2024,14 @@ impl App {
             self.set_info(format!(
                 "Closed fullscreen terminal. Press {key} to reopen."
             ));
+            return true;
+        }
+        if matches!(self.fullscreen_overlay, FullscreenOverlay::StartupLog) {
+            self.fullscreen_overlay = FullscreenOverlay::None;
+            self.startup_log_viewer = None;
+            self.terminal_selection = None;
+            self.startup_log_selection = None;
+            self.set_info("Closed startup command log.");
             return true;
         }
         if !matches!(self.prompt, PromptState::None) {
@@ -2122,6 +2206,26 @@ impl App {
             && matches!(self.gh_status, crate::model::GhStatus::Available)
     }
 
+    pub(crate) fn persist_config_projects_from_runtime(&mut self) -> Result<()> {
+        let existing_projects = self.config.projects.clone();
+        self.config.projects = self
+            .projects
+            .iter()
+            .map(|project| runtime_project_to_config(project, &existing_projects))
+            .collect();
+        save_config(&self.paths.config_path, &self.config, &self.bindings)
+    }
+
+    pub(crate) fn persist_projects_to_config_and_store(&mut self) -> Result<()> {
+        persist_runtime_projects_to_config_and_store(
+            &self.projects,
+            &mut self.config,
+            &self.paths,
+            &self.bindings,
+            &self.session_store,
+        )
+    }
+
     pub(crate) fn filtered_palette_commands(
         &self,
         input: &str,
@@ -2151,6 +2255,9 @@ impl App {
             "reload-config" => self.reload_config_from_disk(),
             "toggle-project-auto-reopen-agents" => self.toggle_project_auto_reopen_agents(),
             "toggle-agent-auto-reopen" => self.toggle_agent_auto_reopen(),
+            "configure-startup-command" => self.open_configure_startup_command(),
+            "rerun-startup-command-on-agent" => self.rerun_startup_command_on_agent(),
+            "read-startup-command-logs" => self.open_startup_command_logs(),
             "pull-project" => self.refresh_selected_project(),
             "delete-project" => self.delete_selected_project(),
             "remove-project" => self.remove_selected_project(),
@@ -2340,7 +2447,7 @@ impl App {
         };
     }
 
-    fn apply_reloaded_config(&mut self, config: Config) -> Result<()> {
+    fn apply_reloaded_config(&mut self, mut config: Config) -> Result<()> {
         let bindings = RuntimeBindings::from_keys_config(&config.keys);
         self.interactive_patterns = bindings.interactive_byte_patterns();
         self.bindings = bindings;
@@ -2355,6 +2462,14 @@ impl App {
         self.commit_pane_height_pct = config.ui.commit_pane_height_pct;
         self.github_integration_enabled = config.ui.github_integration;
         self.pr_banner_at_bottom = config.ui.pr_banner_position == "bottom";
+        self.projects = load_projects(&self.session_store.load_projects()?, &config);
+        persist_runtime_projects_to_config_and_store(
+            &self.projects,
+            &mut config,
+            &self.paths,
+            &self.bindings,
+            &self.session_store,
+        )?;
         self.config = config;
 
         refresh_project_defaults(&mut self.projects, &self.config);
@@ -3052,6 +3167,7 @@ pub(crate) fn load_projects(
             default_provider: provider,
             leading_branch,
             auto_reopen_agents: project.auto_reopen_agents,
+            startup_command: project.startup_command.clone(),
             current_branch,
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: missing,
@@ -3060,21 +3176,248 @@ pub(crate) fn load_projects(
     projects
 }
 
-pub(crate) fn migrate_config_projects_to_store(
+pub(crate) fn persist_runtime_projects_to_config_and_store(
+    projects: &[Project],
     config: &mut Config,
     paths: &DuxPaths,
     bindings: &RuntimeBindings,
     session_store: &SessionStore,
 ) -> Result<()> {
-    if config.projects.is_empty() {
-        return Ok(());
+    let existing_projects = config.projects.clone();
+    let stored_project_configs = projects
+        .iter()
+        .map(|project| runtime_project_to_config(project, &existing_projects))
+        .collect::<Vec<_>>();
+    let config_project_configs = stored_project_configs
+        .iter()
+        .cloned()
+        .map(|mut project| {
+            project.leading_branch = None;
+            project
+        })
+        .collect::<Vec<_>>();
+
+    let stored_projects = session_store.load_projects()?;
+    for (index, project_config) in stored_project_configs.iter().enumerate() {
+        let stored_project = stored_projects.iter().find(|stored| {
+            stored.id == project_config.id || same_expanded_project_path(stored, project_config)
+        });
+        if stored_project != Some(project_config) {
+            session_store.upsert_project_at(project_config, index as i64)?;
+        }
     }
 
-    for (index, project) in config.projects.iter().enumerate() {
-        session_store.upsert_project_at(project, index as i64)?;
+    if config.projects != config_project_configs {
+        config.projects = config_project_configs;
+        save_config(&paths.config_path, config, bindings)?;
     }
-    config.projects.clear();
-    save_config(&paths.config_path, config, bindings)
+
+    Ok(())
+}
+
+pub(crate) fn sync_config_projects_with_store(
+    config: &mut Config,
+    paths: &DuxPaths,
+    bindings: &RuntimeBindings,
+    session_store: &SessionStore,
+) -> Result<()> {
+    validate_project_records("config.toml", &config.projects)?;
+    let mut stored = session_store.load_projects()?;
+    validate_project_records("SQLite", &stored)?;
+
+    let mut changed_config = false;
+    let mut changed_store = false;
+    let mut merged = config.projects.clone();
+
+    for (index, cfg_project) in config.projects.iter().enumerate() {
+        match stored.iter().position(|stored_project| {
+            stored_project.id == cfg_project.id
+                || same_expanded_project_path(stored_project, cfg_project)
+        }) {
+            Some(stored_index) => {
+                let stored_project = &stored[stored_index];
+                let (merged_config_project, merged_stored_project) =
+                    merge_project_records(cfg_project, stored_project)?;
+                if &merged_config_project != cfg_project {
+                    merged[index] = merged_config_project;
+                    changed_config = true;
+                }
+                if &merged_stored_project != stored_project {
+                    session_store.upsert_project_at(&merged_stored_project, stored_index as i64)?;
+                    stored[stored_index] = merged_stored_project;
+                    changed_store = true;
+                }
+            }
+            None => {
+                session_store.upsert_project_at(cfg_project, index as i64)?;
+                changed_store = true;
+                stored.push(cfg_project.clone());
+            }
+        }
+    }
+
+    for stored_project in stored {
+        let exists = merged.iter().any(|cfg_project| {
+            cfg_project.id == stored_project.id
+                || same_expanded_project_path(cfg_project, &stored_project)
+        });
+        if !exists {
+            let mut portable = stored_project;
+            portable.path = portable_project_path(&portable.path);
+            merged.push(portable);
+            changed_config = true;
+        }
+    }
+
+    if changed_config {
+        config.projects = merged;
+        save_config(&paths.config_path, config, bindings)?;
+    } else if changed_store {
+        // Keep the on-disk config normalized when the database was repaired
+        // from config-only projects.
+        save_config(&paths.config_path, config, bindings)?;
+    }
+    Ok(())
+}
+
+fn validate_project_records(source: &str, projects: &[crate::config::ProjectConfig]) -> Result<()> {
+    for (index, project) in projects.iter().enumerate() {
+        for other in projects.iter().skip(index + 1) {
+            if project.id == other.id {
+                anyhow::bail!(
+                    "Project sync conflict in {source}: duplicate project id \"{}\". Remove or rename one [[projects]] entry, then restart dux.",
+                    project.id
+                );
+            }
+            if same_expanded_project_path(project, other) {
+                anyhow::bail!(
+                    "Project sync conflict in {source}: duplicate project path \"{}\". Remove one duplicate project entry, then restart dux.",
+                    expanded_project_path(project).unwrap_or_else(|| project.path.clone())
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn merge_project_records(
+    config_project: &crate::config::ProjectConfig,
+    stored_project: &crate::config::ProjectConfig,
+) -> Result<(crate::config::ProjectConfig, crate::config::ProjectConfig)> {
+    let config_path = expanded_project_path(config_project);
+    let stored_path = expanded_project_path(stored_project);
+    if config_project.id == stored_project.id && config_path != stored_path {
+        anyhow::bail!(
+            "Project sync conflict for id \"{}\": config.toml points to \"{}\" but SQLite points to \"{}\". Edit config.toml or remove/re-add the project so both stores agree.",
+            config_project.id,
+            config_project.path,
+            stored_project.path
+        );
+    }
+    if config_path == stored_path && config_project.id != stored_project.id {
+        anyhow::bail!(
+            "Project sync conflict for path \"{}\": config.toml uses id \"{}\" but SQLite uses id \"{}\". Edit config.toml or remove/re-add the project so both stores agree.",
+            config_path.unwrap_or_else(|| config_project.path.clone()),
+            config_project.id,
+            stored_project.id
+        );
+    }
+
+    let mut merged_config = config_project.clone();
+    let mut merged_stored = stored_project.clone();
+
+    sync_config_authoritative_project_field(&mut merged_config.name, &mut merged_stored.name);
+    sync_config_authoritative_project_field(
+        &mut merged_config.default_provider,
+        &mut merged_stored.default_provider,
+    );
+    if merged_stored.leading_branch.is_none() {
+        merged_stored.leading_branch = merged_config.leading_branch.clone();
+    }
+    merged_config.leading_branch = None;
+    sync_config_authoritative_project_field(
+        &mut merged_config.startup_command,
+        &mut merged_stored.startup_command,
+    );
+    sync_config_authoritative_project_field(
+        &mut merged_config.auto_reopen_agents,
+        &mut merged_stored.auto_reopen_agents,
+    );
+
+    Ok((merged_config, merged_stored))
+}
+
+fn sync_config_authoritative_project_field<T>(
+    config_value: &mut Option<T>,
+    stored_value: &mut Option<T>,
+) where
+    T: Clone,
+{
+    match config_value.as_ref() {
+        Some(config) => {
+            *stored_value = Some(config.clone());
+        }
+        None => {
+            *config_value = stored_value.clone();
+        }
+    }
+}
+
+fn same_expanded_project_path(
+    left: &crate::config::ProjectConfig,
+    right: &crate::config::ProjectConfig,
+) -> bool {
+    expanded_project_path(left).is_some_and(|left_path| {
+        expanded_project_path(right).is_some_and(|right_path| left_path == right_path)
+    })
+}
+
+fn expanded_project_path(project: &crate::config::ProjectConfig) -> Option<String> {
+    crate::config::expand_path(&project.path)
+}
+
+pub(crate) fn portable_project_path(path: &str) -> String {
+    let Some(home) = home::home_dir() else {
+        return path.to_string();
+    };
+    let path_buf = Path::new(path);
+    if let Ok(relative) = path_buf.strip_prefix(&home) {
+        let relative = relative.to_string_lossy();
+        if relative.is_empty() {
+            "$HOME".to_string()
+        } else {
+            format!("$HOME/{}", relative)
+        }
+    } else {
+        path.to_string()
+    }
+}
+
+pub(crate) fn runtime_project_to_config(
+    project: &Project,
+    existing_projects: &[crate::config::ProjectConfig],
+) -> crate::config::ProjectConfig {
+    let path = existing_projects
+        .iter()
+        .find(|existing| {
+            existing.id == project.id
+                && expanded_project_path(existing).is_some_and(|expanded| expanded == project.path)
+        })
+        .map(|existing| existing.path.clone())
+        .unwrap_or_else(|| portable_project_path(&project.path));
+
+    crate::config::ProjectConfig {
+        id: project.id.clone(),
+        path,
+        name: Some(project.name.clone()),
+        default_provider: project
+            .explicit_default_provider
+            .as_ref()
+            .map(|provider| provider.as_str().to_string()),
+        leading_branch: project.leading_branch.clone(),
+        auto_reopen_agents: project.auto_reopen_agents,
+        startup_command: project.startup_command.clone(),
+    }
 }
 
 // ── Resource monitor helpers ───────────────────────────────────────────────
@@ -3213,6 +3556,7 @@ mod tests {
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -3407,7 +3751,7 @@ mod tests {
     }
 
     #[test]
-    fn migrates_legacy_config_projects_to_sqlite_and_strips_config() {
+    fn config_only_project_is_synced_to_sqlite_and_preserved() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let root = dir.path().to_path_buf();
         let paths = DuxPaths {
@@ -3438,10 +3782,10 @@ leading_branch = "main"
         let bindings = RuntimeBindings::from_keys_config(&config.keys);
         let store = SessionStore::open(&paths.sessions_db_path).expect("store");
 
-        migrate_config_projects_to_store(&mut config, &paths, &bindings, &store)
-            .expect("migrate projects");
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+            .expect("sync projects");
 
-        assert!(config.projects.is_empty());
+        assert_eq!(config.projects.len(), 1);
         let projects = store.load_projects().expect("load projects");
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].id, "project-1");
@@ -3451,8 +3795,208 @@ leading_branch = "main"
         assert_eq!(projects[0].leading_branch.as_deref(), Some("main"));
 
         let saved = std::fs::read_to_string(&paths.config_path).expect("read config");
-        assert!(!saved.contains("[[projects]]"));
-        assert!(!saved.contains("project-1"));
+        assert!(saved.contains("[[projects]]"));
+        assert!(saved.contains("project-1"));
+        assert!(!saved.contains("leading_branch"));
+    }
+
+    #[test]
+    fn sqlite_only_project_is_written_to_config() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+            root: root.clone(),
+        };
+        paths.ensure_dirs().expect("dirs");
+        std::fs::write(&paths.config_path, "[defaults]\nprovider = \"codex\"\n").expect("config");
+        let mut config = ensure_config(&paths).expect("load config");
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let store = SessionStore::open(&paths.sessions_db_path).expect("store");
+        store
+            .upsert_project(&crate::config::ProjectConfig {
+                id: "project-db".to_string(),
+                path: root.join("repo").to_string_lossy().to_string(),
+                name: Some("repo".to_string()),
+                default_provider: Some("codex".to_string()),
+                leading_branch: Some("main".to_string()),
+                auto_reopen_agents: None,
+                startup_command: Some("npm install".to_string()),
+            })
+            .expect("seed project");
+
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+            .expect("sync projects");
+
+        assert_eq!(config.projects.len(), 1);
+        let saved = std::fs::read_to_string(&paths.config_path).expect("read config");
+        assert!(saved.contains("id = \"project-db\""));
+        assert!(saved.contains("startup_command = \"npm install\""));
+        assert!(!saved.contains("leading_branch"));
+    }
+
+    #[test]
+    fn config_project_backfills_missing_sqlite_optional_fields() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+            root: root.clone(),
+        };
+        paths.ensure_dirs().expect("dirs");
+        let repo = root.join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::fs::write(
+            &paths.config_path,
+            format!(
+                "[defaults]\nprovider = \"codex\"\n\n[[projects]]\nid = \"project-1\"\npath = \"{}\"\nname = \"repo\"\nleading_branch = \"main\"\n",
+                repo.display()
+            ),
+        )
+        .expect("config");
+        let mut config = ensure_config(&paths).expect("load config");
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let store = SessionStore::open(&paths.sessions_db_path).expect("store");
+        store
+            .upsert_project(&crate::config::ProjectConfig {
+                id: "project-1".to_string(),
+                path: repo.to_string_lossy().to_string(),
+                name: Some("repo".to_string()),
+                default_provider: None,
+                leading_branch: None,
+                auto_reopen_agents: None,
+                startup_command: None,
+            })
+            .expect("seed project");
+
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+            .expect("sync projects");
+
+        let projects = store.load_projects().expect("load projects");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].leading_branch.as_deref(), Some("main"));
+        let saved = std::fs::read_to_string(&paths.config_path).expect("read config");
+        assert!(!saved.contains("leading_branch"));
+    }
+
+    #[test]
+    fn derived_project_leading_branch_is_persisted_to_sqlite_only() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+            root: root.clone(),
+        };
+        paths.ensure_dirs().expect("dirs");
+        let repo = root.join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::process::Command::new("git")
+            .arg("init")
+            .arg(&repo)
+            .output()
+            .expect("git init");
+        std::process::Command::new("git")
+            .arg("checkout")
+            .arg("-b")
+            .arg("main")
+            .current_dir(&repo)
+            .output()
+            .expect("git checkout main");
+        std::fs::write(
+            &paths.config_path,
+            format!(
+                "[defaults]\nprovider = \"codex\"\n\n[[projects]]\nid = \"project-1\"\npath = \"{}\"\nname = \"repo\"\n",
+                repo.display()
+            ),
+        )
+        .expect("config");
+        let mut config = ensure_config(&paths).expect("load config");
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let store = SessionStore::open(&paths.sessions_db_path).expect("store");
+        store
+            .upsert_project(&crate::config::ProjectConfig {
+                id: "project-1".to_string(),
+                path: repo.to_string_lossy().to_string(),
+                name: Some("repo".to_string()),
+                default_provider: None,
+                leading_branch: None,
+                auto_reopen_agents: None,
+                startup_command: None,
+            })
+            .expect("seed project");
+
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+            .expect("sync projects");
+        let projects = load_projects(&store.load_projects().expect("load projects"), &config);
+        assert_eq!(projects[0].leading_branch.as_deref(), Some("main"));
+
+        persist_runtime_projects_to_config_and_store(
+            &projects,
+            &mut config,
+            &paths,
+            &bindings,
+            &store,
+        )
+        .expect("persist derived projects");
+
+        let saved = std::fs::read_to_string(&paths.config_path).expect("read config");
+        assert!(!saved.contains("leading_branch"));
+        let stored = store.load_projects().expect("reload projects");
+        assert_eq!(stored[0].leading_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn config_project_values_update_sqlite_on_sync() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let root = dir.path().to_path_buf();
+        let paths = DuxPaths {
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+            root: root.clone(),
+        };
+        paths.ensure_dirs().expect("dirs");
+        let repo = root.join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        std::fs::write(
+            &paths.config_path,
+            format!(
+                "[defaults]\nprovider = \"codex\"\n\n[[projects]]\nid = \"project-1\"\npath = \"{}\"\nname = \"repo\"\nstartup_command = \"npm install\"\n",
+                repo.display()
+            ),
+        )
+        .expect("config");
+        let mut config = ensure_config(&paths).expect("load config");
+        let bindings = RuntimeBindings::from_keys_config(&config.keys);
+        let store = SessionStore::open(&paths.sessions_db_path).expect("store");
+        store
+            .upsert_project(&crate::config::ProjectConfig {
+                id: "project-1".to_string(),
+                path: repo.to_string_lossy().to_string(),
+                name: Some("repo".to_string()),
+                default_provider: None,
+                leading_branch: None,
+                auto_reopen_agents: None,
+                startup_command: Some("pnpm install".to_string()),
+            })
+            .expect("seed project");
+
+        sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+            .expect("sync projects");
+
+        let projects = store.load_projects().expect("load projects");
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].startup_command.as_deref(), Some("npm install"));
     }
 
     #[test]
@@ -3591,6 +4135,7 @@ leading_branch = "main"
             default_provider: ProviderKind::new("codex"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Leading,
             path_missing: false,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3373,6 +3373,346 @@ impl App {
                     offset: state.offset(),
                 };
             }
+            PromptState::ConfigureStartupCommand {
+                project_name,
+                input,
+                ..
+            } => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect_exact(76, 16, frame.area());
+                self.clear_overlay_area(frame, area);
+                let outer = self.themed_overlay_block("Configure Startup Command");
+                let inner = outer.inner(area);
+                outer.render(area, frame.buffer_mut());
+                let [label_area, input_area, hint_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Length(2),
+                        Constraint::Min(3),
+                        Constraint::Length(1),
+                    ])
+                    .areas(inner);
+                Paragraph::new(vec![
+                    Line::from(vec![
+                        Span::styled(" Project: ", Style::default().fg(self.theme.input_label_fg)),
+                        Span::styled(
+                            project_name.clone(),
+                            Style::default().fg(self.theme.input_label_fg),
+                        ),
+                    ]),
+                    Line::from(Span::styled(
+                        " Enter a command to run before the provider launches:",
+                        Style::default().fg(self.theme.input_label_fg),
+                    )),
+                ])
+                .render(label_area, frame.buffer_mut());
+
+                let focused = self.input_target == InputTarget::StartupCommand;
+                let input_block = Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(if focused {
+                        self.theme.border_focused
+                    } else {
+                        self.theme.overlay_border
+                    }));
+                let text_area = input_block.inner(input_area);
+                input_block.render(input_area, frame.buffer_mut());
+
+                let mut render_input = input.clone();
+                render_input
+                    .set_display_width((text_area.width > 0).then_some(text_area.width as usize));
+                render_input.set_visible_lines(text_area.height as usize);
+                let visible = render_input.visible_lines();
+                let is_empty = render_input.is_empty();
+                if is_empty {
+                    if let Some(placeholder) = render_input.placeholder() {
+                        Paragraph::new(placeholder.to_string())
+                            .style(Style::default().fg(self.theme.hint_desc_fg))
+                            .render(text_area, frame.buffer_mut());
+                    }
+                } else {
+                    for (index, line_text) in visible.iter().enumerate() {
+                        if index >= text_area.height as usize {
+                            break;
+                        }
+                        let line_area =
+                            Rect::new(text_area.x, text_area.y + index as u16, text_area.width, 1);
+                        Paragraph::new(line_text.as_str()).render(line_area, frame.buffer_mut());
+                    }
+                }
+                if focused {
+                    let (cursor_row, cursor_col) = render_input.cursor_display_position();
+                    let cx = text_area.x + cursor_col as u16;
+                    let cy = text_area.y + cursor_row as u16;
+                    if cx < text_area.x + text_area.width && cy < text_area.y + text_area.height {
+                        frame.set_cursor_position((cx, cy));
+                    }
+                }
+
+                let confirm_key = self.bindings.label_for(Action::Confirm);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let edit_key = self.bindings.label_for(Action::EngageCommitInput);
+                let exit_key = self.bindings.labels_for(Action::ExitCommitInput);
+                let clear_key = "Ctrl-d";
+                let mut hints = vec![Span::raw(" ")];
+                if focused {
+                    hints.extend(self.theme.key_badge_default(&exit_key));
+                    hints.push(Span::styled(
+                        " exit edit  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hints.extend(self.theme.key_badge_default(clear_key));
+                    hints.push(Span::styled(
+                        " clear",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                } else {
+                    hints.extend(self.theme.key_badge_default(&edit_key));
+                    hints.push(Span::styled(
+                        " edit  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hints.extend(self.theme.key_badge_default(&confirm_key));
+                    hints.push(Span::styled(
+                        " save  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hints.extend(self.theme.key_badge_default(clear_key));
+                    hints.push(Span::styled(
+                        " clear  ",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                    hints.extend(self.theme.key_badge_default(&close_key));
+                    hints.push(Span::styled(
+                        " cancel",
+                        Style::default().fg(self.theme.hint_desc_fg),
+                    ));
+                }
+                Paragraph::new(Line::from(hints)).render(hint_area, frame.buffer_mut());
+                self.overlay_layout.active =
+                    OverlayMouseLayout::ConfigureStartupCommand { input: text_area };
+            }
+            PromptState::StartupCommandLogs(prompt) => {
+                self.render_dim_overlay(frame);
+                let area = centered_rect(92, 82, frame.area());
+                self.clear_overlay_area(frame, area);
+                let close_key = self.bindings.label_for(Action::CloseOverlay);
+                let mut bottom_spans = vec![Span::raw(" ")];
+                let move_keys = self.bindings.labels_for(Action::MoveDown);
+                let search_key = self.bindings.label_for(Action::SearchToggle);
+                let open_file_key = self.bindings.label_for(Action::OpenStartupCommandLogFile);
+                let open_folder_key = self.bindings.label_for(Action::OpenStartupCommandLogFolder);
+                bottom_spans.extend(self.theme.key_badge_default(&move_keys));
+                bottom_spans.push(Span::styled(
+                    " logs  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&search_key));
+                bottom_spans.push(Span::styled(
+                    " search  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default("PgUp/PgDn"));
+                bottom_spans.push(Span::styled(
+                    " scroll  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&open_file_key));
+                bottom_spans.push(Span::styled(
+                    " Open file  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&open_folder_key));
+                bottom_spans.push(Span::styled(
+                    " Open folder  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                bottom_spans.extend(self.theme.key_badge_default(&close_key));
+                bottom_spans.push(Span::styled(
+                    " close",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+
+                let title = format!("Startup Command Logs - {}", prompt.scope_label);
+                let block = self
+                    .themed_overlay_block(&title)
+                    .title_bottom(Line::from(bottom_spans))
+                    .border_style(Style::default().fg(self.theme.overlay_border));
+                let inner = block.inner(area);
+                block.render(area, frame.buffer_mut());
+                let [content_area, button_area] = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(6), Constraint::Length(3)])
+                    .areas(inner);
+                let [left_area, _, body_area] = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Length(34),
+                        Constraint::Length(1),
+                        Constraint::Min(20),
+                    ])
+                    .areas(content_area);
+                let (filter_area, list_area) = if prompt.searching || !prompt.filter.is_empty() {
+                    let [filter_area, list_area] = Layout::default()
+                        .direction(Direction::Vertical)
+                        .constraints([Constraint::Length(3), Constraint::Min(1)])
+                        .areas(left_area);
+                    (Some(filter_area), list_area)
+                } else {
+                    (None, left_area)
+                };
+                let visible_indices = Self::startup_command_log_filtered_indices(prompt);
+                let items = if prompt.entries.is_empty() {
+                    vec![ListItem::new("No logs")]
+                } else if visible_indices.is_empty() {
+                    vec![ListItem::new("No matching logs")]
+                } else {
+                    visible_indices
+                        .iter()
+                        .filter_map(|index| prompt.entries.get(*index))
+                        .map(|entry| {
+                            let modified = entry
+                                .modified_at
+                                .map(|ts| ts.format("%Y-%m-%d %H:%M:%S").to_string())
+                                .unwrap_or_else(|| "unknown time".to_string());
+                            ListItem::new(vec![
+                                Line::from(Span::styled(
+                                    entry.display_name.clone(),
+                                    Style::default()
+                                        .fg(self.theme.help_section_header_fg)
+                                        .add_modifier(Modifier::BOLD),
+                                )),
+                                Line::from(Span::styled(
+                                    modified,
+                                    Style::default().fg(self.theme.hint_desc_fg),
+                                )),
+                            ])
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let selected_visual =
+                    Self::startup_command_log_selected_visual_index(prompt, &visible_indices);
+                let mut state = ListState::default().with_selected(selected_visual);
+                if let Some(filter_area) = filter_area {
+                    let filter_block = Block::default()
+                        .title(" Filter ")
+                        .borders(Borders::ALL)
+                        .border_set(border::ROUNDED)
+                        .border_style(Style::default().fg(if prompt.searching {
+                            self.theme.border_focused
+                        } else {
+                            self.theme.overlay_border
+                        }))
+                        .style(Style::default().bg(self.theme.overlay_bg));
+                    let filter_inner = filter_block.inner(filter_area);
+                    filter_block.render(filter_area, frame.buffer_mut());
+                    let text = if prompt.filter.is_empty() && prompt.searching {
+                        "type to filter logs"
+                    } else {
+                        prompt.filter.text.as_str()
+                    };
+                    Paragraph::new(text)
+                        .style(Style::default().fg(if prompt.filter.is_empty() {
+                            self.theme.hint_desc_fg
+                        } else {
+                            self.theme.text_fg
+                        }))
+                        .render(filter_inner, frame.buffer_mut());
+                    if prompt.searching {
+                        let cursor_x = filter_inner
+                            .x
+                            .saturating_add(prompt.filter.cursor as u16)
+                            .min(filter_inner.x + filter_inner.width.saturating_sub(1));
+                        frame.set_cursor_position((cursor_x, filter_inner.y));
+                    }
+                }
+                let list_block = Block::default()
+                    .title(" Runs ")
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(self.theme.overlay_border))
+                    .style(Style::default().bg(self.theme.overlay_bg));
+                let list_inner = list_block.inner(list_area);
+                StatefulWidget::render(
+                    List::new(items)
+                        .block(list_block)
+                        .highlight_style(self.theme.selection_style()),
+                    list_area,
+                    frame.buffer_mut(),
+                    &mut state,
+                );
+                let body_block = Block::default()
+                    .title(" Output ")
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .border_style(Style::default().fg(self.theme.overlay_border))
+                    .style(Style::default().bg(self.theme.overlay_bg));
+                let body_inner = body_block.inner(body_area);
+                body_block.render(body_area, frame.buffer_mut());
+                let content_lines = crate::app::input::startup_command_log_visual_lines(
+                    &prompt.content,
+                    body_inner.width,
+                );
+                let max_scroll = u16::try_from(content_lines.len())
+                    .unwrap_or(u16::MAX)
+                    .saturating_sub(body_inner.height);
+                let scroll_offset = prompt.scroll_offset.min(max_scroll);
+                for (display_row, line) in content_lines
+                    .iter()
+                    .skip(scroll_offset as usize)
+                    .take(body_inner.height as usize)
+                    .enumerate()
+                {
+                    let y = body_inner.y + display_row as u16;
+                    for (display_col, ch) in
+                        line.chars().take(body_inner.width as usize).enumerate()
+                    {
+                        let x = body_inner.x + display_col as u16;
+                        let selected =
+                            self.startup_log_selection
+                                .as_ref()
+                                .is_some_and(|selection| {
+                                    selection.anchor != selection.end
+                                        && selection.contains(
+                                            scroll_offset + display_row as u16,
+                                            display_col as u16,
+                                        )
+                                });
+                        let style = if selected {
+                            self.theme.selection_style()
+                        } else {
+                            Style::default().fg(self.theme.text_fg)
+                        };
+                        frame.buffer_mut().set_string(x, y, ch.to_string(), style);
+                    }
+                }
+
+                let close_width = 16;
+                let close_area = Rect {
+                    x: button_area.x + button_area.width.saturating_sub(close_width) / 2,
+                    y: button_area.y,
+                    width: close_width.min(button_area.width),
+                    height: 3,
+                };
+                Button::new("Close")
+                    .kind(ButtonKind::Confirm)
+                    .state(button_state_for(
+                        ButtonPressedTarget::StartupCommandLogsClose,
+                        self.pressed_button,
+                        false,
+                        true,
+                    ))
+                    .render(frame, close_area, &self.theme);
+                self.overlay_layout.active = OverlayMouseLayout::StartupCommandLogs {
+                    area,
+                    list: list_inner,
+                    body: body_inner,
+                    items: visible_indices.len(),
+                    offset: state.offset(),
+                    close_button: close_area,
+                };
+            }
             PromptState::PickEditor {
                 session_label,
                 worktree_path,
@@ -5819,6 +6159,10 @@ impl App {
                 self.render_fullscreen_terminal(frame);
                 return;
             }
+            FullscreenOverlay::StartupLog => {
+                self.render_fullscreen_startup_log(frame);
+                return;
+            }
             FullscreenOverlay::None => {}
         }
         if !matches!(self.prompt, PromptState::None) {
@@ -5874,6 +6218,172 @@ impl App {
         self.session_surface = SessionSurface::Terminal;
         self.render_agent_terminal(frame, area, " Terminal ", true);
         self.session_surface = saved;
+    }
+
+    fn render_fullscreen_startup_log(&mut self, frame: &mut Frame) {
+        self.render_dim_overlay(frame);
+        let area = centered_rect(96, 94, frame.area());
+        Clear.render(area, frame.buffer_mut());
+        frame
+            .buffer_mut()
+            .set_style(area, Style::default().bg(self.theme.app_bg));
+
+        let title = self
+            .startup_log_viewer
+            .as_ref()
+            .map(|viewer| {
+                format!(
+                    " Startup command log · {} · {} ",
+                    viewer.scope_label, viewer.display_name
+                )
+            })
+            .unwrap_or_else(|| " Startup command log ".to_string());
+        let outer_block = self.themed_block(&title, true);
+        let inner = outer_block.inner(area);
+        outer_block.render(area, frame.buffer_mut());
+        if inner.height < 2 || inner.width < 4 {
+            return;
+        }
+
+        let [term_area, hint_area] = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(2)])
+            .areas(inner);
+        self.mouse_layout.agent_term = Some(term_area);
+
+        let Some(viewer) = &mut self.startup_log_viewer else {
+            return;
+        };
+        let lines =
+            crate::app::input::startup_command_log_visual_lines(&viewer.content, term_area.width);
+        let max_scroll = u16::try_from(lines.len())
+            .unwrap_or(u16::MAX)
+            .saturating_sub(term_area.height);
+        viewer.scroll_offset = viewer.scroll_offset.min(max_scroll);
+        let query = viewer.search.text.trim().to_lowercase();
+
+        for (row, line) in lines
+            .iter()
+            .skip(viewer.scroll_offset as usize)
+            .take(term_area.height as usize)
+            .enumerate()
+        {
+            let line_style = if !query.is_empty() && line.to_lowercase().contains(&query) {
+                self.theme.selection_style()
+            } else {
+                Style::default().fg(self.theme.text_fg)
+            };
+            let y = term_area.y + row as u16;
+            for (col, ch) in line.chars().take(term_area.width as usize).enumerate() {
+                let selected = self.terminal_selection.as_ref().is_some_and(|selection| {
+                    selection.anchor != selection.end
+                        && selection.contains(viewer.scroll_offset + row as u16, col as u16)
+                });
+                let style = if selected {
+                    self.theme.selection_style()
+                } else {
+                    line_style
+                };
+                frame
+                    .buffer_mut()
+                    .set_string(term_area.x + col as u16, y, ch.to_string(), style);
+            }
+        }
+
+        let close_key = self.bindings.label_for(Action::CloseOverlay);
+        let search_key = self.bindings.label_for(Action::SearchToggle);
+        let scroll_up = self.bindings.labels_for(Action::ScrollPageUp);
+        let scroll_down = self.bindings.labels_for(Action::ScrollPageDown);
+        let open_file = self.bindings.label_for(Action::OpenStartupCommandLogFile);
+        let open_folder = self.bindings.label_for(Action::OpenStartupCommandLogFolder);
+        let desc_style = Style::default().fg(self.theme.hint_dim_desc_fg);
+        let mut spans = Vec::new();
+        if viewer.searching {
+            spans.extend(self.theme.dim_key_badge_default(&close_key));
+            spans.push(Span::styled(" close search", desc_style));
+        } else {
+            spans.extend(self.theme.dim_key_badge_default(&close_key));
+            spans.push(Span::styled(" close  ", desc_style));
+            spans.extend(self.theme.dim_key_badge_default(&scroll_up));
+            spans.push(Span::styled("/", desc_style));
+            spans.extend(self.theme.dim_key_badge_default(&scroll_down));
+            spans.push(Span::styled(" scroll  ", desc_style));
+            spans.extend(self.theme.dim_key_badge_default(&search_key));
+            spans.push(Span::styled(" search  ", desc_style));
+            spans.extend(self.theme.dim_key_badge_default(&open_file));
+            spans.push(Span::styled(" Open file  ", desc_style));
+            spans.extend(self.theme.dim_key_badge_default(&open_folder));
+            spans.push(Span::styled(" Open folder", desc_style));
+        }
+        Paragraph::new(Line::from(spans))
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_style(Style::default().fg(self.theme.border_normal)),
+            )
+            .render(hint_area, frame.buffer_mut());
+
+        if self
+            .startup_log_viewer
+            .as_ref()
+            .is_some_and(|viewer| viewer.searching)
+        {
+            self.render_startup_log_search_bar(frame, inner);
+        }
+    }
+
+    fn render_startup_log_search_bar(&mut self, frame: &mut Frame, area: Rect) {
+        let Some(viewer) = &self.startup_log_viewer else {
+            return;
+        };
+        let query = viewer.search.text.clone();
+        let cursor = viewer.search.cursor.min(viewer.search.text.len());
+        if area.height < 3 {
+            return;
+        }
+
+        let bar_area = Rect::new(
+            area.x,
+            area.y + area.height.saturating_sub(3),
+            area.width,
+            3,
+        );
+        self.clear_overlay_area(frame, bar_area);
+
+        let mut bottom_spans = vec![Span::raw(" ")];
+        for (key, desc) in &[("Enter", "done"), ("Esc", "cancel")] {
+            let badge = self.theme.key_badge_default(key);
+            bottom_spans.extend(
+                badge
+                    .into_iter()
+                    .map(|s| Span::styled(s.content.to_string(), s.style)),
+            );
+            bottom_spans.push(Span::styled(
+                format!(" {desc}  "),
+                Style::default().fg(self.theme.hint_desc_fg),
+            ));
+        }
+
+        let input_block = self
+            .themed_overlay_block("Search log")
+            .title_bottom(Line::from(bottom_spans));
+        let input_inner = input_block.inner(bar_area);
+        Paragraph::new(render_single_line_cursor_input(
+            "/ ",
+            &query,
+            cursor,
+            self.theme.input_cursor_fg,
+            self.theme.input_cursor_bg,
+        ))
+        .block(input_block)
+        .render(bar_area, frame.buffer_mut());
+
+        let cursor_col = query[..cursor].chars().count() + 2;
+        let cx = input_inner.x + cursor_col as u16;
+        let cy = input_inner.y;
+        if cx < input_inner.x + input_inner.width && cy < input_inner.y + input_inner.height {
+            frame.set_cursor_position((cx, cy));
+        }
     }
 
     fn render_macro_bar(&mut self, frame: &mut Frame, area: Rect) {

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -157,6 +157,7 @@ impl App {
             default_provider: self.config.default_provider(),
             leading_branch: Some(leading_branch),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: branch,
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -899,6 +900,11 @@ impl App {
         // in-memory state first and the DB call then failed, the session
         // would vanish from the UI but reappear on restart.
         self.session_store.delete_session(&session.id)?;
+        Self::spawn_delete_startup_command_logs(
+            self.paths.clone(),
+            session.project_id.clone(),
+            session.id.clone(),
+        );
 
         self.providers.remove(&session.id);
         self.running_provider_pins.remove(&session.id);
@@ -963,8 +969,8 @@ impl App {
                 (false, true, Some(branch_already_deleted)) => {
                     if branch_already_deleted {
                         self.set_info(format!(
-                            "Deleted agent (branch \"{}\" was already removed)",
-                            session.branch_name
+                            "Deleted agent (branch \"{}\" was already removed).",
+                            session.branch_name,
                         ));
                     } else {
                         let project_name = project
@@ -972,10 +978,10 @@ impl App {
                             .map(|p| p.name.as_str())
                             .unwrap_or("<unknown>");
                         self.set_info(format!(
-                            "Deleted {} agent from project \"{}\" with branch \"{}\"",
+                            "Deleted {} agent from project \"{}\" with branch \"{}\".",
                             session.provider.as_str(),
                             project_name,
-                            session.branch_name
+                            session.branch_name,
                         ));
                     }
                 }
@@ -1380,6 +1386,260 @@ impl App {
             session.branch_name
         ));
         Ok(())
+    }
+
+    pub(crate) fn open_configure_startup_command(&mut self) -> Result<()> {
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::ConfigureStartupCommand {
+            project_id: project.id,
+            project_name: project.name.clone(),
+            input: TextInput::with_text(project.startup_command.unwrap_or_default())
+                .with_multiline(6)
+                .with_placeholder("Enter startup command..."),
+        };
+        self.input_target = InputTarget::None;
+        self.set_info("Enter a startup command for this project. Empty clears it.");
+        Ok(())
+    }
+
+    pub(crate) fn apply_configure_startup_command(&mut self) -> Result<()> {
+        let (project_id, project_name, command) = match &self.prompt {
+            PromptState::ConfigureStartupCommand {
+                project_id,
+                project_name,
+                input,
+            } => (
+                project_id.clone(),
+                project_name.clone(),
+                input.text.trim().to_string(),
+            ),
+            _ => return Ok(()),
+        };
+        self.prompt = PromptState::None;
+        self.input_target = InputTarget::None;
+        if !self.projects.iter().any(|project| project.id == project_id) {
+            self.set_error(format!("Could not find project \"{project_name}\"."));
+            return Ok(());
+        }
+        self.spawn_project_persistence(ProjectPersistenceAction::UpdateStartupCommand {
+            project_id,
+            project_name: project_name.clone(),
+            startup_command: (!command.is_empty()).then_some(command),
+        });
+        self.set_busy(format!(
+            "Saving startup command for project \"{project_name}\"..."
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn rerun_startup_command_on_agent(&mut self) -> Result<()> {
+        let Some(session) = self.selected_session().cloned() else {
+            self.set_error("Select an agent first.");
+            return Ok(());
+        };
+        let Some(project) = self
+            .projects
+            .iter()
+            .find(|project| project.id == session.project_id)
+            .cloned()
+        else {
+            self.set_error("Could not find the selected agent's project.");
+            return Ok(());
+        };
+        let Some(command) = project
+            .startup_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|command| !command.is_empty())
+            .map(str::to_string)
+        else {
+            self.set_error(format!(
+                "Project \"{}\" does not have a startup command.",
+                project.name
+            ));
+            return Ok(());
+        };
+        let paths = self.paths.clone();
+        let tx = self.worker_tx.clone();
+        let branch = session.branch_name.clone();
+        let terminal = self.config.startup_command_terminal.clone();
+        std::thread::spawn(move || {
+            let result = crate::startup::run_startup_command(
+                &paths,
+                crate::startup::StartupCommandRun {
+                    project,
+                    session,
+                    command,
+                    terminal,
+                },
+            );
+            let _ = tx.send(WorkerEvent::StartupCommandRerunCompleted(result));
+        });
+        self.set_busy(format!(
+            "Rerunning startup command for agent \"{branch}\"..."
+        ));
+        Ok(())
+    }
+
+    pub(crate) fn open_startup_command_logs(&mut self) -> Result<()> {
+        let (scope_label, scope) = if let Some(session) = self.selected_session().cloned() {
+            let project_name = self.project_name_for_session(&session);
+            (
+                format!(
+                    "agent \"{}\" in project \"{}\"",
+                    session.branch_name, project_name
+                ),
+                crate::startup::StartupCommandLogScope::Agent {
+                    project_id: session.project_id,
+                    session_id: session.id,
+                },
+            )
+        } else if let Some(project) = self.selected_project().cloned() {
+            (
+                format!("project \"{}\"", project.name),
+                crate::startup::StartupCommandLogScope::Project {
+                    project_id: project.id,
+                },
+            )
+        } else {
+            self.set_error("Select an agent or project first.");
+            return Ok(());
+        };
+
+        self.spawn_startup_command_log_load(scope_label, scope);
+        Ok(())
+    }
+
+    pub(crate) fn select_startup_command_log(&mut self, selected: usize) {
+        let Some((path, count)) = (match &self.prompt {
+            PromptState::StartupCommandLogs(prompt) => prompt
+                .entries
+                .get(selected)
+                .map(|entry| (entry.path.clone(), prompt.entries.len())),
+            _ => None,
+        }) else {
+            return;
+        };
+        let content = crate::startup::read_log(&path)
+            .unwrap_or_else(|err| format!("Could not read {}: {err:#}", path.display()));
+        if let PromptState::StartupCommandLogs(prompt) = &mut self.prompt {
+            prompt.selected = selected.min(count.saturating_sub(1));
+            prompt.content = content;
+            prompt.scroll_offset = 0;
+        }
+        self.startup_log_selection = None;
+    }
+
+    pub(crate) fn startup_command_log_filtered_indices(
+        prompt: &StartupCommandLogPrompt,
+    ) -> Vec<usize> {
+        let query = prompt.filter.text.trim().to_lowercase();
+        prompt
+            .entries
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| {
+                (query.is_empty() || entry.display_name.to_lowercase().contains(&query))
+                    .then_some(index)
+            })
+            .collect()
+    }
+
+    pub(crate) fn startup_command_log_selected_visual_index(
+        prompt: &StartupCommandLogPrompt,
+        visible_indices: &[usize],
+    ) -> Option<usize> {
+        visible_indices
+            .iter()
+            .position(|index| *index == prompt.selected)
+    }
+
+    pub(crate) fn select_startup_command_log_visual_index(&mut self, visual_index: usize) {
+        let Some(actual_index) = (match &self.prompt {
+            PromptState::StartupCommandLogs(prompt) => {
+                Self::startup_command_log_filtered_indices(prompt)
+                    .get(visual_index)
+                    .copied()
+            }
+            _ => None,
+        }) else {
+            return;
+        };
+        self.select_startup_command_log(actual_index);
+    }
+
+    pub(crate) fn open_selected_startup_command_log(&mut self) {
+        let Some(path) = self
+            .startup_log_viewer
+            .as_ref()
+            .and_then(|viewer| viewer.path.clone())
+        else {
+            self.set_error("No startup command log is selected.");
+            return;
+        };
+        self.spawn_open_path(path, "startup command log file");
+    }
+
+    pub(crate) fn open_selected_startup_command_log_folder(&mut self) {
+        let Some(path) = self
+            .startup_log_viewer
+            .as_ref()
+            .and_then(|viewer| viewer.path.as_ref())
+            .and_then(|path| path.parent().map(Path::to_path_buf))
+        else {
+            self.set_error("No startup command log folder is selected.");
+            return;
+        };
+        self.spawn_open_path(path, "startup command log folder");
+    }
+
+    fn spawn_open_path(&mut self, path: PathBuf, target: &'static str) {
+        let display = path.display().to_string();
+        let tx = self.worker_tx.clone();
+        std::thread::spawn(move || {
+            let result = crate::startup::open_path(&path).map_err(|err| format!("{err:#}"));
+            let _ = tx.send(WorkerEvent::OpenPathCompleted {
+                target: target.to_string(),
+                result,
+            });
+        });
+        self.set_busy(format!("Opening {target}: {display}"));
+    }
+
+    fn spawn_startup_command_log_load(
+        &mut self,
+        scope_label: String,
+        scope: crate::startup::StartupCommandLogScope,
+    ) {
+        let paths = self.paths.clone();
+        let tx = self.worker_tx.clone();
+        let status_label = scope_label.clone();
+        std::thread::spawn(move || {
+            let result = crate::startup::latest_log_for_scope(&paths, scope)
+                .map_err(|err| format!("{err:#}"));
+            let _ = tx.send(WorkerEvent::StartupCommandLogsLoaded {
+                scope_label,
+                result,
+            });
+        });
+        self.set_busy(format!(
+            "Opening startup command logs for {status_label}..."
+        ));
+    }
+
+    fn spawn_delete_startup_command_logs(paths: DuxPaths, project_id: String, session_id: String) {
+        std::thread::spawn(move || {
+            if let Err(err) = crate::startup::delete_agent_logs(&paths, &project_id, &session_id) {
+                logger::error(&format!(
+                    "failed to delete startup command logs for session {session_id}: {err:#}"
+                ));
+            }
+        });
     }
 
     pub(crate) fn open_change_theme_prompt(&mut self) -> Result<()> {
@@ -2338,6 +2598,7 @@ mod tests {
             last_help_height: 0,
             last_help_lines: 0,
             fullscreen_overlay: FullscreenOverlay::None,
+            startup_log_viewer: None,
             status: StatusLine::new("ready"),
             prompt: PromptState::None,
             input_target: InputTarget::None,
@@ -2404,6 +2665,7 @@ mod tests {
             snapshot_buf: crate::pty::TerminalSnapshot::empty(),
             last_snapshot_id: None,
             terminal_selection: None,
+            startup_log_selection: None,
             _single_instance_lock: single_instance_lock,
         };
         app.interactive_patterns = app.bindings.interactive_byte_patterns();
@@ -2440,6 +2702,7 @@ mod tests {
             default_provider: ProviderKind::from_str(provider),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -2593,6 +2856,7 @@ mod tests {
             default_provider: ProviderKind::from_str(provider),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -462,6 +462,11 @@ impl App {
                                     ProjectBranchStatus::NotLeading
                                 };
                         }
+                        if let Err(err) = self.persist_projects_to_config_and_store() {
+                            self.set_error(format!(
+                                "Project branch was detected, but config.toml could not be updated: {err:#}"
+                            ));
+                        }
                         if let Err(err) =
                             self.continue_create_agent_after_branch_inspection(project, inspection)
                         {
@@ -562,6 +567,46 @@ impl App {
                 WorkerEvent::ProjectPersistenceCompleted { action, result } => {
                     self.apply_project_persistence_result(action, result);
                 }
+                WorkerEvent::StartupCommandRerunCompleted(result) => match result.status {
+                    Ok(()) => {
+                        let palette_key = self.bindings.label_for(Action::OpenPalette);
+                        self.set_info(format!(
+                            "Startup command completed for project \"{}\". Press {palette_key} and run read-startup-command-logs to view the latest log.",
+                            result.project_name
+                        ));
+                    }
+                    Err(err) => self.set_error(format!(
+                        "Startup command failed for project \"{}\": {err}. Run read-startup-command-logs for details.",
+                        result.project_name
+                    )),
+                },
+                WorkerEvent::StartupCommandLogsLoaded {
+                    scope_label,
+                    result,
+                } => match result {
+                    Ok(log) => {
+                        self.input_target = InputTarget::None;
+                        self.terminal_selection = None;
+                        self.prompt = PromptState::None;
+                        self.fullscreen_overlay = FullscreenOverlay::StartupLog;
+                        self.startup_log_viewer = Some(StartupLogViewer {
+                            scope_label,
+                            path: log.path,
+                            display_name: log.display_name,
+                            content: log.content,
+                            scroll_offset: 0,
+                            search: TextInput::new(),
+                            searching: false,
+                        });
+                    }
+                    Err(err) => self.set_error(format!(
+                        "Could not read startup command logs for {scope_label}: {err}"
+                    )),
+                },
+                WorkerEvent::OpenPathCompleted { target, result } => match result {
+                    Ok(()) => self.set_info(format!("Opened {target}.")),
+                    Err(err) => self.set_error(format!("Could not open {target}: {err}")),
+                },
             }
         }
         self.retry_hung_resume_sessions();
@@ -744,6 +789,11 @@ impl App {
                         "Could not save the auto-reopen change for project \"{project_name}\": {err}"
                     ));
                 }
+                ProjectPersistenceAction::UpdateStartupCommand { project_name, .. } => {
+                    self.set_error(format!(
+                        "Could not save the startup command for project \"{project_name}\": {err}"
+                    ));
+                }
             }
             return;
         }
@@ -761,6 +811,12 @@ impl App {
                 }) {
                     self.selected_left = index;
                 }
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Project was saved to the database, but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
                 self.set_info(status_message);
             }
             ProjectPersistenceAction::Remove {
@@ -770,6 +826,12 @@ impl App {
                 self.projects.retain(|project| project.id != project_id);
                 self.rebuild_left_items();
                 self.selected_left = self.selected_left.saturating_sub(1);
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Project was removed from the database, but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
                 self.set_info(format!("Removed project \"{project_name}\" from app"));
             }
             ProjectPersistenceAction::Delete {
@@ -780,6 +842,12 @@ impl App {
                 self.rebuild_left_items();
                 self.selected_left = self.selected_left.saturating_sub(1);
                 self.reload_changed_files();
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Project was deleted from the database, but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
                 self.set_info(format!(
                     "Deleted project \"{project_name}\" and all its agents"
                 ));
@@ -799,6 +867,12 @@ impl App {
                 }
                 refresh_project_defaults(&mut self.projects, &self.config);
                 self.rebuild_left_items();
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Provider preference saved to the database for \"{project_name}\", but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
                 let message = match provider {
                     Some(provider) => format!(
                         "Project provider for \"{}\" changed to {}. Future agents in this project will use it; existing agents keep their current provider.",
@@ -825,12 +899,45 @@ impl App {
                 {
                     project.auto_reopen_agents = auto_reopen_agents;
                 }
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Auto-reopen preference saved to the database for \"{project_name}\", but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
                 let enabled = auto_reopen_agents.unwrap_or(true);
                 self.set_info(format!(
                     "Startup auto-reopen {} for project \"{}\".",
                     if enabled { "enabled" } else { "disabled" },
                     project_name
                 ));
+            }
+            ProjectPersistenceAction::UpdateStartupCommand {
+                project_id,
+                project_name,
+                startup_command,
+            } => {
+                if let Some(project) = self
+                    .projects
+                    .iter_mut()
+                    .find(|project| project.id == project_id)
+                {
+                    project.startup_command = startup_command.clone();
+                }
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Startup command saved to the database for \"{project_name}\", but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
+                match startup_command {
+                    Some(command) => self.set_info(format!(
+                        "Startup command for project \"{project_name}\" set to: {command}"
+                    )),
+                    None => self.set_info(format!(
+                        "Startup command cleared for project \"{project_name}\"."
+                    )),
+                }
             }
         }
     }
@@ -853,6 +960,7 @@ impl App {
                                 .map(|provider| provider.as_str().to_string()),
                             leading_branch: project.leading_branch.clone(),
                             auto_reopen_agents: project.auto_reopen_agents,
+                            startup_command: project.startup_command.clone(),
                         })?;
                     }
                     ProjectPersistenceAction::Remove { project_id, .. }
@@ -875,6 +983,16 @@ impl App {
                         ..
                     } => {
                         store.update_project_auto_reopen(project_id, *auto_reopen_agents)?;
+                    }
+                    ProjectPersistenceAction::UpdateStartupCommand {
+                        project_id,
+                        startup_command,
+                        ..
+                    } => {
+                        store.update_project_startup_command(
+                            project_id,
+                            startup_command.as_deref(),
+                        )?;
                     }
                 }
                 Ok(())
@@ -920,8 +1038,22 @@ impl App {
             self.show_agent_surface();
             self.input_target = InputTarget::Agent;
             self.fullscreen_overlay = FullscreenOverlay::Agent;
-            if let AgentLaunchKind::Create { status_message, .. } = request.kind {
-                self.set_info(status_message);
+            if let AgentLaunchKind::Create {
+                status_message,
+                startup_result,
+                ..
+            } = request.kind
+            {
+                if let Some(result) = startup_result
+                    && let Err(err) = result.status
+                {
+                    self.set_error(format!(
+                        "Startup command failed for agent \"{}\": {err}. Run read-startup-command-logs for details.",
+                        session.branch_name
+                    ));
+                } else {
+                    self.set_info(status_message);
+                }
             }
             return;
         }
@@ -1343,10 +1475,31 @@ impl App {
         thread::spawn(move || {
             let result = crate::config::ensure_config(&paths)
                 .map_err(|err| format!("{err:#}"))
-                .and_then(|config| match crate::config::validate_keys(&config.keys) {
-                    Ok(()) => Ok(config),
-                    Err(message) => Err(message),
-                });
+                .and_then(
+                    |mut config| match crate::config::validate_keys(&config.keys) {
+                        Ok(()) => {
+                            let bindings = RuntimeBindings::from_keys_config(&config.keys);
+                            let store = SessionStore::open(&paths.sessions_db_path)
+                                .map_err(|err| format!("{err:#}"))?;
+                            sync_config_projects_with_store(&mut config, &paths, &bindings, &store)
+                                .map_err(|err| format!("{err:#}"))?;
+                            let projects = load_projects(
+                                &store.load_projects().map_err(|err| format!("{err:#}"))?,
+                                &config,
+                            );
+                            persist_runtime_projects_to_config_and_store(
+                                &projects,
+                                &mut config,
+                                &paths,
+                                &bindings,
+                                &store,
+                            )
+                            .map_err(|err| format!("{err:#}"))?;
+                            Ok(config)
+                        }
+                        Err(message) => Err(message),
+                    },
+                );
             let _ = tx.send(WorkerEvent::ConfigReloadReady(Box::new(result)));
         });
     }
@@ -2033,6 +2186,40 @@ pub(crate) fn run_create_agent_job(
         let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(hint));
         return;
     }
+    let startup_result = project
+        .startup_command
+        .as_deref()
+        .map(str::trim)
+        .filter(|command| !command.is_empty())
+        .map(|command| {
+            let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                "Running startup command for agent \"{}\"...",
+                session.branch_name
+            )));
+            crate::startup::run_startup_command(
+                &paths,
+                crate::startup::StartupCommandRun {
+                    project: project.clone(),
+                    session: session.clone(),
+                    command: command.to_string(),
+                    terminal: config.startup_command_terminal.clone(),
+                },
+            )
+        });
+    if let Some(result) = &startup_result {
+        match &result.status {
+            Ok(()) => logger::info(&format!(
+                "startup command succeeded for {} (log: {})",
+                result.session_id,
+                result.log_path.display()
+            )),
+            Err(err) => logger::error(&format!(
+                "startup command failed for {}: {err} (log: {})",
+                result.session_id,
+                result.log_path.display()
+            )),
+        }
+    }
     let launch_message = if launch_with_resume {
         format!(
             "Continuing {} in the existing worktree...",
@@ -2057,6 +2244,7 @@ pub(crate) fn run_create_agent_job(
             status_message,
             repo_path: repo_path.to_string_lossy().to_string(),
             owns_worktree,
+            startup_result,
         },
     };
     run_agent_launch_job(request, worker_tx);
@@ -2475,6 +2663,7 @@ mod tests {
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -2538,6 +2727,7 @@ mod tests {
             default_provider: ProviderKind::from_str("codex"),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: None,
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub defaults: Defaults,
     pub providers: ProvidersConfig,
     pub terminal: TerminalConfig,
+    pub startup_command_terminal: StartupCommandTerminalConfig,
     pub logging: LoggingConfig,
     pub projects: Vec<ProjectConfig>,
     pub ui: UiConfig,
@@ -139,6 +140,13 @@ pub struct TerminalConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
+pub struct StartupCommandTerminalConfig {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct LoggingConfig {
     pub level: String,
     pub path: String,
@@ -179,6 +187,7 @@ pub struct ProjectConfig {
     pub default_provider: Option<String>,
     pub leading_branch: Option<String>,
     pub auto_reopen_agents: Option<bool>,
+    pub startup_command: Option<String>,
 }
 
 fn new_project_id() -> String {
@@ -214,6 +223,7 @@ impl Default for Config {
             defaults: Defaults::default(),
             providers: ProvidersConfig::default(),
             terminal: TerminalConfig::default(),
+            startup_command_terminal: StartupCommandTerminalConfig::default(),
             logging: LoggingConfig {
                 level: "info".to_string(),
                 path: "dux.log".to_string(),
@@ -333,6 +343,15 @@ impl Default for TerminalConfig {
         Self {
             command: default_terminal_command(),
             args: default_terminal_args(),
+        }
+    }
+}
+
+impl Default for StartupCommandTerminalConfig {
+    fn default() -> Self {
+        Self {
+            command: "$SHELL".to_string(),
+            args: vec!["-l".to_string(), "-c".to_string()],
         }
     }
 }
@@ -588,8 +607,12 @@ enum ConfigEntry {
     },
     /// Renders all `[providers.*]` sub-tables dynamically.
     Providers,
+    /// Renders `[[projects]]` declarations.
+    Projects,
     /// Renders the `[terminal]` section.
     Terminal,
+    /// Renders the `[startup_command_terminal]` section.
+    StartupCommandTerminal,
     /// Renders the `[keys]` section with all keybindings.
     Keys,
     /// Renders the `[macros]` section with text macros.
@@ -650,8 +673,11 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             value_fn: |c| FieldValue::Bool(c.defaults.pull_before_creating_agent_by_default),
         },
         ConfigEntry::Blank,
+        ConfigEntry::Projects,
+        ConfigEntry::Blank,
         ConfigEntry::Providers,
         ConfigEntry::Terminal,
+        ConfigEntry::StartupCommandTerminal,
         ConfigEntry::Section("logging"),
         ConfigEntry::Field {
             key: "level",
@@ -838,7 +864,11 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
                 }
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
+            ConfigEntry::Projects => render_project_configs(&mut out, &config.projects),
             ConfigEntry::Terminal => render_terminal_config(&mut out, &config.terminal),
+            ConfigEntry::StartupCommandTerminal => {
+                render_startup_command_terminal_config(&mut out, &config.startup_command_terminal);
+            }
             ConfigEntry::Keys => render_keys_config(&mut out, &config.keys, bindings),
             ConfigEntry::Macros => render_macros_config(&mut out, &config.macros, bindings),
         }
@@ -994,6 +1024,20 @@ pub fn save_config(
     patch_table_str(&mut doc, "terminal", "command", &config.terminal.command);
     patch_table_string_array(&mut doc, "terminal", "args", &config.terminal.args);
 
+    // --- [startup_command_terminal] ---
+    patch_table_str(
+        &mut doc,
+        "startup_command_terminal",
+        "command",
+        &config.startup_command_terminal.command,
+    );
+    patch_table_string_array(
+        &mut doc,
+        "startup_command_terminal",
+        "args",
+        &config.startup_command_terminal.args,
+    );
+
     // --- [keys] ---
     patch_table_bool(
         &mut doc,
@@ -1019,10 +1063,8 @@ pub fn save_config(
     // --- [providers.*] ---
     patch_providers(&mut doc, &config.providers);
 
-    // --- legacy [[projects]] ---
-    // Projects now live in SQLite. Saving config always strips any legacy
-    // project declarations after they have been migrated by the app bootstrap.
-    let _ = doc.remove("projects");
+    // --- [[projects]] ---
+    patch_projects(&mut doc, &config.projects);
 
     // --- [macros] ---
     patch_macros(&mut doc, &config.macros);
@@ -1191,6 +1233,34 @@ fn patch_macros(doc: &mut DocumentMut, macros: &MacrosConfig) {
         );
         table[name] = toml_edit::value(Value::InlineTable(inline));
     }
+}
+
+fn patch_projects(doc: &mut DocumentMut, projects: &[ProjectConfig]) {
+    let _ = doc.remove("projects");
+    if projects.is_empty() {
+        return;
+    }
+
+    let mut array = toml_edit::ArrayOfTables::new();
+    for project in projects {
+        let mut table = Table::new();
+        table["id"] = toml_edit::value(project.id.as_str());
+        table["path"] = toml_edit::value(project.path.as_str());
+        if let Some(name) = project.name.as_deref() {
+            table["name"] = toml_edit::value(name);
+        }
+        if let Some(provider) = project.default_provider.as_deref() {
+            table["default_provider"] = toml_edit::value(provider);
+        }
+        if let Some(auto_reopen_agents) = project.auto_reopen_agents {
+            table["auto_reopen_agents"] = toml_edit::value(auto_reopen_agents);
+        }
+        if let Some(command) = project.startup_command.as_deref() {
+            table["startup_command"] = toml_edit::value(command);
+        }
+        array.push(table);
+    }
+    doc["projects"] = Item::ArrayOfTables(array);
 }
 
 fn render_keys_config(
@@ -1447,6 +1517,54 @@ fn render_provider_configs(out: &mut String, providers: &ProvidersConfig) {
     }
 }
 
+fn render_project_configs(out: &mut String, projects: &[ProjectConfig]) {
+    out.push_str(
+        "# Projects are mirrored with dux's runtime database.\n\
+         # Paths may use $HOME, ${HOME}, or ~ for portability across machines.\n\
+         # startup_command runs in each new agent worktree before the provider launches.\n",
+    );
+    if projects.is_empty() {
+        out.push_str(
+            "# [[projects]]\n\
+             # id = \"00000000-0000-0000-0000-000000000000\"\n\
+             # path = \"$HOME/projects/example\"\n\
+             # name = \"example\"\n\
+             # default_provider = \"codex\"\n\
+             # auto_reopen_agents = true\n\
+             # startup_command = \"npm install\"\n\n",
+        );
+        return;
+    }
+
+    for project in projects {
+        out.push_str("[[projects]]\n");
+        out.push_str(&format!("id = \"{}\"\n", escape_toml_string(&project.id)));
+        out.push_str(&format!(
+            "path = \"{}\"\n",
+            escape_toml_string(&project.path)
+        ));
+        if let Some(name) = &project.name {
+            out.push_str(&format!("name = \"{}\"\n", escape_toml_string(name)));
+        }
+        if let Some(provider) = &project.default_provider {
+            out.push_str(&format!(
+                "default_provider = \"{}\"\n",
+                escape_toml_string(provider)
+            ));
+        }
+        if let Some(auto_reopen_agents) = project.auto_reopen_agents {
+            out.push_str(&format!("auto_reopen_agents = {auto_reopen_agents}\n"));
+        }
+        if let Some(command) = &project.startup_command {
+            out.push_str(&format!(
+                "startup_command = \"{}\"\n",
+                escape_toml_string(command)
+            ));
+        }
+        out.push('\n');
+    }
+}
+
 fn render_terminal_config(out: &mut String, terminal: &TerminalConfig) {
     out.push_str("[terminal]\n");
     out.push_str(
@@ -1458,6 +1576,29 @@ fn render_terminal_config(out: &mut String, terminal: &TerminalConfig) {
     ));
     out.push_str(
         "# Arguments for the companion terminal command. The default [\"-l\"] launches a login\n# shell so your profile, aliases, and prompt are loaded.\n",
+    );
+    out.push_str(&format!(
+        "args = {}\n\n",
+        render_string_list(&terminal.args)
+    ));
+}
+
+fn render_startup_command_terminal_config(
+    out: &mut String,
+    terminal: &StartupCommandTerminalConfig,
+) {
+    out.push_str("[startup_command_terminal]\n");
+    out.push_str(
+        "# Shell used to run project startup commands before launching a new agent.\n\
+         # \"$SHELL\" is expanded when the command runs and falls back to /bin/sh if unset.\n",
+    );
+    out.push_str(&format!(
+        "command = \"{}\"\n",
+        escape_toml_string(&terminal.command)
+    ));
+    out.push_str(
+        "# Arguments passed before the configured project startup command.\n\
+         # The default [\"-l\", \"-c\"] runs a login shell without interactive job-control warnings.\n",
     );
     out.push_str(&format!(
         "args = {}\n\n",
@@ -1627,6 +1768,55 @@ fn discover_root(home: &Path, xdg_config_home: Option<std::ffi::OsString>) -> Pa
     }
 }
 
+/// Expand environment variables (`$VAR`, `${VAR}`) in a config string.
+/// Returns `None` when variable syntax is invalid.
+pub fn expand_env_vars(raw: &str) -> Option<String> {
+    let mut result = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' {
+            let braced = chars.peek() == Some(&'{');
+            if braced {
+                chars.next();
+            }
+            let mut var_name = String::new();
+            while let Some(&c) = chars.peek() {
+                if braced {
+                    if c == '}' {
+                        chars.next();
+                        break;
+                    }
+                } else if !c.is_ascii_alphanumeric() && c != '_' {
+                    break;
+                }
+                var_name.push(c);
+                chars.next();
+            }
+            if var_name.is_empty() || !is_valid_var_name(&var_name) {
+                return None;
+            }
+            match std::env::var(&var_name) {
+                Ok(value) => result.push_str(&value),
+                Err(_) => {
+                    result.push('$');
+                    if braced {
+                        result.push('{');
+                    }
+                    result.push_str(&var_name);
+                    if braced {
+                        result.push('}');
+                    }
+                }
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    Some(result)
+}
+
 /// Expand environment variables (`$VAR`, `${VAR}`) and tilde (`~`) in a path
 /// string.  Returns `None` when the result is unsafe (relative path, directory
 /// traversal via `..`, or invalid variable names).
@@ -1749,6 +1939,9 @@ mod tests {
         assert!(rendered.contains("[terminal]"));
         assert!(rendered.contains("command = "));
         assert!(rendered.contains("args = []"));
+        assert!(rendered.contains("[startup_command_terminal]"));
+        assert!(rendered.contains("command = \"$SHELL\""));
+        assert!(rendered.contains("args = [\"-l\", \"-c\"]"));
         assert!(rendered.contains("[ui]"));
         assert!(rendered.contains("agent_scrollback_lines = 10000"));
         assert!(rendered.contains("empty_project_separator_min_projects = 5"));
@@ -1801,11 +1994,14 @@ mod tests {
             default_provider: None,
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
+            startup_command: Some("npm install".to_string()),
         });
         let rendered = render_config_default(&config);
-        assert!(!rendered.contains("[[projects]]"));
+        assert!(rendered.contains("[[projects]]"));
+        assert!(rendered.contains("startup_command = \"npm install\""));
+        assert!(!rendered.contains("leading_branch"));
         let parsed: Config = toml::from_str(&rendered).expect("should parse back");
-        assert!(parsed.projects.is_empty());
+        assert_eq!(parsed.projects.len(), 1);
     }
 
     #[test]
@@ -1848,6 +2044,20 @@ enable_randomized_pet_name_by_default = false
     }
 
     #[test]
+    fn old_config_missing_startup_command_terminal_uses_portable_default() {
+        let parsed: Config = toml::from_str(
+            r#"
+[defaults]
+provider = "claude"
+"#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(parsed.startup_command_terminal.command, "$SHELL");
+        assert_eq!(parsed.startup_command_terminal.args, ["-l", "-c"]);
+    }
+
+    #[test]
     fn save_config_strips_legacy_projects() {
         let dir = tempfile::TempDir::new().expect("tempdir");
         let config_path = dir.path().join("config.toml");
@@ -1870,13 +2080,15 @@ name = "test"
             default_provider: None,
             leading_branch: None,
             auto_reopen_agents: None,
+            startup_command: Some("echo ready".to_string()),
         });
         let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
         save_config(&config_path, &config, &bindings).expect("save config");
 
         let saved = fs::read_to_string(config_path).expect("read config");
-        assert!(!saved.contains("[[projects]]"));
-        assert!(!saved.contains("project-1"));
+        assert!(saved.contains("[[projects]]"));
+        assert!(saved.contains("project-1"));
+        assert!(saved.contains("startup_command = \"echo ready\""));
     }
 
     #[test]
@@ -1928,6 +2140,17 @@ name = "test"
         let parsed: Config = toml::from_str(&rendered).expect("config should parse");
         assert_eq!(parsed.terminal.command, "fish");
         assert_eq!(parsed.terminal.args, vec!["-l"]);
+    }
+
+    #[test]
+    fn default_config_round_trips_startup_command_terminal() {
+        let mut config = Config::default();
+        config.startup_command_terminal.command = "/bin/bash".to_string();
+        config.startup_command_terminal.args = vec!["-l".to_string(), "-c".to_string()];
+        let rendered = render_config_default(&config);
+        let parsed: Config = toml::from_str(&rendered).expect("config should parse");
+        assert_eq!(parsed.startup_command_terminal.command, "/bin/bash");
+        assert_eq!(parsed.startup_command_terminal.args, vec!["-l", "-c"]);
     }
 
     #[test]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -72,6 +72,8 @@ pub enum Action {
     ExitPathEditorOnProjectAdd,
     OpenEntry,
     AddCurrentDir,
+    OpenStartupCommandLogFile,
+    OpenStartupCommandLogFolder,
     Confirm,
     ToggleSelection,
     ToggleMarked,
@@ -92,6 +94,9 @@ pub enum Action {
     ToggleGithubIntegration,
     ToggleProjectAutoReopenAgents,
     ToggleAgentAutoReopen,
+    ConfigureStartupCommand,
+    RerunStartupCommandOnAgent,
+    ReadStartupCommandLogs,
     ToggleRandomizedPetNameDefault,
     TogglePrBannerPosition,
     ForceReconnectAgent,
@@ -111,6 +116,7 @@ pub enum BindingScope {
     Palette,
     Browser,
     RuntimeKill,
+    StartupCommandLogs,
     Dialog,
     CommitInput,
     Help,
@@ -128,6 +134,7 @@ impl BindingScope {
         Self::Palette,
         Self::Browser,
         Self::RuntimeKill,
+        Self::StartupCommandLogs,
         Self::Dialog,
         Self::CommitInput,
         Self::Help,
@@ -145,6 +152,7 @@ impl BindingScope {
             Self::Palette => "Command palette",
             Self::Browser => "Project browser",
             Self::RuntimeKill => "Kill running modal",
+            Self::StartupCommandLogs => "Startup command logs modal",
             Self::Dialog => "Dialog",
             Self::CommitInput => "Commit input",
             Self::Help => "Help overlay",
@@ -249,6 +257,8 @@ impl Action {
             Action::ExitPathEditorOnProjectAdd => "exit_path_editor_on_project_add",
             Action::OpenEntry => "open_entry",
             Action::AddCurrentDir => "add_current_dir",
+            Action::OpenStartupCommandLogFile => "open_startup_command_log_file",
+            Action::OpenStartupCommandLogFolder => "open_startup_command_log_folder",
             Action::Confirm => "confirm",
             Action::ToggleSelection => "toggle_selection",
             Action::ToggleMarked => "toggle_marked",
@@ -269,6 +279,9 @@ impl Action {
             Action::ToggleGithubIntegration => "toggle_github_integration",
             Action::ToggleProjectAutoReopenAgents => "toggle_project_auto_reopen_agents",
             Action::ToggleAgentAutoReopen => "toggle_agent_auto_reopen",
+            Action::ConfigureStartupCommand => "configure_startup_command",
+            Action::RerunStartupCommandOnAgent => "rerun_startup_command_on_agent",
+            Action::ReadStartupCommandLogs => "read_startup_command_logs",
             Action::ToggleRandomizedPetNameDefault => "toggle_randomized_pet_name_default",
             Action::TogglePrBannerPosition => "toggle_pr_banner_position",
             Action::ForceReconnectAgent => "force_reconnect_agent",
@@ -356,6 +369,8 @@ impl Action {
             Action::ExitPathEditorOnProjectAdd => "Exit typed-path mode in the project browser.",
             Action::OpenEntry => "Open or navigate into the selected entry in the project browser.",
             Action::AddCurrentDir => "Add the current directory as a project.",
+            Action::OpenStartupCommandLogFile => "Open the selected startup command log file.",
+            Action::OpenStartupCommandLogFolder => "Open the selected startup command log folder.",
             Action::Confirm => "Confirm the selected action in a dialog.",
             Action::ToggleSelection => "Toggle between options in a confirmation dialog.",
             Action::ToggleMarked => "Toggle the hovered runtime in the kill-running modal.",
@@ -379,6 +394,15 @@ impl Action {
                 "Toggle startup auto-reopen for agents in the selected project."
             }
             Action::ToggleAgentAutoReopen => "Toggle startup auto-reopen for the selected agent.",
+            Action::ConfigureStartupCommand => {
+                "Configure the selected project's startup command for newly created agents."
+            }
+            Action::RerunStartupCommandOnAgent => {
+                "Rerun the selected agent's project startup command."
+            }
+            Action::ReadStartupCommandLogs => {
+                "Open startup command logs for the selected agent or project."
+            }
             Action::ToggleRandomizedPetNameDefault => {
                 "Toggle whether the agent name prompt starts with a random pet name."
             }
@@ -452,6 +476,8 @@ impl Action {
             | Action::ExitPathEditorOnProjectAdd
             | Action::OpenEntry
             | Action::AddCurrentDir
+            | Action::OpenStartupCommandLogFile
+            | Action::OpenStartupCommandLogFolder
             | Action::Confirm
             | Action::ToggleSelection
             | Action::ToggleMarked => Some("Overlays"),
@@ -470,6 +496,9 @@ impl Action {
             | Action::ToggleGithubIntegration
             | Action::ToggleProjectAutoReopenAgents
             | Action::ToggleAgentAutoReopen
+            | Action::ConfigureStartupCommand
+            | Action::RerunStartupCommandOnAgent
+            | Action::ReadStartupCommandLogs
             | Action::ToggleRandomizedPetNameDefault
             | Action::TogglePrBannerPosition
             | Action::ForceReconnectAgent
@@ -522,6 +551,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             BindingScope::Palette,
             BindingScope::Browser,
             BindingScope::RuntimeKill,
+            BindingScope::StartupCommandLogs,
             BindingScope::Help,
         ],
         help: Some(HelpEntry {
@@ -545,6 +575,7 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             BindingScope::Palette,
             BindingScope::Browser,
             BindingScope::RuntimeKill,
+            BindingScope::StartupCommandLogs,
             BindingScope::Help,
         ],
         help: None, // covered by MoveDown's combined label
@@ -691,6 +722,39 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "toggle-agent-auto-reopen",
             description: "Opt the selected agent in or out of startup reopening",
+        }),
+    },
+    BindingDef {
+        action: Action::ConfigureStartupCommand,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "configure-startup-command",
+            description: "Configure the selected project's startup command",
+        }),
+    },
+    BindingDef {
+        action: Action::RerunStartupCommandOnAgent,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "rerun-startup-command-on-agent",
+            description: "Rerun the selected agent's startup command",
+        }),
+    },
+    BindingDef {
+        action: Action::ReadStartupCommandLogs,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "read-startup-command-logs",
+            description: "Read startup command logs for the selected agent or project",
         }),
     },
     BindingDef {
@@ -1307,7 +1371,11 @@ pub const BINDING_DEFS: &[BindingDef] = &[
             KeyCode::Char('/'),
             KeyModifiers::NONE,
         )],
-        scopes: &[BindingScope::Browser, BindingScope::RuntimeKill],
+        scopes: &[
+            BindingScope::Browser,
+            BindingScope::RuntimeKill,
+            BindingScope::StartupCommandLogs,
+        ],
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Toggle search mode",
@@ -1355,6 +1423,31 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         help: Some(HelpEntry {
             section: "Overlays",
             description: "Add the current directory as a project",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::OpenStartupCommandLogFile,
+        default_keys: &[key!(o)],
+        scopes: &[BindingScope::StartupCommandLogs],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Open selected startup command log file",
+        }),
+        hint_contexts: &[],
+        palette: None,
+    },
+    BindingDef {
+        action: Action::OpenStartupCommandLogFolder,
+        default_keys: &[KeyCombination::one_key(
+            KeyCode::Char('O'),
+            KeyModifiers::SHIFT,
+        )],
+        scopes: &[BindingScope::StartupCommandLogs],
+        help: Some(HelpEntry {
+            section: "Overlays",
+            description: "Open selected startup command log folder",
         }),
         hint_contexts: &[],
         palette: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod model;
 mod provider;
 mod pty;
 mod raw_input;
+mod startup;
 mod statusline;
 mod storage;
 mod theme;

--- a/src/model.rs
+++ b/src/model.rs
@@ -59,6 +59,7 @@ pub struct Project {
     pub default_provider: ProviderKind,
     pub leading_branch: Option<String>,
     pub auto_reopen_agents: Option<bool>,
+    pub startup_command: Option<String>,
     pub current_branch: String,
     pub branch_status: ProjectBranchStatus,
     pub path_missing: bool,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,0 +1,520 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Local, Utc};
+
+use crate::config::{DuxPaths, StartupCommandTerminalConfig};
+use crate::model::{AgentSession, Project};
+
+pub const LOG_ROOT: &str = "startup-command-logs";
+
+#[derive(Clone, Debug)]
+pub struct StartupCommandRun {
+    pub project: Project,
+    pub session: AgentSession,
+    pub command: String,
+    pub terminal: StartupCommandTerminalConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartupCommandResult {
+    pub session_id: String,
+    pub project_name: String,
+    pub log_path: PathBuf,
+    pub status: Result<(), String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StartupCommandLogEntry {
+    pub path: PathBuf,
+    pub display_name: String,
+    pub modified_at: Option<DateTime<Local>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum StartupCommandLogScope {
+    Agent {
+        project_id: String,
+        session_id: String,
+    },
+    Project {
+        project_id: String,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct StartupCommandLatestLog {
+    pub path: Option<PathBuf>,
+    pub display_name: String,
+    pub content: String,
+}
+
+pub fn agent_log_dir(paths: &DuxPaths, project_id: &str, session_id: &str) -> PathBuf {
+    paths.root.join(LOG_ROOT).join(project_id).join(session_id)
+}
+
+pub fn delete_agent_logs(paths: &DuxPaths, project_id: &str, session_id: &str) -> Result<()> {
+    let dir = agent_log_dir(paths, project_id, session_id);
+    if !dir.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(&dir).with_context(|| format!("failed to delete {}", dir.display()))
+}
+
+pub fn list_agent_logs(
+    paths: &DuxPaths,
+    project_id: &str,
+    session_id: &str,
+) -> Result<Vec<StartupCommandLogEntry>> {
+    list_logs_in_dir(&agent_log_dir(paths, project_id, session_id))
+}
+
+pub fn list_project_logs(
+    paths: &DuxPaths,
+    project_id: &str,
+) -> Result<Vec<StartupCommandLogEntry>> {
+    let root = paths.root.join(LOG_ROOT).join(project_id);
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+    let mut logs = Vec::new();
+    for entry in
+        fs::read_dir(&root).with_context(|| format!("failed to read {}", root.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            logs.extend(list_logs_in_dir(&path)?);
+        }
+    }
+    logs.sort_by(|a, b| {
+        b.modified_at
+            .cmp(&a.modified_at)
+            .then_with(|| b.path.cmp(&a.path))
+    });
+    Ok(logs)
+}
+
+fn list_logs_in_dir(dir: &Path) -> Result<Vec<StartupCommandLogEntry>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut logs = Vec::new();
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("log") {
+            continue;
+        }
+        let modified_at = entry
+            .metadata()
+            .ok()
+            .and_then(|meta| meta.modified().ok())
+            .map(DateTime::<Local>::from);
+        let display_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("startup-command.log")
+            .to_string();
+        logs.push(StartupCommandLogEntry {
+            path,
+            display_name,
+            modified_at,
+        });
+    }
+    logs.sort_by(|a, b| {
+        b.modified_at
+            .cmp(&a.modified_at)
+            .then_with(|| b.path.cmp(&a.path))
+    });
+    Ok(logs)
+}
+
+pub fn read_log(path: &Path) -> Result<String> {
+    fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))
+}
+
+pub fn latest_log_for_scope(
+    paths: &DuxPaths,
+    scope: StartupCommandLogScope,
+) -> Result<StartupCommandLatestLog> {
+    let entries = match scope {
+        StartupCommandLogScope::Agent {
+            project_id,
+            session_id,
+        } => list_agent_logs(paths, &project_id, &session_id)?,
+        StartupCommandLogScope::Project { project_id } => list_project_logs(paths, &project_id)?,
+    };
+
+    match entries.first() {
+        Some(entry) => Ok(StartupCommandLatestLog {
+            path: Some(entry.path.clone()),
+            display_name: entry.display_name.clone(),
+            content: read_log(&entry.path)?,
+        }),
+        None => Ok(StartupCommandLatestLog {
+            path: None,
+            display_name: "No startup command log".to_string(),
+            content: "No startup command logs found.".to_string(),
+        }),
+    }
+}
+
+pub fn open_path(path: &Path) -> Result<()> {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    Command::new(opener)
+        .arg(path)
+        .spawn()
+        .with_context(|| format!("failed to run {opener} {}", path.display()))?;
+    Ok(())
+}
+
+pub fn run_startup_command(paths: &DuxPaths, run: StartupCommandRun) -> StartupCommandResult {
+    let log_dir = agent_log_dir(paths, &run.project.id, &run.session.id);
+    let timestamp = Utc::now();
+    let file_stamp = timestamp.format("%Y%m%dT%H%M%SZ");
+    let safe_branch = sanitize_file_component(&run.session.branch_name);
+    let log_path = log_dir.join(format!("{file_stamp}-{safe_branch}.log"));
+    let result = (|| -> Result<CommandOutcome> {
+        fs::create_dir_all(&log_dir)
+            .with_context(|| format!("failed to create {}", log_dir.display()))?;
+        let shell = startup_shell_command(&run.terminal.command);
+        let shell_args = run.terminal.args.clone();
+        let started = Utc::now();
+        let started_instant = Instant::now();
+        let output = Command::new(&shell)
+            .args(&shell_args)
+            .arg(&run.command)
+            .current_dir(&run.session.worktree_path)
+            .env("DUX_PROJECT_PATH", &run.project.path)
+            .env("DUX_WORKTREE_PATH", &run.session.worktree_path)
+            .env("DUX_AGENT_ID", &run.session.id)
+            .env("DUX_AGENT_BRANCH", &run.session.branch_name)
+            .env("DUX_PROVIDER", run.session.provider.as_str())
+            .env("DUX_STARTUP_COMMAND_LOG", &log_path)
+            .output()
+            .with_context(|| format!("failed to run startup command through {shell}"))?;
+        let ended = Utc::now();
+        Ok(CommandOutcome {
+            shell,
+            shell_args,
+            started,
+            ended,
+            duration_ms: started_instant.elapsed().as_millis(),
+            code: output.status.code(),
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    })();
+
+    let status = match result {
+        Ok(outcome) => {
+            let write_result = write_log(&log_path, &run, &outcome);
+            if let Err(err) = write_result {
+                Err(format!("{err:#}"))
+            } else if outcome.success {
+                Ok(())
+            } else {
+                Err(format!(
+                    "exit status {}",
+                    outcome
+                        .code
+                        .map(|code| code.to_string())
+                        .unwrap_or_else(|| "terminated by signal".to_string())
+                ))
+            }
+        }
+        Err(err) => {
+            let fallback = CommandOutcome {
+                shell: startup_shell_command(&run.terminal.command),
+                shell_args: run.terminal.args.clone(),
+                started: timestamp,
+                ended: Utc::now(),
+                duration_ms: 0,
+                code: None,
+                success: false,
+                stdout: String::new(),
+                stderr: format!("{err:#}"),
+            };
+            let _ = fs::create_dir_all(&log_dir);
+            let _ = write_log(&log_path, &run, &fallback);
+            Err(format!("{err:#}"))
+        }
+    };
+
+    StartupCommandResult {
+        session_id: run.session.id,
+        project_name: run.project.name,
+        log_path,
+        status,
+    }
+}
+
+fn startup_shell_command(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "$SHELL" || trimmed == "${SHELL}" {
+        return std::env::var("SHELL")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "/bin/sh".to_string());
+    }
+
+    crate::config::expand_env_vars(trimmed).unwrap_or_else(|| trimmed.to_string())
+}
+
+struct CommandOutcome {
+    shell: String,
+    shell_args: Vec<String>,
+    started: DateTime<Utc>,
+    ended: DateTime<Utc>,
+    duration_ms: u128,
+    code: Option<i32>,
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn write_log(path: &Path, run: &StartupCommandRun, outcome: &CommandOutcome) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("startup command log path has no parent"))?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    let mut body = String::new();
+    body.push_str("dux startup command log\n");
+    body.push_str(&format!("started_at = {}\n", outcome.started.to_rfc3339()));
+    body.push_str(&format!("ended_at = {}\n", outcome.ended.to_rfc3339()));
+    body.push_str(&format!("duration_ms = {}\n", outcome.duration_ms));
+    body.push_str(&format!("project_id = {}\n", run.project.id));
+    body.push_str(&format!("project_name = {}\n", run.project.name));
+    body.push_str(&format!("project_path = {}\n", run.project.path));
+    body.push_str(&format!("agent_id = {}\n", run.session.id));
+    body.push_str(&format!("agent_branch = {}\n", run.session.branch_name));
+    body.push_str(&format!("worktree_path = {}\n", run.session.worktree_path));
+    body.push_str(&format!("provider = {}\n", run.session.provider.as_str()));
+    body.push_str(&format!("shell = {}\n", outcome.shell));
+    body.push_str(&format!("shell_args = {:?}\n", outcome.shell_args));
+    body.push_str(&format!("command = {}\n", run.command));
+    body.push_str(&format!("exit_code = {}\n", format_exit_code(outcome.code)));
+    body.push_str(&format!("success = {}\n", outcome.success));
+    body.push_str("\n--- stdout ---\n");
+    body.push_str(&outcome.stdout);
+    if !outcome.stdout.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push_str("\n--- stderr ---\n");
+    body.push_str(&outcome.stderr);
+    if !outcome.stderr.ends_with('\n') {
+        body.push('\n');
+    }
+    fs::write(path, body).with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn format_exit_code(code: Option<i32>) -> String {
+    code.map(|code| code.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn sanitize_file_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    sanitized
+        .trim_matches('-')
+        .chars()
+        .take(80)
+        .collect::<String>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    use crate::model::{ProjectBranchStatus, ProviderKind, SessionStatus};
+
+    fn test_paths(root: &Path) -> DuxPaths {
+        DuxPaths {
+            root: root.to_path_buf(),
+            config_path: root.join("config.toml"),
+            sessions_db_path: root.join("sessions.sqlite3"),
+            worktrees_root: root.join("worktrees"),
+            lock_path: root.join("dux.lock"),
+        }
+    }
+
+    fn test_project(root: &Path) -> Project {
+        Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: root.to_string_lossy().to_string(),
+            explicit_default_provider: None,
+            default_provider: ProviderKind::from_str("codex"),
+            leading_branch: Some("main".to_string()),
+            auto_reopen_agents: None,
+            startup_command: Some("echo setup".to_string()),
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Leading,
+            path_missing: false,
+        }
+    }
+
+    fn test_session(worktree: &Path) -> AgentSession {
+        let now = Utc::now();
+        AgentSession {
+            id: "session-1".to_string(),
+            project_id: "project-1".to_string(),
+            project_path: Some(worktree.to_string_lossy().to_string()),
+            provider: ProviderKind::from_str("codex"),
+            source_branch: "main".to_string(),
+            branch_name: "feature/setup".to_string(),
+            worktree_path: worktree.to_string_lossy().to_string(),
+            title: None,
+            started_providers: Vec::new(),
+            desired_running: true,
+            auto_reopen_enabled: true,
+            status: SessionStatus::Active,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn startup_command_success_writes_log() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+        let project = test_project(tmp.path());
+        let session = test_session(tmp.path());
+        let result = run_startup_command(
+            &paths,
+            StartupCommandRun {
+                project,
+                session,
+                command: "printf hello".to_string(),
+                terminal: StartupCommandTerminalConfig {
+                    command: "/bin/sh".to_string(),
+                    args: vec!["-c".to_string()],
+                },
+            },
+        );
+
+        assert!(result.status.is_ok());
+        let log = read_log(&result.log_path).expect("log");
+        assert!(log.contains("success = true"));
+        assert!(log.contains("command = printf hello"));
+        assert!(log.contains("--- stdout ---\nhello"));
+    }
+
+    #[test]
+    fn startup_command_shell_defaults_to_login_non_interactive_mode() {
+        let terminal = StartupCommandTerminalConfig::default();
+        assert_eq!(terminal.command, "$SHELL");
+        assert_eq!(terminal.args, ["-l", "-c"]);
+    }
+
+    #[test]
+    fn startup_command_shell_expands_config_env_vars() {
+        unsafe { std::env::set_var("DUX_TEST_STARTUP_SHELL", "/bin/sh") };
+        assert_eq!(startup_shell_command("$DUX_TEST_STARTUP_SHELL"), "/bin/sh");
+        unsafe { std::env::remove_var("DUX_TEST_STARTUP_SHELL") };
+    }
+
+    #[test]
+    fn startup_command_failure_is_logged_without_erroring_log_write() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+        let project = test_project(tmp.path());
+        let session = test_session(tmp.path());
+        let result = run_startup_command(
+            &paths,
+            StartupCommandRun {
+                project,
+                session,
+                command: "printf nope >&2; exit 7".to_string(),
+                terminal: StartupCommandTerminalConfig {
+                    command: "/bin/sh".to_string(),
+                    args: vec!["-c".to_string()],
+                },
+            },
+        );
+
+        assert!(result.status.is_err());
+        let log = read_log(&result.log_path).expect("log");
+        assert!(log.contains("success = false"));
+        assert!(log.contains("exit_code = 7"));
+        assert!(log.contains("--- stderr ---"));
+        assert!(log.contains("nope"));
+    }
+
+    #[test]
+    fn delete_agent_logs_removes_session_directory() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+        let dir = agent_log_dir(&paths, "project-1", "session-1");
+        fs::create_dir_all(&dir).expect("log dir");
+        fs::write(dir.join("one.log"), "log").expect("log file");
+
+        delete_agent_logs(&paths, "project-1", "session-1").expect("delete logs");
+
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn latest_log_for_scope_reads_newest_project_log() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+        let old_dir = agent_log_dir(&paths, "project-1", "session-1");
+        let new_dir = agent_log_dir(&paths, "project-1", "session-2");
+        fs::create_dir_all(&old_dir).expect("old log dir");
+        fs::create_dir_all(&new_dir).expect("new log dir");
+        fs::write(old_dir.join("20260101T000000Z-old.log"), "old").expect("old log");
+        let newest = new_dir.join("20260101T000001Z-new.log");
+        fs::write(&newest, "new").expect("new log");
+
+        let latest = latest_log_for_scope(
+            &paths,
+            StartupCommandLogScope::Project {
+                project_id: "project-1".to_string(),
+            },
+        )
+        .expect("latest log");
+
+        assert_eq!(latest.path, Some(newest));
+        assert_eq!(latest.display_name, "20260101T000001Z-new.log");
+        assert_eq!(latest.content, "new");
+    }
+
+    #[test]
+    fn latest_log_for_scope_reports_empty_state() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+
+        let latest = latest_log_for_scope(
+            &paths,
+            StartupCommandLogScope::Agent {
+                project_id: "project-1".to_string(),
+                session_id: "session-1".to_string(),
+            },
+        )
+        .expect("latest log");
+
+        assert!(latest.path.is_none());
+        assert_eq!(latest.display_name, "No startup command log");
+        assert_eq!(latest.content, "No startup command logs found.");
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -57,6 +57,7 @@ impl SessionStore {
                 default_provider text,
                 leading_branch text,
                 auto_reopen_agents integer,
+                startup_command text,
                 sort_order integer not null default 0,
                 created_at text not null,
                 updated_at text not null
@@ -67,6 +68,7 @@ impl SessionStore {
         ensure_column(&self.conn, "projects", "default_provider", "text")?;
         ensure_column(&self.conn, "projects", "leading_branch", "text")?;
         ensure_column(&self.conn, "projects", "auto_reopen_agents", "integer")?;
+        ensure_column(&self.conn, "projects", "startup_command", "text")?;
         ensure_column(
             &self.conn,
             "projects",
@@ -158,8 +160,9 @@ impl SessionStore {
                 default_provider = ?4,
                 leading_branch = ?5,
                 auto_reopen_agents = ?6,
-                sort_order = ?7,
-                updated_at = ?8
+                startup_command = ?7,
+                sort_order = ?8,
+                updated_at = ?9
             where id = ?1
             "#,
             params![
@@ -169,6 +172,7 @@ impl SessionStore {
                 project.default_provider,
                 project.leading_branch,
                 project.auto_reopen_agents,
+                project.startup_command,
                 sort_order,
                 now,
             ],
@@ -180,14 +184,15 @@ impl SessionStore {
         self.conn.execute(
             r#"
             insert into projects
-                (id, path, name, default_provider, leading_branch, auto_reopen_agents, sort_order, created_at, updated_at)
+                (id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command, sort_order, created_at, updated_at)
             values
-                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
             on conflict(path) do update set
                 name=excluded.name,
                 default_provider=excluded.default_provider,
                 leading_branch=excluded.leading_branch,
                 auto_reopen_agents=excluded.auto_reopen_agents,
+                startup_command=excluded.startup_command,
                 sort_order=excluded.sort_order,
                 updated_at=excluded.updated_at
             "#,
@@ -198,6 +203,7 @@ impl SessionStore {
                 project.default_provider,
                 project.leading_branch,
                 project.auto_reopen_agents,
+                project.startup_command,
                 sort_order,
                 now,
             ],
@@ -218,7 +224,7 @@ impl SessionStore {
     pub fn load_projects(&self) -> Result<Vec<ProjectConfig>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select id, path, name, default_provider, leading_branch, auto_reopen_agents
+            select id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command
             from projects
             order by sort_order, name collate nocase, path collate nocase
             "#,
@@ -231,6 +237,7 @@ impl SessionStore {
                 default_provider: row.get(3)?,
                 leading_branch: row.get(4)?,
                 auto_reopen_agents: row.get(5)?,
+                startup_command: row.get(6)?,
             })
         })?;
 
@@ -271,6 +278,23 @@ impl SessionStore {
             where id = ?1
             "#,
             params![project_id, auto_reopen_agents, Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_project_startup_command(
+        &self,
+        project_id: &str,
+        startup_command: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            r#"
+            update projects
+            set startup_command = ?2,
+                updated_at = ?3
+            where id = ?1
+            "#,
+            params![project_id, startup_command, Utc::now().to_rfc3339()],
         )?;
         Ok(())
     }
@@ -607,6 +631,7 @@ mod tests {
             default_provider: Some("codex".to_string()),
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: Some(false),
+            startup_command: Some("npm install".to_string()),
         };
 
         store.upsert_project(&project).unwrap();
@@ -626,6 +651,7 @@ mod tests {
                 default_provider: None,
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
+                startup_command: None,
             })
             .unwrap();
 
@@ -637,6 +663,7 @@ mod tests {
                 default_provider: Some("claude".to_string()),
                 leading_branch: Some("trunk".to_string()),
                 auto_reopen_agents: Some(false),
+                startup_command: Some("echo setup".to_string()),
             })
             .unwrap();
 
@@ -647,6 +674,7 @@ mod tests {
         assert_eq!(loaded[0].default_provider.as_deref(), Some("claude"));
         assert_eq!(loaded[0].leading_branch.as_deref(), Some("trunk"));
         assert_eq!(loaded[0].auto_reopen_agents, Some(false));
+        assert_eq!(loaded[0].startup_command.as_deref(), Some("echo setup"));
     }
 
     #[test]


### PR DESCRIPTION
This adds per-project startup commands that run inside a new agent worktree before the provider launches. Commands run through the user shell and receive DUX environment variables for the project, worktree, agent, provider, and log path.

Project entries are restored in config.toml and mirrored with SQLite so projects remain portable while still preserving runtime state. Conflicts between config and SQLite now fail clearly instead of silently choosing one side.

Startup command output is written under the dux config directory and can be viewed from the app. Failed startup commands do not block agent creation; users can inspect logs or rerun the command for the selected agent.