### PR TITLE
Add environment variables for projects and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Some projects need a little ceremony before an agent is useful. JavaScript proje
 id = "00000000-0000-0000-0000-000000000000"
 path = "$HOME/projects/web-app"
 name = "web-app"
+env = { EDITOR = "true", API_KEY = "${FOOBAR_API_KEY}" }
 startup_command = """
 npm install
 npm run build:types
@@ -131,7 +132,17 @@ args = ["-l", "-c"]
 
 You can edit the command from the palette with `configure-startup-command`, or keep it in `config.toml` with the rest of your project intent. The multiline editor is not pretending to be fancy: dux passes the whole block as one script string to your configured shell, and shells already know that newlines separate commands. Put `npm install`, symlink setup, cache priming, or whatever tiny ritual your repo demands in there.
 
-Project paths support `$HOME`, `${HOME}`, and `~` so the file can travel between machines without hardcoding your username like a tiny portability crime. The startup command itself runs through your configured shell, so shell environment expansion works inside the command (`$HOME`, `${VAR}`, `$PATH`, `$EDITOR`, and friends). It runs with the agent worktree as the current directory, so relative paths point at the new checkout and normal shells report that through `$PWD`. dux also sets `DUX_PROJECT_PATH`, `DUX_WORKTREE_PATH`, `DUX_AGENT_ID`, `DUX_AGENT_BRANCH`, `DUX_PROVIDER`, and `DUX_STARTUP_COMMAND_LOG` for scripts that want to know where they are and who invited them.
+Global env goes in the top-level `[env]` table and applies to every project:
+
+```toml
+[env]
+EDITOR = "true"
+API_KEY = "${FOOBAR_API_KEY}"
+```
+
+Project `env` values override global keys, because sometimes one repo deserves special treatment and the rest of your machine should not have to hear about it. Edit the global set from the palette with `configure-global-env`, and edit the selected project with `configure-project-env`.
+
+Project paths support `$HOME`, `${HOME}`, and `~` so the file can travel between machines without hardcoding your username like a tiny portability crime. Env values are passed to new agent PTYs, companion terminals, and startup commands. Values support the same `$VAR` and `${VAR}` expansion, so `API_KEY = "${FOOBAR_API_KEY}"` copies a secret from the parent environment while `EDITOR = "true"` can keep agents out of interactive editors. The startup command itself runs through your configured shell, so shell environment expansion works inside the command (`$HOME`, `${VAR}`, `$PATH`, `$EDITOR`, and friends). It runs with the agent worktree as the current directory, so relative paths point at the new checkout and normal shells report that through `$PWD`. dux also sets `DUX_PROJECT_PATH`, `DUX_WORKTREE_PATH`, `DUX_AGENT_ID`, `DUX_AGENT_BRANCH`, `DUX_PROVIDER`, and `DUX_STARTUP_COMMAND_LOG` for scripts that want to know where they are and who invited them.
 
 If the command fails, dux still creates the agent. The failure shows in the status line, because setup scripts are allowed to be dramatic but not allowed to block the show. Use `read-startup-command-logs` to open the latest log, and `rerun-startup-command-on-agent` when the fix is obvious and you want the machine to try again.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,14 @@ API_KEY = "${FOOBAR_API_KEY}"
 
 Project `env` values override global keys, because sometimes one repo deserves special treatment and the rest of your machine should not have to hear about it. Edit the global set from the palette with `configure-global-env`, and edit the selected project with `configure-project-env`.
 
-Project paths support `$HOME`, `${HOME}`, and `~` so the file can travel between machines without hardcoding your username like a tiny portability crime. Env values are passed to new agent PTYs, companion terminals, and startup commands. Values support the same `$VAR` and `${VAR}` expansion, so `API_KEY = "${FOOBAR_API_KEY}"` copies a secret from the parent environment while `EDITOR = "true"` can keep agents out of interactive editors. The startup command itself runs through your configured shell, so shell environment expansion works inside the command (`$HOME`, `${VAR}`, `$PATH`, `$EDITOR`, and friends). It runs with the agent worktree as the current directory, so relative paths point at the new checkout and normal shells report that through `$PWD`. dux also sets `DUX_PROJECT_PATH`, `DUX_WORKTREE_PATH`, `DUX_AGENT_ID`, `DUX_AGENT_BRANCH`, `DUX_PROVIDER`, and `DUX_STARTUP_COMMAND_LOG` for scripts that want to know where they are and who invited them.
+Project paths support `$HOME`, `${HOME}`, and `~` so the file can travel between machines without hardcoding your username like a tiny portability crime. Env values are passed to new agent PTYs, companion terminals, and startup commands. Values support the same `$VAR` and `${VAR}` expansion, so `API_KEY = "${FOOBAR_API_KEY}"` copies a secret from the parent environment while `EDITOR = "true"` can keep agents out of interactive editors. A terminal or agent may still start a shell that evaluates your profile files again; if those files reconfigure the same variables, dux cannot prevent that. Write shell defaults so they keep incoming values when present:
+
+```bash
+export VISUAL="${VISUAL:-nvim}"
+export EDITOR="${EDITOR:-$VISUAL}"
+```
+
+The startup command itself runs through your configured shell, so shell environment expansion works inside the command (`$HOME`, `${VAR}`, `$PATH`, `$EDITOR`, and friends). It runs with the agent worktree as the current directory, so relative paths point at the new checkout and normal shells report that through `$PWD`. dux also sets `DUX_PROJECT_PATH`, `DUX_WORKTREE_PATH`, `DUX_AGENT_ID`, `DUX_AGENT_BRANCH`, `DUX_PROVIDER`, and `DUX_STARTUP_COMMAND_LOG` for scripts that want to know where they are and who invited them.
 
 If the command fails, dux still creates the agent. The failure shows in the status line, because setup scripts are allowed to be dramatic but not allowed to block the show. Use `read-startup-command-logs` to open the latest log, and `rerun-startup-command-on-agent` when the fix is obvious and you want the machine to try again.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -10,6 +10,15 @@ const MIN_CENTER_WIDTH_PCT: u16 = 20;
 const DOUBLE_CLICK_THRESHOLD: Duration = Duration::from_millis(500);
 const ESC_AMBIGUITY_TIMEOUT: Duration = Duration::from_millis(25);
 
+fn configure_project_text_input_mut(prompt: &mut PromptState) -> Option<&mut TextInput> {
+    match prompt {
+        PromptState::ConfigureStartupCommand { input, .. }
+        | PromptState::ConfigureProjectEnv { input, .. }
+        | PromptState::ConfigureGlobalEnv { input, .. } => Some(input),
+        _ => None,
+    }
+}
+
 /// Maximum size of `loading_input_buf`. During the loading phase we
 /// accumulate bytes only to detect a (possibly multi-byte) ExitInteractive
 /// binding. Since any realistic binding fits in well under this cap, we
@@ -1078,7 +1087,12 @@ impl App {
             self.input_target = InputTarget::None;
             return Ok(());
         }
-        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+        if let Some(input) = match &mut self.prompt {
+            PromptState::ConfigureStartupCommand { input, .. }
+            | PromptState::ConfigureProjectEnv { input, .. }
+            | PromptState::ConfigureGlobalEnv { input, .. } => Some(input),
+            _ => None,
+        } {
             if key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL) {
                 input.clear();
             } else {
@@ -2631,19 +2645,30 @@ impl App {
             return Ok(false);
         }
 
-        if matches!(self.prompt, PromptState::ConfigureStartupCommand { .. })
-            && self.input_target == InputTarget::StartupCommand
+        if matches!(
+            self.prompt,
+            PromptState::ConfigureStartupCommand { .. }
+                | PromptState::ConfigureProjectEnv { .. }
+                | PromptState::ConfigureGlobalEnv { .. }
+        ) && self.input_target == InputTarget::StartupCommand
         {
             self.handle_startup_command_input_key(key)?;
             return Ok(false);
         }
 
-        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+        if matches!(
+            self.prompt,
+            PromptState::ConfigureStartupCommand { .. }
+                | PromptState::ConfigureProjectEnv { .. }
+                | PromptState::ConfigureGlobalEnv { .. }
+        ) {
             let palette_action = self.bindings.lookup(&key, BindingScope::Palette);
             let dialog_action = self.bindings.lookup(&key, BindingScope::Dialog);
             let files_action = self.bindings.lookup(&key, BindingScope::Files);
             if key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL) {
-                input.clear();
+                if let Some(input) = configure_project_text_input_mut(&mut self.prompt) {
+                    input.clear();
+                }
                 return Ok(false);
             }
             match palette_action.or(dialog_action).or(files_action) {
@@ -2652,11 +2677,19 @@ impl App {
                     self.input_target = InputTarget::None;
                 }
                 Some(Action::Confirm) => {
-                    self.apply_configure_startup_command()?;
+                    if matches!(self.prompt, PromptState::ConfigureGlobalEnv { .. }) {
+                        self.apply_configure_global_env()?;
+                    } else if matches!(self.prompt, PromptState::ConfigureProjectEnv { .. }) {
+                        self.apply_configure_project_env()?;
+                    } else {
+                        self.apply_configure_startup_command()?;
+                    }
                 }
                 Some(Action::EngageCommitInput) => {
                     self.input_target = InputTarget::StartupCommand;
-                    input.move_end();
+                    if let Some(input) = configure_project_text_input_mut(&mut self.prompt) {
+                        input.move_end();
+                    }
                 }
                 _ => {
                     if matches!(
@@ -2664,7 +2697,9 @@ impl App {
                         KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
                     ) {
                         self.input_target = InputTarget::StartupCommand;
-                        input.handle_key(key);
+                        if let Some(input) = configure_project_text_input_mut(&mut self.prompt) {
+                            input.handle_key(key);
+                        }
                     }
                 }
             }
@@ -4834,7 +4869,7 @@ impl App {
             OverlayMouseLayout::ConfigureStartupCommand { input } => input,
             _ => return,
         };
-        if let PromptState::ConfigureStartupCommand { input, .. } = &mut self.prompt {
+        if let Some(input) = configure_project_text_input_mut(&mut self.prompt) {
             let display_row = usize::from(row.saturating_sub(input_area.y));
             let display_col = usize::from(column.saturating_sub(input_area.x));
             input.set_cursor_from_display_pos(display_row, display_col);
@@ -6418,6 +6453,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -6431,6 +6467,7 @@ mod tests {
                 leading_branch: project.leading_branch.clone(),
                 auto_reopen_agents: project.auto_reopen_agents,
                 startup_command: project.startup_command.clone(),
+                env: project.env.clone(),
             })
             .expect("seed project");
         let session = AgentSession {
@@ -9069,6 +9106,7 @@ not_a_real_action = ["x"]
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: Default::default(),
                 current_branch: "main".to_string(),
                 branch_status: ProjectBranchStatus::Unknown,
                 path_missing: false,
@@ -13605,6 +13643,7 @@ cyan = "#00ffff"
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -13618,6 +13657,7 @@ cyan = "#00ffff"
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: pinned.env.clone(),
             })
             .expect("seed pinned project");
         app.projects.push(pinned);
@@ -13757,6 +13797,7 @@ cyan = "#00ffff"
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -13770,6 +13811,7 @@ cyan = "#00ffff"
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: pinned.env.clone(),
             })
             .expect("seed pinned project");
         app.projects.push(pinned);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -639,6 +639,15 @@ pub(crate) enum PromptState {
         project_name: String,
         input: TextInput,
     },
+    ConfigureProjectEnv {
+        project_id: String,
+        project_name: String,
+        input: TextInput,
+    },
+    ConfigureGlobalEnv {
+        project_name: String,
+        input: TextInput,
+    },
     #[allow(dead_code)]
     StartupCommandLogs(StartupCommandLogPrompt),
     PickProjectWorktree(PickProjectWorktreePrompt),
@@ -1407,6 +1416,7 @@ pub(crate) enum AgentLaunchKind {
 pub(crate) struct AgentLaunchRequest {
     pub(crate) session: AgentSession,
     pub(crate) provider_config: ProviderCommandConfig,
+    pub(crate) env: Vec<(String, String)>,
     pub(crate) resume: bool,
     pub(crate) pty_size: (u16, u16),
     pub(crate) scrollback_lines: usize,
@@ -1545,6 +1555,10 @@ pub(crate) enum WorkerEvent {
         action: ProjectPersistenceAction,
         result: Result<(), String>,
     },
+    GlobalEnvPersistenceCompleted {
+        env: std::collections::BTreeMap<String, String>,
+        result: Result<(), String>,
+    },
     StartupCommandRerunCompleted(crate::startup::StartupCommandResult),
     StartupCommandLogsLoaded {
         scope_label: String,
@@ -1595,6 +1609,11 @@ pub(crate) enum ProjectPersistenceAction {
         project_id: String,
         project_name: String,
         startup_command: Option<String>,
+    },
+    UpdateEnv {
+        project_id: String,
+        project_name: String,
+        env: std::collections::BTreeMap<String, String>,
     },
 }
 
@@ -2257,6 +2276,8 @@ impl App {
             "toggle-project-auto-reopen-agents" => self.toggle_project_auto_reopen_agents(),
             "toggle-agent-auto-reopen" => self.toggle_agent_auto_reopen(),
             "configure-startup-command" => self.open_configure_startup_command(),
+            "configure-global-env" => self.open_configure_global_env(),
+            "configure-project-env" => self.open_configure_project_env(),
             "rerun-startup-command-on-agent" => self.rerun_startup_command_on_agent(),
             "read-startup-command-logs" => self.open_startup_command_logs(),
             "pull-project" => self.refresh_selected_project(),
@@ -3169,6 +3190,7 @@ pub(crate) fn load_projects(
             leading_branch,
             auto_reopen_agents: project.auto_reopen_agents,
             startup_command: project.startup_command.clone(),
+            env: project.env.clone(),
             current_branch,
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: missing,
@@ -3344,6 +3366,7 @@ fn merge_project_records(
         &mut merged_config.auto_reopen_agents,
         &mut merged_stored.auto_reopen_agents,
     );
+    merged_stored.env = merged_config.env.clone();
 
     Ok((merged_config, merged_stored))
 }
@@ -3418,6 +3441,7 @@ pub(crate) fn runtime_project_to_config(
         leading_branch: project.leading_branch.clone(),
         auto_reopen_agents: project.auto_reopen_agents,
         startup_command: project.startup_command.clone(),
+        env: project.env.clone(),
     }
 }
 
@@ -3558,6 +3582,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -3826,6 +3851,7 @@ leading_branch = "main"
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
                 startup_command: Some("npm install".to_string()),
+                env: Default::default(),
             })
             .expect("seed project");
 
@@ -3873,6 +3899,7 @@ leading_branch = "main"
                 leading_branch: None,
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: Default::default(),
             })
             .expect("seed project");
 
@@ -3932,6 +3959,7 @@ leading_branch = "main"
                 leading_branch: None,
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: Default::default(),
             })
             .expect("seed project");
 
@@ -3989,6 +4017,7 @@ leading_branch = "main"
                 leading_branch: None,
                 auto_reopen_agents: None,
                 startup_command: Some("pnpm install".to_string()),
+                env: Default::default(),
             })
             .expect("seed project");
 
@@ -4137,6 +4166,7 @@ leading_branch = "main"
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Leading,
             path_missing: false,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3377,11 +3377,33 @@ impl App {
                 project_name,
                 input,
                 ..
+            }
+            | PromptState::ConfigureProjectEnv {
+                project_name,
+                input,
+                ..
+            }
+            | PromptState::ConfigureGlobalEnv {
+                project_name,
+                input,
+                ..
             } => {
+                let is_env = matches!(
+                    &self.prompt,
+                    PromptState::ConfigureProjectEnv { .. }
+                        | PromptState::ConfigureGlobalEnv { .. }
+                );
+                let is_global_env = matches!(&self.prompt, PromptState::ConfigureGlobalEnv { .. });
                 self.render_dim_overlay(frame);
-                let area = centered_rect_exact(76, 16, frame.area());
+                let area = centered_rect_exact(76, if is_env { 18 } else { 16 }, frame.area());
                 self.clear_overlay_area(frame, area);
-                let outer = self.themed_overlay_block("Configure Startup Command");
+                let outer = self.themed_overlay_block(if is_global_env {
+                    "Configure Global Environment"
+                } else if is_env {
+                    "Configure Project Environment"
+                } else {
+                    "Configure Startup Command"
+                });
                 let inner = outer.inner(area);
                 outer.render(area, frame.buffer_mut());
                 let [label_area, input_area, hint_area] = Layout::default()
@@ -3394,14 +3416,25 @@ impl App {
                     .areas(inner);
                 Paragraph::new(vec![
                     Line::from(vec![
-                        Span::styled(" Project: ", Style::default().fg(self.theme.input_label_fg)),
+                        Span::styled(
+                            if is_global_env {
+                                " Scope: "
+                            } else {
+                                " Project: "
+                            },
+                            Style::default().fg(self.theme.input_label_fg),
+                        ),
                         Span::styled(
                             project_name.clone(),
                             Style::default().fg(self.theme.input_label_fg),
                         ),
                     ]),
                     Line::from(Span::styled(
-                        " Enter a command to run before the provider launches:",
+                        if is_env {
+                            " Enter one variable per line as KEY=value:"
+                        } else {
+                            " Enter a command to run before the provider launches:"
+                        },
                         Style::default().fg(self.theme.input_label_fg),
                     )),
                 ])

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -158,6 +158,7 @@ impl App {
             leading_branch: Some(leading_branch),
             auto_reopen_agents: None,
             startup_command: None,
+            env: std::collections::BTreeMap::new(),
             current_branch: branch,
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -436,9 +437,18 @@ impl App {
         kind: AgentLaunchKind,
     ) -> AgentLaunchRequest {
         let cfg = provider_config(&self.config, &session.provider);
+        let env = self
+            .projects
+            .iter()
+            .find(|project| project.id == session.project_id)
+            .and_then(|project| {
+                crate::config::resolve_agent_env(&self.config.env, &project.env).ok()
+            })
+            .unwrap_or_default();
         AgentLaunchRequest {
             session,
             provider_config: cfg,
+            env,
             resume,
             pty_size: self.pty_size_for_launch(),
             scrollback_lines: self.config.ui.agent_scrollback_lines,
@@ -484,13 +494,22 @@ impl App {
             cols,
             rows,
         ));
-        PtyClient::spawn(
+        let env = self
+            .projects
+            .iter()
+            .find(|project| project.id == session.project_id)
+            .and_then(|project| {
+                crate::config::resolve_agent_env(&self.config.env, &project.env).ok()
+            })
+            .unwrap_or_default();
+        PtyClient::spawn_with_env(
             &self.config.terminal.command,
             &self.config.terminal.args,
             Path::new(&session.worktree_path),
             rows,
             cols,
             self.config.ui.agent_scrollback_lines,
+            &env,
         )
     }
 
@@ -1438,6 +1457,96 @@ impl App {
         Ok(())
     }
 
+    pub(crate) fn open_configure_project_env(&mut self) -> Result<()> {
+        let Some(project) = self.selected_project().cloned() else {
+            self.set_error("Select a project first.");
+            return Ok(());
+        };
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::ConfigureProjectEnv {
+            project_id: project.id,
+            project_name: project.name.clone(),
+            input: TextInput::with_text(crate::config::project_env_to_lines(&project.env))
+                .with_multiline(8)
+                .with_placeholder("KEY=value"),
+        };
+        self.set_info("Enter one environment variable per line as KEY=value. Empty clears them.");
+        Ok(())
+    }
+
+    pub(crate) fn open_configure_global_env(&mut self) -> Result<()> {
+        self.input_target = InputTarget::None;
+        self.fullscreen_overlay = FullscreenOverlay::None;
+        self.prompt = PromptState::ConfigureGlobalEnv {
+            project_name: "All projects".to_string(),
+            input: TextInput::with_text(crate::config::project_env_to_lines(&self.config.env))
+                .with_multiline(8)
+                .with_placeholder("KEY=value"),
+        };
+        self.set_info("Enter global environment variables as KEY=value. Empty clears them.");
+        Ok(())
+    }
+
+    pub(crate) fn apply_configure_global_env(&mut self) -> Result<()> {
+        let env = match &self.prompt {
+            PromptState::ConfigureGlobalEnv { input, .. } => {
+                match crate::config::parse_project_env_lines(&input.text) {
+                    Ok(env) => env,
+                    Err(err) => {
+                        self.set_error(format!(
+                            "Global environment variables are invalid: {err:#}"
+                        ));
+                        return Ok(());
+                    }
+                }
+            }
+            _ => return Ok(()),
+        };
+        self.prompt = PromptState::None;
+        self.input_target = InputTarget::None;
+        self.spawn_global_env_persistence(env);
+        self.set_busy("Saving global environment variables to config.toml...");
+        Ok(())
+    }
+
+    pub(crate) fn apply_configure_project_env(&mut self) -> Result<()> {
+        let (project_id, project_name, env) = match &self.prompt {
+            PromptState::ConfigureProjectEnv {
+                project_id,
+                project_name,
+                input,
+            } => {
+                let env = match crate::config::parse_project_env_lines(&input.text) {
+                    Ok(env) => env,
+                    Err(err) => {
+                        self.set_error(format!(
+                            "Environment variables for project \"{project_name}\" are invalid: {err:#}"
+                        ));
+                        return Ok(());
+                    }
+                };
+                (project_id.clone(), project_name.clone(), env)
+            }
+            _ => return Ok(()),
+        };
+        self.prompt = PromptState::None;
+        self.input_target = InputTarget::None;
+        if !self.projects.iter().any(|project| project.id == project_id) {
+            self.set_error(format!("Could not find project \"{project_name}\"."));
+            return Ok(());
+        }
+        self.spawn_project_persistence(ProjectPersistenceAction::UpdateEnv {
+            project_id,
+            project_name: project_name.clone(),
+            env,
+        });
+        self.set_busy(format!(
+            "Saving environment variables for project \"{project_name}\"..."
+        ));
+        Ok(())
+    }
+
     pub(crate) fn rerun_startup_command_on_agent(&mut self) -> Result<()> {
         let Some(session) = self.selected_session().cloned() else {
             self.set_error("Select an agent first.");
@@ -1469,6 +1578,8 @@ impl App {
         let tx = self.worker_tx.clone();
         let branch = session.branch_name.clone();
         let terminal = self.config.startup_command_terminal.clone();
+        let env =
+            crate::config::resolve_agent_env(&self.config.env, &project.env).unwrap_or_default();
         std::thread::spawn(move || {
             let result = crate::startup::run_startup_command(
                 &paths,
@@ -1477,6 +1588,7 @@ impl App {
                     session,
                     command,
                     terminal,
+                    env,
                 },
             );
             let _ = tx.send(WorkerEvent::StartupCommandRerunCompleted(result));
@@ -2704,6 +2816,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -2858,6 +2971,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -577,6 +577,24 @@ impl App {
                 WorkerEvent::ProjectPersistenceCompleted { action, result } => {
                     self.apply_project_persistence_result(action, result);
                 }
+                WorkerEvent::GlobalEnvPersistenceCompleted { env, result } => match result {
+                    Ok(()) => {
+                        self.config.env = env;
+                        if self.config.env.is_empty() {
+                            self.set_info("Global environment variables cleared.");
+                        } else {
+                            self.set_info(format!(
+                                "Saved {} global environment variable(s). New agents and terminals will receive them unless a project overrides the same key.",
+                                self.config.env.len()
+                            ));
+                        }
+                    }
+                    Err(err) => {
+                        self.set_error(format!(
+                            "Could not save global environment variables to config.toml: {err}"
+                        ));
+                    }
+                },
                 WorkerEvent::StartupCommandRerunCompleted(result) => match result.status {
                     Ok(()) => {
                         let palette_key = self.bindings.label_for(Action::OpenPalette);
@@ -804,6 +822,11 @@ impl App {
                         "Could not save the startup command for project \"{project_name}\": {err}"
                     ));
                 }
+                ProjectPersistenceAction::UpdateEnv { project_name, .. } => {
+                    self.set_error(format!(
+                        "Could not save environment variables for project \"{project_name}\": {err}"
+                    ));
+                }
             }
             return;
         }
@@ -949,6 +972,35 @@ impl App {
                     )),
                 }
             }
+            ProjectPersistenceAction::UpdateEnv {
+                project_id,
+                project_name,
+                env,
+            } => {
+                if let Some(project) = self
+                    .projects
+                    .iter_mut()
+                    .find(|project| project.id == project_id)
+                {
+                    project.env = env.clone();
+                }
+                if let Err(err) = self.persist_config_projects_from_runtime() {
+                    self.set_error(format!(
+                        "Environment variables saved to the database for \"{project_name}\", but config.toml could not be updated: {err:#}"
+                    ));
+                    return;
+                }
+                if env.is_empty() {
+                    self.set_info(format!(
+                        "Environment variables cleared for project \"{project_name}\"."
+                    ));
+                } else {
+                    self.set_info(format!(
+                        "Saved {} environment variable(s) for project \"{project_name}\". New agents and terminals will receive them.",
+                        env.len()
+                    ));
+                }
+            }
         }
     }
 
@@ -971,6 +1023,7 @@ impl App {
                             leading_branch: project.leading_branch.clone(),
                             auto_reopen_agents: project.auto_reopen_agents,
                             startup_command: project.startup_command.clone(),
+                            env: project.env.clone(),
                         })?;
                     }
                     ProjectPersistenceAction::Remove { project_id, .. }
@@ -1004,11 +1057,32 @@ impl App {
                             startup_command.as_deref(),
                         )?;
                     }
+                    ProjectPersistenceAction::UpdateEnv {
+                        project_id, env, ..
+                    } => {
+                        store.update_project_env(project_id, env)?;
+                    }
                 }
                 Ok(())
             })()
             .map_err(|err| format!("{err:#}"));
             let _ = tx.send(WorkerEvent::ProjectPersistenceCompleted { action, result });
+        });
+    }
+
+    pub(crate) fn spawn_global_env_persistence(
+        &self,
+        env: std::collections::BTreeMap<String, String>,
+    ) {
+        let mut config = self.config.clone();
+        config.env = env.clone();
+        let config_path = self.paths.config_path.clone();
+        let tx = self.worker_tx.clone();
+        thread::spawn(move || {
+            let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
+            let result = crate::config::save_config(&config_path, &config, &bindings)
+                .map_err(|err| format!("{err:#}"));
+            let _ = tx.send(WorkerEvent::GlobalEnvPersistenceCompleted { env, result });
         });
     }
 
@@ -2217,6 +2291,16 @@ pub(crate) fn run_create_agent_job(
         let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(hint));
         return;
     }
+    let env = match crate::config::resolve_agent_env(&config.env, &project.env) {
+        Ok(env) => env,
+        Err(err) => {
+            let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(format!(
+                "Invalid environment variables for project \"{}\": {err:#}",
+                project.name
+            )));
+            return;
+        }
+    };
     let startup_result = project
         .startup_command
         .as_deref()
@@ -2234,6 +2318,7 @@ pub(crate) fn run_create_agent_job(
                     session: session.clone(),
                     command: command.to_string(),
                     terminal: config.startup_command_terminal.clone(),
+                    env: env.clone(),
                 },
             )
         });
@@ -2268,6 +2353,7 @@ pub(crate) fn run_create_agent_job(
     let request = AgentLaunchRequest {
         session,
         provider_config: provider_cfg,
+        env,
         resume: launch_with_resume,
         pty_size: (rows, cols),
         scrollback_lines: config.ui.agent_scrollback_lines,
@@ -2294,13 +2380,14 @@ pub(crate) fn run_agent_launch_job(request: AgentLaunchRequest, worker_tx: Sende
         request.provider_config.supports_session_resume()
     ));
 
-    let client = match PtyClient::spawn(
+    let client = match PtyClient::spawn_with_env(
         &request.provider_config.command,
         launch_args,
         Path::new(&request.session.worktree_path),
         rows,
         cols,
         request.scrollback_lines,
+        &request.env,
     ) {
         Ok(client) => client,
         Err(err) => {
@@ -2710,6 +2797,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -2774,6 +2862,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Unknown,
             path_missing: false,
@@ -2831,6 +2920,7 @@ mod tests {
             leading_branch: Some("trunk".to_string()),
             auto_reopen_agents: None,
             startup_command: None,
+            env: Default::default(),
             current_branch: "feature".to_string(),
             branch_status: ProjectBranchStatus::NotLeading,
             path_missing: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ Rules:
 #[serde(default)]
 pub struct Config {
     pub defaults: Defaults,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
     pub providers: ProvidersConfig,
     pub terminal: TerminalConfig,
     pub startup_command_terminal: StartupCommandTerminalConfig,
@@ -188,6 +190,8 @@ pub struct ProjectConfig {
     pub leading_branch: Option<String>,
     pub auto_reopen_agents: Option<bool>,
     pub startup_command: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
 }
 
 fn new_project_id() -> String {
@@ -221,6 +225,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             defaults: Defaults::default(),
+            env: BTreeMap::new(),
             providers: ProvidersConfig::default(),
             terminal: TerminalConfig::default(),
             startup_command_terminal: StartupCommandTerminalConfig::default(),
@@ -480,7 +485,21 @@ pub fn ensure_config(paths: &DuxPaths) -> Result<Config> {
     let mut config: Config = toml::from_str(&doc.to_string())
         .with_context(|| format!("failed to parse {}", paths.config_path.display()))?;
     config.providers.ensure_defaults();
+    validate_project_envs(&config)?;
     Ok(config)
+}
+
+fn validate_project_envs(config: &Config) -> Result<()> {
+    for project in &config.projects {
+        resolve_agent_env(&config.env, &project.env).with_context(|| {
+            format!(
+                "invalid env for project {}",
+                project.name.as_deref().unwrap_or(&project.path)
+            )
+        })?;
+    }
+    resolve_project_env(&config.env).context("invalid global env")?;
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -609,6 +628,8 @@ enum ConfigEntry {
     Providers,
     /// Renders `[[projects]]` declarations.
     Projects,
+    /// Renders the top-level `[env]` table.
+    Env,
     /// Renders the `[terminal]` section.
     Terminal,
     /// Renders the `[startup_command_terminal]` section.
@@ -672,6 +693,8 @@ fn config_schema(generate_commit_key: &str) -> Vec<ConfigEntry> {
             )),
             value_fn: |c| FieldValue::Bool(c.defaults.pull_before_creating_agent_by_default),
         },
+        ConfigEntry::Blank,
+        ConfigEntry::Env,
         ConfigEntry::Blank,
         ConfigEntry::Projects,
         ConfigEntry::Blank,
@@ -864,6 +887,7 @@ fn render_config(config: &Config, bindings: &crate::keybindings::RuntimeBindings
                 }
             }
             ConfigEntry::Providers => render_provider_configs(&mut out, &config.providers),
+            ConfigEntry::Env => render_env_config(&mut out, &config.env),
             ConfigEntry::Projects => render_project_configs(&mut out, &config.projects),
             ConfigEntry::Terminal => render_terminal_config(&mut out, &config.terminal),
             ConfigEntry::StartupCommandTerminal => {
@@ -946,6 +970,9 @@ pub fn save_config(
         config.defaults.pull_before_creating_agent_by_default,
     );
     remove_table_key(&mut doc, "defaults", "prompt_for_name");
+
+    // --- [env] ---
+    patch_env_table(&mut doc, "env", &config.env);
 
     // --- [logging] ---
     patch_table_str(&mut doc, "logging", "level", &config.logging.level);
@@ -1258,9 +1285,30 @@ fn patch_projects(doc: &mut DocumentMut, projects: &[ProjectConfig]) {
         if let Some(command) = project.startup_command.as_deref() {
             table["startup_command"] = toml_edit::value(command);
         }
+        if !project.env.is_empty() {
+            let mut inline = InlineTable::new();
+            for (name, value) in &project.env {
+                inline.insert(name, Value::String(Formatted::new(value.clone())));
+            }
+            table["env"] = toml_edit::value(Value::InlineTable(inline));
+        }
         array.push(table);
     }
     doc["projects"] = Item::ArrayOfTables(array);
+}
+
+fn patch_env_table(doc: &mut DocumentMut, section: &str, env: &BTreeMap<String, String>) {
+    let table = ensure_table(doc, section);
+    let existing = table
+        .iter()
+        .map(|(key, _)| key.to_string())
+        .collect::<Vec<_>>();
+    for key in existing {
+        table.remove(&key);
+    }
+    for (name, value) in env {
+        table[name] = toml_edit::value(value.as_str());
+    }
 }
 
 fn render_keys_config(
@@ -1521,7 +1569,9 @@ fn render_project_configs(out: &mut String, projects: &[ProjectConfig]) {
     out.push_str(
         "# Projects are mirrored with dux's runtime database.\n\
          # Paths may use $HOME, ${HOME}, or ~ for portability across machines.\n\
-         # startup_command runs in each new agent worktree before the provider launches.\n",
+         # startup_command runs in each new agent worktree before the provider launches.\n\
+         # env defines per-project variables passed to agent and companion terminal PTYs.\n\
+         # Values may reference existing environment variables with $VAR or ${VAR}.\n",
     );
     if projects.is_empty() {
         out.push_str(
@@ -1531,7 +1581,8 @@ fn render_project_configs(out: &mut String, projects: &[ProjectConfig]) {
              # name = \"example\"\n\
              # default_provider = \"codex\"\n\
              # auto_reopen_agents = true\n\
-             # startup_command = \"npm install\"\n\n",
+             # startup_command = \"npm install\"\n\
+             # env = { EDITOR = \"true\", API_KEY = \"${FOOBAR_API_KEY}\" }\n\n",
         );
         return;
     }
@@ -1561,8 +1612,38 @@ fn render_project_configs(out: &mut String, projects: &[ProjectConfig]) {
                 escape_toml_string(command)
             ));
         }
+        if !project.env.is_empty() {
+            out.push_str("env = { ");
+            for (index, (key, value)) in project.env.iter().enumerate() {
+                if index > 0 {
+                    out.push_str(", ");
+                }
+                out.push_str(&format!("{} = \"{}\"", key, escape_toml_string(value)));
+            }
+            out.push_str(" }\n");
+        }
         out.push('\n');
     }
+}
+
+fn render_env_config(out: &mut String, env: &BTreeMap<String, String>) {
+    out.push_str("[env]\n");
+    out.push_str(
+        "# Environment variables passed to every agent PTY, companion terminal,\n\
+         # and startup command. Project-level env overrides keys defined here.\n\
+         # Values may reference existing environment variables with $VAR or ${VAR}.\n",
+    );
+    if env.is_empty() {
+        out.push_str(
+            "# EDITOR = \"true\"\n\
+             # API_KEY = \"${FOOBAR_API_KEY}\"\n\n",
+        );
+        return;
+    }
+    for (name, value) in env {
+        out.push_str(&format!("{} = \"{}\"\n", name, escape_toml_string(value)));
+    }
+    out.push('\n');
 }
 
 fn render_terminal_config(out: &mut String, terminal: &TerminalConfig) {
@@ -1817,6 +1898,71 @@ pub fn expand_env_vars(raw: &str) -> Option<String> {
     Some(result)
 }
 
+pub fn resolve_project_env(env: &BTreeMap<String, String>) -> Result<Vec<(String, String)>> {
+    let mut resolved = Vec::with_capacity(env.len());
+    for (name, value) in env {
+        validate_project_env_name(name)?;
+        let expanded = expand_env_vars(value)
+            .ok_or_else(|| anyhow!("environment variable {name} has invalid expansion syntax"))?;
+        if expanded.contains('\0') {
+            bail!("environment variable {name} contains a NUL byte");
+        }
+        resolved.push((name.clone(), expanded));
+    }
+    Ok(resolved)
+}
+
+pub fn resolve_agent_env(
+    global_env: &BTreeMap<String, String>,
+    project_env: &BTreeMap<String, String>,
+) -> Result<Vec<(String, String)>> {
+    let mut merged = global_env.clone();
+    merged.extend(project_env.clone());
+    resolve_project_env(&merged)
+}
+
+pub fn project_env_to_lines(env: &BTreeMap<String, String>) -> String {
+    env.iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn parse_project_env_lines(raw: &str) -> Result<BTreeMap<String, String>> {
+    let mut env = BTreeMap::new();
+    for (index, line) in raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some((name, value)) = trimmed.split_once('=') else {
+            bail!("line {} must use KEY=value syntax", index + 1);
+        };
+        let name = name.trim();
+        validate_project_env_name(name)
+            .with_context(|| format!("line {} has an invalid variable name", index + 1))?;
+        if value.contains('\0') {
+            bail!("line {} contains a NUL byte", index + 1);
+        }
+        expand_env_vars(value).ok_or_else(|| {
+            anyhow!(
+                "line {} has invalid environment variable expansion syntax",
+                index + 1
+            )
+        })?;
+        env.insert(name.to_string(), value.to_string());
+    }
+    Ok(env)
+}
+
+fn validate_project_env_name(name: &str) -> Result<()> {
+    if is_valid_var_name(name) {
+        Ok(())
+    } else {
+        bail!("expected [A-Za-z_][A-Za-z0-9_]*")
+    }
+}
+
 /// Expand environment variables (`$VAR`, `${VAR}`) and tilde (`~`) in a path
 /// string.  Returns `None` when the result is unsafe (relative path, directory
 /// traversal via `..`, or invalid variable names).
@@ -1995,6 +2141,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: Some("npm install".to_string()),
+            env: Default::default(),
         });
         let rendered = render_config_default(&config);
         assert!(rendered.contains("[[projects]]"));
@@ -2081,6 +2228,7 @@ name = "test"
             leading_branch: None,
             auto_reopen_agents: None,
             startup_command: Some("echo ready".to_string()),
+            env: Default::default(),
         });
         let bindings = crate::keybindings::RuntimeBindings::from_keys_config(&config.keys);
         save_config(&config_path, &config, &bindings).expect("save config");
@@ -3055,5 +3203,47 @@ args = [\"-l\"]
     #[test]
     fn expand_path_rejects_empty_braced_var_name() {
         assert!(expand_path("${}/foo").is_none());
+    }
+
+    #[test]
+    fn project_env_lines_parse_and_expand() {
+        unsafe { std::env::set_var("DUX_TEST_PROJECT_ENV_SOURCE", "secret") };
+        let env = parse_project_env_lines("EDITOR=true\nAPI_KEY=${DUX_TEST_PROJECT_ENV_SOURCE}")
+            .expect("parse env");
+        let resolved = resolve_project_env(&env).expect("resolve env");
+        assert!(resolved.contains(&("EDITOR".to_string(), "true".to_string())));
+        assert!(resolved.contains(&("API_KEY".to_string(), "secret".to_string())));
+        unsafe { std::env::remove_var("DUX_TEST_PROJECT_ENV_SOURCE") };
+    }
+
+    #[test]
+    fn project_env_lines_reject_invalid_names_and_expansions() {
+        assert!(parse_project_env_lines("1BAD=value").is_err());
+        assert!(parse_project_env_lines("GOOD=${}").is_err());
+        assert!(parse_project_env_lines("MISSING_EQUALS").is_err());
+    }
+
+    #[test]
+    fn agent_env_merges_global_and_project_with_project_override() {
+        let global = BTreeMap::from([
+            ("EDITOR".to_string(), "true".to_string()),
+            ("API_KEY".to_string(), "global".to_string()),
+        ]);
+        let project = BTreeMap::from([("API_KEY".to_string(), "project".to_string())]);
+
+        let resolved = resolve_agent_env(&global, &project).expect("resolve env");
+
+        assert!(resolved.contains(&("EDITOR".to_string(), "true".to_string())));
+        assert!(resolved.contains(&("API_KEY".to_string(), "project".to_string())));
+        assert!(!resolved.contains(&("API_KEY".to_string(), "global".to_string())));
+    }
+
+    #[test]
+    fn rendered_default_config_documents_global_env() {
+        let rendered = render_default_config();
+
+        assert!(rendered.contains("[env]"));
+        assert!(rendered.contains("# EDITOR = \"true\""));
+        assert!(rendered.contains("# API_KEY = \"${FOOBAR_API_KEY}\""));
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -95,6 +95,8 @@ pub enum Action {
     ToggleProjectAutoReopenAgents,
     ToggleAgentAutoReopen,
     ConfigureStartupCommand,
+    ConfigureGlobalEnv,
+    ConfigureProjectEnv,
     RerunStartupCommandOnAgent,
     ReadStartupCommandLogs,
     ToggleRandomizedPetNameDefault,
@@ -280,6 +282,8 @@ impl Action {
             Action::ToggleProjectAutoReopenAgents => "toggle_project_auto_reopen_agents",
             Action::ToggleAgentAutoReopen => "toggle_agent_auto_reopen",
             Action::ConfigureStartupCommand => "configure_startup_command",
+            Action::ConfigureGlobalEnv => "configure_global_env",
+            Action::ConfigureProjectEnv => "configure_project_env",
             Action::RerunStartupCommandOnAgent => "rerun_startup_command_on_agent",
             Action::ReadStartupCommandLogs => "read_startup_command_logs",
             Action::ToggleRandomizedPetNameDefault => "toggle_randomized_pet_name_default",
@@ -397,6 +401,12 @@ impl Action {
             Action::ConfigureStartupCommand => {
                 "Configure the selected project's startup command for newly created agents."
             }
+            Action::ConfigureGlobalEnv => {
+                "Configure environment variables for every project's agents and terminals."
+            }
+            Action::ConfigureProjectEnv => {
+                "Configure the selected project's environment variables for agents and terminals."
+            }
             Action::RerunStartupCommandOnAgent => {
                 "Rerun the selected agent's project startup command."
             }
@@ -497,6 +507,8 @@ impl Action {
             | Action::ToggleProjectAutoReopenAgents
             | Action::ToggleAgentAutoReopen
             | Action::ConfigureStartupCommand
+            | Action::ConfigureGlobalEnv
+            | Action::ConfigureProjectEnv
             | Action::RerunStartupCommandOnAgent
             | Action::ReadStartupCommandLogs
             | Action::ToggleRandomizedPetNameDefault
@@ -733,6 +745,28 @@ pub const BINDING_DEFS: &[BindingDef] = &[
         palette: Some(PaletteEntry {
             name: "configure-startup-command",
             description: "Configure the selected project's startup command",
+        }),
+    },
+    BindingDef {
+        action: Action::ConfigureGlobalEnv,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "configure-global-env",
+            description: "Configure environment variables inherited by every project",
+        }),
+    },
+    BindingDef {
+        action: Action::ConfigureProjectEnv,
+        default_keys: &[],
+        scopes: &[],
+        help: None,
+        hint_contexts: &[],
+        palette: Some(PaletteEntry {
+            name: "configure-project-env",
+            description: "Configure environment variables for the selected project's agents and terminals",
         }),
     },
     BindingDef {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 
 /// GitHub CLI availability status, checked once at startup.
@@ -60,6 +62,7 @@ pub struct Project {
     pub leading_branch: Option<String>,
     pub auto_reopen_agents: Option<bool>,
     pub startup_command: Option<String>,
+    pub env: BTreeMap<String, String>,
     pub current_branch: String,
     pub branch_status: ProjectBranchStatus,
     pub path_missing: bool,

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -106,6 +106,7 @@ struct PendingIngest {
 
 impl PtyClient {
     /// Spawn a CLI command in a new PTY with the given size.
+    #[allow(dead_code)]
     pub fn spawn(
         command: &str,
         args: &[String],
@@ -113,6 +114,18 @@ impl PtyClient {
         rows: u16,
         cols: u16,
         scrollback_lines: usize,
+    ) -> Result<Self> {
+        Self::spawn_with_env(command, args, cwd, rows, cols, scrollback_lines, &[])
+    }
+
+    pub fn spawn_with_env(
+        command: &str,
+        args: &[String],
+        cwd: &Path,
+        rows: u16,
+        cols: u16,
+        scrollback_lines: usize,
+        env: &[(String, String)],
     ) -> Result<Self> {
         let pty_system = NativePtySystem::default();
         let pair = pty_system
@@ -130,6 +143,9 @@ impl PtyClient {
         }
         cmd.cwd(cwd);
         apply_terminal_env(&mut cmd);
+        for (name, value) in env {
+            cmd.env(name, value);
+        }
 
         let child = pair
             .slave
@@ -1174,6 +1190,39 @@ mod tests {
         assert_eq!(
             cmd.get_env("COLORTERM").and_then(|value| value.to_str()),
             Some("truecolor")
+        );
+    }
+
+    #[test]
+    fn spawn_with_env_passes_custom_environment() {
+        let args = vec!["-c".to_string(), "printf \"$DUX_TEST_PTY_ENV\"".to_string()];
+        let mut client = PtyClient::spawn_with_env(
+            "/bin/sh",
+            &args,
+            Path::new("."),
+            5,
+            40,
+            100,
+            &[("DUX_TEST_PTY_ENV".to_string(), "visible".to_string())],
+        )
+        .expect("spawn pty");
+
+        for _ in 0..20 {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            let snapshot = client.snapshot();
+            if viewport_lines(&snapshot)
+                .iter()
+                .any(|line| line.contains("visible"))
+            {
+                let _ = client.try_wait();
+                return;
+            }
+        }
+
+        let snapshot = client.snapshot();
+        panic!(
+            "expected custom env output, got {:?}",
+            viewport_lines(&snapshot)
         );
     }
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -17,6 +17,7 @@ pub struct StartupCommandRun {
     pub session: AgentSession,
     pub command: String,
     pub terminal: StartupCommandTerminalConfig,
+    pub env: Vec<(String, String)>,
 }
 
 #[derive(Clone, Debug)]
@@ -189,7 +190,8 @@ pub fn run_startup_command(paths: &DuxPaths, run: StartupCommandRun) -> StartupC
         let shell_args = run.terminal.args.clone();
         let started = Utc::now();
         let started_instant = Instant::now();
-        let output = Command::new(&shell)
+        let mut command = Command::new(&shell);
+        command
             .args(&shell_args)
             .arg(&run.command)
             .current_dir(&run.session.worktree_path)
@@ -198,7 +200,11 @@ pub fn run_startup_command(paths: &DuxPaths, run: StartupCommandRun) -> StartupC
             .env("DUX_AGENT_ID", &run.session.id)
             .env("DUX_AGENT_BRANCH", &run.session.branch_name)
             .env("DUX_PROVIDER", run.session.provider.as_str())
-            .env("DUX_STARTUP_COMMAND_LOG", &log_path)
+            .env("DUX_STARTUP_COMMAND_LOG", &log_path);
+        for (name, value) in &run.env {
+            command.env(name, value);
+        }
+        let output = command
             .output()
             .with_context(|| format!("failed to run startup command through {shell}"))?;
         let ended = Utc::now();
@@ -368,6 +374,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: None,
             startup_command: Some("echo setup".to_string()),
+            env: Default::default(),
             current_branch: "main".to_string(),
             branch_status: ProjectBranchStatus::Leading,
             path_missing: false,
@@ -410,6 +417,7 @@ mod tests {
                     command: "/bin/sh".to_string(),
                     args: vec!["-c".to_string()],
                 },
+                env: Vec::new(),
             },
         );
 
@@ -450,6 +458,7 @@ mod tests {
                     command: "/bin/sh".to_string(),
                     args: vec!["-c".to_string()],
                 },
+                env: Vec::new(),
             },
         );
 
@@ -459,6 +468,34 @@ mod tests {
         assert!(log.contains("exit_code = 7"));
         assert!(log.contains("--- stderr ---"));
         assert!(log.contains("nope"));
+    }
+
+    #[test]
+    fn startup_command_receives_project_env() {
+        let tmp = tempdir().expect("tempdir");
+        let paths = test_paths(tmp.path());
+        let project = test_project(tmp.path());
+        let session = test_session(tmp.path());
+        let result = run_startup_command(
+            &paths,
+            StartupCommandRun {
+                project,
+                session,
+                command: "printf \"$EDITOR:$API_KEY\"".to_string(),
+                terminal: StartupCommandTerminalConfig {
+                    command: "/bin/sh".to_string(),
+                    args: vec!["-c".to_string()],
+                },
+                env: vec![
+                    ("EDITOR".to_string(), "true".to_string()),
+                    ("API_KEY".to_string(), "secret".to_string()),
+                ],
+            },
+        );
+
+        assert!(result.status.is_ok());
+        let log = read_log(&result.log_path).expect("log");
+        assert!(log.contains("--- stdout ---\ntrue:secret"));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
@@ -58,6 +60,7 @@ impl SessionStore {
                 leading_branch text,
                 auto_reopen_agents integer,
                 startup_command text,
+                env text not null default '{}',
                 sort_order integer not null default 0,
                 created_at text not null,
                 updated_at text not null
@@ -69,6 +72,7 @@ impl SessionStore {
         ensure_column(&self.conn, "projects", "leading_branch", "text")?;
         ensure_column(&self.conn, "projects", "auto_reopen_agents", "integer")?;
         ensure_column(&self.conn, "projects", "startup_command", "text")?;
+        ensure_column(&self.conn, "projects", "env", "text not null default '{}'")?;
         ensure_column(
             &self.conn,
             "projects",
@@ -161,8 +165,9 @@ impl SessionStore {
                 leading_branch = ?5,
                 auto_reopen_agents = ?6,
                 startup_command = ?7,
-                sort_order = ?8,
-                updated_at = ?9
+                env = ?8,
+                sort_order = ?9,
+                updated_at = ?10
             where id = ?1
             "#,
             params![
@@ -173,6 +178,7 @@ impl SessionStore {
                 project.leading_branch,
                 project.auto_reopen_agents,
                 project.startup_command,
+                serialize_project_env(&project.env),
                 sort_order,
                 now,
             ],
@@ -184,15 +190,16 @@ impl SessionStore {
         self.conn.execute(
             r#"
             insert into projects
-                (id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command, sort_order, created_at, updated_at)
+                (id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command, env, sort_order, created_at, updated_at)
             values
-                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?9)
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)
             on conflict(path) do update set
                 name=excluded.name,
                 default_provider=excluded.default_provider,
                 leading_branch=excluded.leading_branch,
                 auto_reopen_agents=excluded.auto_reopen_agents,
                 startup_command=excluded.startup_command,
+                env=excluded.env,
                 sort_order=excluded.sort_order,
                 updated_at=excluded.updated_at
             "#,
@@ -204,6 +211,7 @@ impl SessionStore {
                 project.leading_branch,
                 project.auto_reopen_agents,
                 project.startup_command,
+                serialize_project_env(&project.env),
                 sort_order,
                 now,
             ],
@@ -224,7 +232,7 @@ impl SessionStore {
     pub fn load_projects(&self) -> Result<Vec<ProjectConfig>> {
         let mut stmt = self.conn.prepare(
             r#"
-            select id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command
+            select id, path, name, default_provider, leading_branch, auto_reopen_agents, startup_command, env
             from projects
             order by sort_order, name collate nocase, path collate nocase
             "#,
@@ -238,6 +246,7 @@ impl SessionStore {
                 leading_branch: row.get(4)?,
                 auto_reopen_agents: row.get(5)?,
                 startup_command: row.get(6)?,
+                env: deserialize_project_env(row.get::<_, String>(7)?.as_str()),
             })
         })?;
 
@@ -295,6 +304,27 @@ impl SessionStore {
             where id = ?1
             "#,
             params![project_id, startup_command, Utc::now().to_rfc3339()],
+        )?;
+        Ok(())
+    }
+
+    pub fn update_project_env(
+        &self,
+        project_id: &str,
+        env: &BTreeMap<String, String>,
+    ) -> Result<()> {
+        self.conn.execute(
+            r#"
+            update projects
+            set env = ?2,
+                updated_at = ?3
+            where id = ?1
+            "#,
+            params![
+                project_id,
+                serialize_project_env(env),
+                Utc::now().to_rfc3339()
+            ],
         )?;
         Ok(())
     }
@@ -501,6 +531,14 @@ fn parse_time(value: &str) -> Option<DateTime<Utc>> {
         .map(|dt| dt.with_timezone(&Utc))
 }
 
+fn serialize_project_env(env: &BTreeMap<String, String>) -> String {
+    serde_json::to_string(env).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn deserialize_project_env(value: &str) -> BTreeMap<String, String> {
+    serde_json::from_str::<BTreeMap<String, String>>(value).unwrap_or_default()
+}
+
 fn serialize_started_providers(started_providers: &[String]) -> String {
     serde_json::to_string(started_providers).unwrap_or_else(|_| "[]".to_string())
 }
@@ -632,6 +670,7 @@ mod tests {
             leading_branch: Some("main".to_string()),
             auto_reopen_agents: Some(false),
             startup_command: Some("npm install".to_string()),
+            env: BTreeMap::from([("EDITOR".to_string(), "true".to_string())]),
         };
 
         store.upsert_project(&project).unwrap();
@@ -652,6 +691,7 @@ mod tests {
                 leading_branch: Some("main".to_string()),
                 auto_reopen_agents: None,
                 startup_command: None,
+                env: Default::default(),
             })
             .unwrap();
 
@@ -664,6 +704,7 @@ mod tests {
                 leading_branch: Some("trunk".to_string()),
                 auto_reopen_agents: Some(false),
                 startup_command: Some("echo setup".to_string()),
+                env: BTreeMap::from([("API_KEY".to_string(), "${FOO_API_KEY}".to_string())]),
             })
             .unwrap();
 
@@ -675,6 +716,10 @@ mod tests {
         assert_eq!(loaded[0].leading_branch.as_deref(), Some("trunk"));
         assert_eq!(loaded[0].auto_reopen_agents, Some(false));
         assert_eq!(loaded[0].startup_command.as_deref(), Some("echo setup"));
+        assert_eq!(
+            loaded[0].env.get("API_KEY").map(String::as_str),
+            Some("${FOO_API_KEY}")
+        );
     }
 
     #[test]


### PR DESCRIPTION
This adds environment variable support at both the global config level and per project. Global values apply to new agents, companion terminals, and startup commands, while project values can override the same keys when needed.

The config renderer, README, command palette, storage, and launch paths now understand these settings so they stay documented, persisted, and applied consistently.