### PR TITLE
Clear stale create-agent branch status

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -6886,6 +6886,7 @@ not_a_real_action = ["x"]
         let mut app = test_app(default_bindings());
 
         app.create_agent_for_selected_project().unwrap();
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Busy);
         complete_create_agent_branch_inspection(&mut app, "main", "main");
 
         match &app.prompt {
@@ -6903,6 +6904,11 @@ not_a_real_action = ["x"]
             }
             other => panic!("expected name-new-agent prompt, got {other:?}"),
         }
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
+        assert_eq!(
+            app.status.message(),
+            "Branch check complete for \"demo\". Confirm or edit the agent name to continue."
+        );
     }
 
     #[test]

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -449,6 +449,7 @@ impl App {
                 },
                 WorkerEvent::CreateAgentBranchInspected { project, result } => match result {
                     Ok(inspection) => {
+                        let project_name = project.name.clone();
                         if let Some(existing) =
                             self.projects.iter_mut().find(|p| p.id == project.id)
                         {
@@ -465,6 +466,10 @@ impl App {
                             self.continue_create_agent_after_branch_inspection(project, inspection)
                         {
                             self.set_error(format!("{err:#}"));
+                        } else {
+                            self.set_info(format!(
+                                "Branch check complete for \"{project_name}\". Confirm or edit the agent name to continue."
+                            ));
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
This fixes the create-agent flow so the branch-check status no longer stays stuck after the name prompt opens.

When branch inspection completes successfully, the statusline now switches to an actionable message telling the user to confirm or edit the agent name. The regression test covers the transition from the busy branch-check state to the ready prompt state.