### PR TITLE
Bug Fix: Pull projects from their leading branch

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1318,16 +1318,25 @@ impl App {
         self.set_busy(busy_message);
         thread::spawn(move || {
             let result = match &target {
-                PullTarget::Project { .. } => match git::is_dirty(&repo_path) {
-                    Ok(true) => Err(
-                        "Refresh blocked because the source checkout has uncommitted changes."
-                            .to_string(),
-                    ),
-                    Ok(false) => git::pull_current_branch(&repo_path)
+                PullTarget::Project { leading_branch, .. } => {
+                    let leading_branch = match leading_branch.clone() {
+                        Some(branch) => Ok(branch),
+                        None => git::current_branch(&repo_path)
+                            .map(|branch| leading_branch_for_project(&repo_path, &branch)),
+                    };
+                    leading_branch
+                        .and_then(|branch| {
+                            git::switch_branch_if_needed(&repo_path, &branch)?;
+                            if git::has_tracked_changes(&repo_path)? {
+                                return Err(anyhow::anyhow!(
+                                    "Refresh blocked because the source checkout has uncommitted changes."
+                                ));
+                            }
+                            git::pull_branch(&repo_path, &branch)
+                        })
                         .map(|_| git::current_branch(&repo_path).ok())
-                        .map_err(|e| e.to_string()),
-                    Err(e) => Err(e.to_string()),
-                },
+                        .map_err(|e| e.to_string())
+                }
                 PullTarget::Session => git::pull_current_branch(&repo_path)
                     .map(|_| None)
                     .map_err(|e| e.to_string()),
@@ -6956,6 +6965,7 @@ not_a_real_action = ["x"]
                 target: PullTarget::Project {
                     project_id: app.projects[0].id.clone(),
                     project_name: app.projects[0].name.clone(),
+                    leading_branch: app.projects[0].leading_branch.clone(),
                 },
                 result: Ok(Some("feature/demo".to_string())),
             })
@@ -6965,6 +6975,10 @@ not_a_real_action = ["x"]
 
         assert!(app.pulls_in_flight.is_empty());
         assert_eq!(app.projects[0].current_branch, "feature/demo");
+        assert_eq!(
+            app.projects[0].branch_status,
+            ProjectBranchStatus::NotLeading
+        );
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1561,6 +1561,7 @@ pub(crate) enum PullTarget {
     Project {
         project_id: String,
         project_name: String,
+        leading_branch: Option<String>,
     },
     Session,
 }

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -684,6 +684,7 @@ impl App {
             PullTarget::Project {
                 project_id: project.id,
                 project_name: project.name.clone(),
+                leading_branch: project.leading_branch.clone(),
             },
             format!("Refreshing project \"{}\" from remote…", project.name),
             format!(

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -58,6 +58,7 @@ impl App {
                         PullTarget::Project {
                             project_id,
                             project_name,
+                            ..
                         } => match result {
                             Ok(branch_name) => {
                                 if let Some(existing) = self
@@ -67,11 +68,20 @@ impl App {
                                     && let Some(branch_name) = branch_name
                                 {
                                     existing.current_branch = branch_name;
-                                    let warning = branch_warning_kind(
-                                        Path::new(&existing.path),
-                                        &existing.current_branch,
-                                    );
-                                    existing.branch_status = branch_status_from_warning(warning.as_ref());
+                                    existing.branch_status =
+                                        if existing.leading_branch.as_deref()
+                                            == Some(&existing.current_branch)
+                                        {
+                                            ProjectBranchStatus::Leading
+                                        } else if existing.leading_branch.is_some() {
+                                            ProjectBranchStatus::NotLeading
+                                        } else {
+                                            let warning = branch_warning_kind(
+                                                Path::new(&existing.path),
+                                                &existing.current_branch,
+                                            );
+                                            branch_status_from_warning(warning.as_ref())
+                                        };
                                 }
                                 self.set_info(format!(
                                     "Refreshed project \"{}\". Local branch is up to date with remote.",
@@ -1651,7 +1661,17 @@ pub(crate) fn run_checkout_project_default_branch_inspection_job(
     let repo_path = PathBuf::from(&project.path);
     let result = git::current_branch(&repo_path)
         .map(|branch| {
-            let warning_kind = branch_warning_kind(&repo_path, &branch);
+            let warning_kind = if let Some(leading_branch) = project.leading_branch.as_deref() {
+                if branch == leading_branch {
+                    None
+                } else {
+                    Some(BranchWarningKind::Known {
+                        default_branch: leading_branch.to_string(),
+                    })
+                }
+            } else {
+                branch_warning_kind(&repo_path, &branch)
+            };
             (branch, warning_kind)
         })
         .map_err(|err| format!("{err:#}"));
@@ -1743,7 +1763,18 @@ pub(crate) fn run_create_agent_job(
                     "Pulling latest changes for project \"{}\" before creating the agent...",
                     project.name
                 )));
-                if let Err(err) = git::pull_current_branch(&repo_path) {
+                let leading_branch = project
+                    .leading_branch
+                    .clone()
+                    .unwrap_or_else(|| project.current_branch.clone());
+                if let Err(err) = git::switch_branch_if_needed(&repo_path, &leading_branch)
+                    .and_then(|_| {
+                        if git::has_tracked_changes(&repo_path)? {
+                            return Err(anyhow::anyhow!("source checkout has uncommitted changes"));
+                        }
+                        git::pull_branch(&repo_path, &leading_branch)
+                    })
+                {
                     logger::error(&format!(
                         "pre-create pull failed for {}: {err}",
                         project.path
@@ -2645,6 +2676,21 @@ mod tests {
     use super::*;
     use crate::model::PrState;
 
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {:?} failed in {}: {}",
+            args,
+            cwd.display(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
     #[test]
     fn fork_worker_requires_name_from_prompt() {
         let tmp = tempdir().expect("tempdir");
@@ -2765,6 +2811,45 @@ mod tests {
             _ => panic!("expected pre-create pull failure"),
         }
         assert!(worker_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn checkout_project_default_branch_inspection_uses_stored_leading_branch() {
+        let repo = tempdir().expect("repo tempdir");
+        run_git(repo.path(), &["init", "-b", "trunk"]);
+        run_git(repo.path(), &["config", "user.name", "test"]);
+        run_git(repo.path(), &["config", "user.email", "t@t"]);
+        run_git(repo.path(), &["commit", "--allow-empty", "-m", "init"]);
+        run_git(repo.path(), &["switch", "-c", "feature"]);
+
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: repo.path().to_string_lossy().to_string(),
+            explicit_default_provider: None,
+            default_provider: ProviderKind::from_str("codex"),
+            leading_branch: Some("trunk".to_string()),
+            auto_reopen_agents: None,
+            startup_command: None,
+            current_branch: "feature".to_string(),
+            branch_status: ProjectBranchStatus::NotLeading,
+            path_missing: false,
+        };
+        let (worker_tx, worker_rx) = mpsc::channel();
+
+        run_checkout_project_default_branch_inspection_job(project, worker_tx);
+
+        match worker_rx.recv().expect("worker event") {
+            WorkerEvent::CheckoutProjectDefaultBranchInspected { result, .. } => {
+                let (current_branch, warning_kind) = result.expect("inspection");
+                assert_eq!(current_branch, "feature");
+                assert!(matches!(
+                    warning_kind,
+                    Some(BranchWarningKind::Known { default_branch }) if default_branch == "trunk"
+                ));
+            }
+            _ => panic!("expected checkout inspection event"),
+        }
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -187,7 +187,25 @@ pub fn parse_worktree_list_porcelain_z(bytes: &[u8]) -> Result<Vec<GitWorktree>>
     Ok(worktrees)
 }
 
-pub fn is_dirty(repo_path: &Path) -> Result<bool> {
+pub fn pull_current_branch(repo_path: &Path) -> Result<()> {
+    let branch = current_branch(repo_path)?;
+    pull_origin_branch(repo_path, &branch)
+}
+
+pub fn pull_branch(repo_path: &Path, branch: &str) -> Result<()> {
+    switch_branch_if_needed(repo_path, branch)?;
+    pull_origin_branch(repo_path, branch)
+}
+
+pub fn switch_branch_if_needed(repo_path: &Path, branch: &str) -> Result<()> {
+    let current = current_branch(repo_path)?;
+    if current != branch {
+        switch_branch(repo_path, branch)?;
+    }
+    Ok(())
+}
+
+pub fn has_tracked_changes(repo_path: &Path) -> Result<bool> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -204,11 +222,10 @@ pub fn is_dirty(repo_path: &Path) -> Result<bool> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+    Ok(!output.stdout.is_empty())
 }
 
-pub fn pull_current_branch(repo_path: &Path) -> Result<()> {
-    let branch = current_branch(repo_path)?;
+fn pull_origin_branch(repo_path: &Path, branch: &str) -> Result<()> {
     let output = Command::new("git")
         .args([
             "-C",
@@ -216,7 +233,7 @@ pub fn pull_current_branch(repo_path: &Path) -> Result<()> {
             "pull",
             "--ff-only",
             "origin",
-            &branch,
+            branch,
         ])
         .output()?;
     if !output.status.success() {
@@ -2054,5 +2071,48 @@ mod tests {
             msg.contains("overwritten") || msg.contains("would be"),
             "expected conflict error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn pull_branch_switches_to_requested_branch_before_pull() {
+        let bare_dir = tempfile::tempdir().unwrap();
+        let bare = bare_dir.path();
+        run_git(bare, &["init", "--bare", "-b", "main"]);
+
+        let staging_dir = tempfile::tempdir().unwrap();
+        let staging = staging_dir.path();
+        run_git(staging, &["clone", bare.to_str().unwrap(), "."]);
+        run_git(staging, &["config", "user.name", "test"]);
+        run_git(staging, &["config", "user.email", "t@t"]);
+        run_git(staging, &["commit", "--allow-empty", "-m", "init"]);
+        run_git(staging, &["push", "origin", "main"]);
+        run_git(staging, &["switch", "-c", "feature"]);
+        run_git(staging, &["commit", "--allow-empty", "-m", "feature"]);
+        run_git(staging, &["push", "origin", "feature"]);
+
+        let clone_dir = tempfile::tempdir().unwrap();
+        let clone = clone_dir.path();
+        run_git(clone, &["clone", bare.to_str().unwrap(), "."]);
+        run_git(clone, &["switch", "feature"]);
+        assert_eq!(current_branch(clone).unwrap(), "feature");
+
+        pull_branch(clone, "main").unwrap();
+
+        assert_eq!(current_branch(clone).unwrap(), "main");
+    }
+
+    #[test]
+    fn has_tracked_changes_ignores_untracked_files() {
+        let repo = init_test_repo();
+
+        fs::write(repo.path().join("scratch.txt"), "untracked\n").unwrap();
+        assert!(!has_tracked_changes(repo.path()).unwrap());
+
+        fs::write(repo.path().join("tracked.txt"), "clean\n").unwrap();
+        commit_all(repo.path(), "add tracked file");
+        assert!(!has_tracked_changes(repo.path()).unwrap());
+
+        fs::write(repo.path().join("tracked.txt"), "dirty\n").unwrap();
+        assert!(has_tracked_changes(repo.path()).unwrap());
     }
 }


### PR DESCRIPTION
Project refresh now switches the source checkout back to the stored leading branch before pulling. If that switch fails, the pull stops and reports the git error instead of updating whichever branch happened to be checked out on disk.

This also aligns related source-checkout flows with the same branch contract: pull-before-create uses the leading branch, the default-branch checkout action respects the stored leading branch, and project branch status is evaluated against that stored value.