### PR TITLE
Sync fresh agents before creation

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2749,7 +2749,7 @@ impl App {
                     self.prompt = PromptState::None;
                 }
                 Some(Action::ToggleSelection) => {
-                    self.toggle_name_new_agent_randomized_name();
+                    self.focus_next_name_new_agent_control(!is_reverse_tab(key));
                 }
                 Some(Action::Confirm) => {
                     // Extract the name from the input before taking ownership.
@@ -2845,12 +2845,12 @@ impl App {
                         let checkbox_focused = matches!(
                             self.prompt,
                             PromptState::NameNewAgent {
-                                focus: NameNewAgentFocus::Checkbox,
+                                focus: NameNewAgentFocus::RandomizedNameCheckbox,
                                 ..
                             }
                         );
                         if checkbox_focused {
-                            self.toggle_name_new_agent_randomized_name();
+                            self.toggle_focused_name_new_agent_checkbox();
                         } else if let PromptState::NameNewAgent { input, .. } = &mut self.prompt {
                             input.handle_key(key);
                         }
@@ -4445,6 +4445,30 @@ impl App {
         }
     }
 
+    fn focus_next_name_new_agent_control(&mut self, forward: bool) {
+        if let PromptState::NameNewAgent { focus, .. } = &mut self.prompt {
+            *focus = match (*focus, forward) {
+                (NameNewAgentFocus::Input, true) => NameNewAgentFocus::RandomizedNameCheckbox,
+                (NameNewAgentFocus::RandomizedNameCheckbox, true) => NameNewAgentFocus::Input,
+                (NameNewAgentFocus::Input, false) => NameNewAgentFocus::RandomizedNameCheckbox,
+                (NameNewAgentFocus::RandomizedNameCheckbox, false) => NameNewAgentFocus::Input,
+            };
+        }
+    }
+
+    fn toggle_focused_name_new_agent_checkbox(&mut self) {
+        let focus = match &self.prompt {
+            PromptState::NameNewAgent { focus, .. } => *focus,
+            _ => return,
+        };
+        match focus {
+            NameNewAgentFocus::RandomizedNameCheckbox => {
+                self.toggle_name_new_agent_randomized_name()
+            }
+            NameNewAgentFocus::Input => {}
+        }
+    }
+
     fn toggle_name_new_agent_randomized_name(&mut self) {
         if let PromptState::NameNewAgent {
             input,
@@ -4454,7 +4478,7 @@ impl App {
             ..
         } = &mut self.prompt
         {
-            *focus = NameNewAgentFocus::Checkbox;
+            *focus = NameNewAgentFocus::RandomizedNameCheckbox;
             *randomize_name = !*randomize_name;
             if *randomize_name {
                 let name = crate::git::docker_style_name();
@@ -6932,6 +6956,7 @@ not_a_real_action = ["x"]
                 project: app.projects[0].clone(),
                 custom_name: None,
                 use_existing_branch: false,
+                pull_before_create: false,
             },
             input: TextInput::with_text("reuse-me".to_string()),
             randomize_name: false,
@@ -7368,12 +7393,58 @@ not_a_real_action = ["x"]
     }
 
     #[test]
+    fn fresh_agent_request_uses_pull_before_create_config_default() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.pull_before_creating_agent_by_default = true;
+
+        app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", "main");
+
+        match &app.prompt {
+            PromptState::NameNewAgent { request, .. } => match request {
+                CreateAgentRequest::NewProject {
+                    pull_before_create, ..
+                } => assert!(*pull_before_create),
+                other => panic!("expected NewProject request, got {other:?}"),
+            },
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_agent_prompt_does_not_expose_pull_before_create_checkbox() {
+        let mut app = test_app(default_bindings());
+        app.config.defaults.pull_before_creating_agent_by_default = true;
+
+        app.create_agent_for_selected_project().unwrap();
+        complete_create_agent_branch_inspection(&mut app, "main", "main");
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::NameNewAgent { focus, .. } => {
+                assert_eq!(*focus, NameNewAgentFocus::RandomizedNameCheckbox)
+            }
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        match &app.prompt {
+            PromptState::NameNewAgent { focus, .. } => assert_eq!(*focus, NameNewAgentFocus::Input),
+            other => panic!("expected NameNewAgent prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn name_prompt_toggle_randomized_name_fills_and_clears_input() {
         let mut app = test_app(default_bindings());
         app.create_agent_for_selected_project().unwrap();
         complete_create_agent_branch_inspection(&mut app, "main", "main");
 
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
             .unwrap();
 
         let generated = match &app.prompt {
@@ -7385,7 +7456,7 @@ not_a_real_action = ["x"]
                 ..
             } => {
                 assert!(*randomize_name);
-                assert_eq!(*focus, NameNewAgentFocus::Checkbox);
+                assert_eq!(*focus, NameNewAgentFocus::RandomizedNameCheckbox);
                 assert!(!input.text.is_empty());
                 assert_eq!(randomized_name.as_deref(), Some(input.text.as_str()));
                 input.text.clone()
@@ -7394,6 +7465,10 @@ not_a_real_action = ["x"]
         };
 
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT))
+            .unwrap();
+        app.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE))
             .unwrap();
 
         match &app.prompt {
@@ -10461,7 +10536,7 @@ cyan = "#00ffff"
                 ..
             } => {
                 assert!(*randomize_name);
-                assert_eq!(*focus, NameNewAgentFocus::Checkbox);
+                assert_eq!(*focus, NameNewAgentFocus::RandomizedNameCheckbox);
                 assert!(!input.text.is_empty());
                 assert_eq!(randomized_name.as_deref(), Some(input.text.as_str()));
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -560,7 +560,7 @@ pub(crate) enum ConfirmNonDefaultBranchFocus {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NameNewAgentFocus {
     Input,
-    Checkbox,
+    RandomizedNameCheckbox,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1381,6 +1381,7 @@ pub(crate) enum CreateAgentRequest {
         project: Project,
         custom_name: Option<String>,
         use_existing_branch: bool,
+        pull_before_create: bool,
     },
     PullRequest {
         project: Project,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -5106,20 +5106,20 @@ impl App {
                 ..
             } => {
                 self.render_dim_overlay(frame);
-                let checkbox = Checkbox::new("Use randomized pet name")
+                let randomize_checkbox = Checkbox::new("Use randomized pet name")
                     .checked(*randomize_name)
-                    .state(if *focus == NameNewAgentFocus::Checkbox {
+                    .state(if *focus == NameNewAgentFocus::RandomizedNameCheckbox {
                         CheckboxState::Focused
                     } else {
                         CheckboxState::Normal
                     });
                 let dialog_width = 60.min(frame.area().width.max(1));
                 let inner_width = dialog_width.saturating_sub(2);
-                let checkbox_height = checkbox
+                let randomize_checkbox_height = randomize_checkbox
                     .layout(
                         inner_width,
-                        checkbox.marker_style(Style::default()),
-                        checkbox.label_style(Style::default()),
+                        randomize_checkbox.marker_style(Style::default()),
+                        randomize_checkbox.label_style(Style::default()),
                     )
                     .height
                     .saturating_add(1);
@@ -5144,7 +5144,10 @@ impl App {
                 let context_height = u16::from(context_line.is_some());
                 let area = centered_rect_exact(
                     dialog_width,
-                    8 + context_height + checkbox_spacing + checkbox_height + footer_spacing,
+                    8 + context_height
+                        + checkbox_spacing
+                        + randomize_checkbox_height
+                        + footer_spacing,
                     frame.area(),
                 );
                 self.clear_overlay_area(frame, area);
@@ -5158,7 +5161,7 @@ impl App {
                     context_area,
                     input_area,
                     _,
-                    checkbox_area,
+                    randomize_checkbox_area,
                     _,
                     hint_area,
                 ] = Layout::default()
@@ -5168,7 +5171,7 @@ impl App {
                         Constraint::Length(context_height),
                         Constraint::Length(3),
                         Constraint::Length(checkbox_spacing),
-                        Constraint::Length(checkbox_height),
+                        Constraint::Length(randomize_checkbox_height),
                         Constraint::Length(footer_spacing),
                         Constraint::Min(1),
                     ])
@@ -5227,12 +5230,12 @@ impl App {
                     .block(input_block)
                     .render(input_area, frame.buffer_mut());
 
-                let (checkbox_rect, _) = self.render_overlay_checkbox(
+                let (randomized_name_checkbox_rect, _) = self.render_overlay_checkbox(
                     frame,
-                    checkbox_area,
+                    randomize_checkbox_area,
                     "Use randomized pet name",
                     *randomize_name,
-                    if *focus == NameNewAgentFocus::Checkbox {
+                    if *focus == NameNewAgentFocus::RandomizedNameCheckbox {
                         CheckboxState::Focused
                     } else {
                         CheckboxState::Normal
@@ -5257,7 +5260,11 @@ impl App {
                 ));
                 hints.extend(self.theme.key_badge_default(&toggle_key));
                 hints.push(Span::styled(
-                    " randomize  ",
+                    " focus  ",
+                    Style::default().fg(self.theme.hint_desc_fg),
+                ));
+                hints.push(Span::styled(
+                    "Space toggle  ",
                     Style::default().fg(self.theme.hint_desc_fg),
                 ));
                 hints.extend(self.theme.key_badge_default(&close_key));
@@ -5270,7 +5277,7 @@ impl App {
                     input: input_inner,
                     checkbox: Some(OverlayCheckbox {
                         id: OverlayCheckboxId::NameNewAgentRandomizedPetName,
-                        rect: checkbox_rect,
+                        rect: randomized_name_checkbox_rect,
                     }),
                 };
             }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -201,6 +201,7 @@ impl App {
             project,
             custom_name: None,
             use_existing_branch: false,
+            pull_before_create: self.config.defaults.pull_before_creating_agent_by_default,
         })
     }
 

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -1576,8 +1576,27 @@ pub(crate) fn run_create_agent_job(
             project,
             custom_name,
             use_existing_branch,
+            pull_before_create,
         } => {
             let repo_path = PathBuf::from(&project.path);
+
+            if pull_before_create {
+                let _ = worker_tx.send(WorkerEvent::CreateAgentProgress(format!(
+                    "Pulling latest changes for project \"{}\" before creating the agent...",
+                    project.name
+                )));
+                if let Err(err) = git::pull_current_branch(&repo_path) {
+                    logger::error(&format!(
+                        "pre-create pull failed for {}: {err}",
+                        project.path
+                    ));
+                    let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                        "Failed to pull latest changes for project \"{}\" before creating the agent: {err}",
+                        project.name
+                    )));
+                    return;
+                }
+            }
 
             // Resolve the branch name early so we can check for an
             // existing branch before calling git worktree add.  When no
@@ -2492,6 +2511,63 @@ mod tests {
                 assert_eq!(message, "Forking an agent requires choosing a name first.");
             }
             _ => panic!("expected missing-name failure"),
+        }
+        assert!(worker_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn fresh_worker_reports_pre_create_pull_failure_before_worktree_creation() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = DuxPaths {
+            config_path: tmp.path().join("config.toml"),
+            sessions_db_path: tmp.path().join("sessions.sqlite3"),
+            worktrees_root: tmp.path().join("worktrees"),
+            lock_path: tmp.path().join("dux.lock"),
+            root: tmp.path().to_path_buf(),
+        };
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: tmp.path().join("not-a-repo").to_string_lossy().to_string(),
+            explicit_default_provider: None,
+            default_provider: ProviderKind::from_str("codex"),
+            leading_branch: Some("main".to_string()),
+            auto_reopen_agents: None,
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
+            path_missing: false,
+        };
+        let (worker_tx, worker_rx) = mpsc::channel();
+
+        run_create_agent_job(
+            CreateAgentRequest::NewProject {
+                project,
+                custom_name: Some("agent-branch".to_string()),
+                use_existing_branch: false,
+                pull_before_create: true,
+            },
+            paths,
+            Config::default(),
+            worker_tx,
+            (80, 24),
+        );
+
+        match worker_rx.recv().expect("worker event") {
+            WorkerEvent::CreateAgentProgress(message) => {
+                assert_eq!(
+                    message,
+                    "Pulling latest changes for project \"demo\" before creating the agent..."
+                );
+            }
+            _ => panic!("expected pre-create pull progress"),
+        }
+        match worker_rx.recv().expect("worker event") {
+            WorkerEvent::CreateAgentFailed(message) => {
+                assert!(message.contains(
+                    "Failed to pull latest changes for project \"demo\" before creating the agent"
+                ));
+            }
+            _ => panic!("expected pre-create pull failure"),
         }
         assert!(worker_rx.try_recv().is_err());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,8 @@ pub struct Defaults {
     pub start_directory: Option<String>,
     pub commit_prompt: Option<String>,
     pub enable_randomized_pet_name_by_default: bool,
+    #[serde(default = "default_true")]
+    pub pull_before_creating_agent_by_default: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -181,6 +183,10 @@ pub struct ProjectConfig {
 
 fn new_project_id() -> String {
     Uuid::new_v4().to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -265,6 +271,7 @@ impl Default for Defaults {
             start_directory,
             commit_prompt: Some(DEFAULT_COMMIT_PROMPT.to_string()),
             enable_randomized_pet_name_by_default: false,
+            pull_before_creating_agent_by_default: true,
         }
     }
 }
@@ -632,6 +639,16 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             )),
             value_fn: |c| FieldValue::Bool(c.defaults.enable_randomized_pet_name_by_default),
         },
+        ConfigEntry::Field {
+            key: "pull_before_creating_agent_by_default",
+            comment: Some(CommentSource::Static(
+                "# When true, dux safely fast-forward pulls the project source checkout\n\
+                 # before creating a fresh project agent worktree.\n\
+                 # This uses `git pull --ff-only`; it will not create merge commits or rebase.\n\
+                 # Set to false to keep fresh agent creation from contacting the remote.",
+            )),
+            value_fn: |c| FieldValue::Bool(c.defaults.pull_before_creating_agent_by_default),
+        },
         ConfigEntry::Blank,
         ConfigEntry::Providers,
         ConfigEntry::Terminal,
@@ -891,6 +908,12 @@ pub fn save_config(
         "defaults",
         "enable_randomized_pet_name_by_default",
         config.defaults.enable_randomized_pet_name_by_default,
+    );
+    patch_table_bool(
+        &mut doc,
+        "defaults",
+        "pull_before_creating_agent_by_default",
+        config.defaults.pull_before_creating_agent_by_default,
     );
     remove_table_key(&mut doc, "defaults", "prompt_for_name");
 
@@ -1715,6 +1738,7 @@ mod tests {
         assert!(rendered.contains("[defaults]"));
         assert!(rendered.contains("provider = \"claude\""));
         assert!(rendered.contains("enable_randomized_pet_name_by_default = false"));
+        assert!(rendered.contains("pull_before_creating_agent_by_default = true"));
         assert!(!rendered.contains("prompt_for_name"));
         assert!(rendered.contains("[providers.claude]"));
         assert!(rendered.contains("[providers.codex]"));
@@ -1805,6 +1829,22 @@ leading_branch = "main"
             Some("codex")
         );
         assert_eq!(parsed.projects[0].leading_branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn old_config_missing_pull_before_create_defaults_to_true() {
+        let parsed: Config = toml::from_str(
+            r#"
+[defaults]
+provider = "claude"
+start_directory = "/tmp"
+commit_prompt = ""
+enable_randomized_pet_name_by_default = false
+"#,
+        )
+        .expect("config should parse");
+
+        assert!(parsed.defaults.pull_before_creating_agent_by_default);
     }
 
     #[test]
@@ -2690,6 +2730,7 @@ args = [\"-l\"]
         let mut config: Config = toml::from_str(&default_body).expect("parse");
         config.ui.right_width_pct = 30;
         config.ui.auto_reopen_agents = true;
+        config.defaults.pull_before_creating_agent_by_default = false;
         config.editor.default = "zed".to_string();
         let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
         save_config(&config_path, &config, &bindings).expect("save");
@@ -2699,6 +2740,7 @@ args = [\"-l\"]
         let reloaded: Config = toml::from_str(&saved).expect("parse saved");
         assert_eq!(reloaded.ui.right_width_pct, 30);
         assert!(reloaded.ui.auto_reopen_agents);
+        assert!(!reloaded.defaults.pull_before_creating_agent_by_default);
         assert_eq!(reloaded.editor.default, "zed");
     }
 


### PR DESCRIPTION
Fresh project agents now start from a safely updated source checkout by default. Before creating the worktree, dux runs the existing fast-forward-only pull path so the new agent starts from the latest upstream state when possible.

The behavior is controlled by a new defaults config flag, `pull_before_creating_agent_by_default`, which is enabled by default. The generated config explains that this uses `git pull --ff-only`, so it will not create merge commits or rebase local work.

The new-agent prompt stays simple: there is no extra checkbox, and users who prefer offline or no-remote creation can turn the setting off in config.