### PR TITLE
Improve provider launch failures

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -11891,6 +11891,8 @@ cyan = "#00ffff"
             "provider should still be present after fallback retry"
         );
         assert_eq!(app.sessions[0].status, SessionStatus::Active);
+        assert_eq!(app.input_target, InputTarget::Agent);
+        assert_eq!(app.fullscreen_overlay, FullscreenOverlay::Agent);
         assert!(
             !app.resume_fallback_candidates.contains_key(&session_id),
             "candidate should have been removed after fallback"
@@ -12051,6 +12053,34 @@ cyan = "#00ffff"
     }
 
     #[test]
+    fn quick_nonzero_exit_reports_minimal_output() {
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let worktree = std::path::Path::new(&app.sessions[0].worktree_path);
+        let args = vec![
+            "-c".to_string(),
+            "echo 'custom provider failed'; exit 1".to_string(),
+        ];
+        let client = PtyClient::spawn("/bin/sh", &args, worktree, 24, 80, 1_000)
+            .expect("spawn nonzero-output");
+        app.providers.insert(session_id.clone(), client);
+        app.mark_session_desired_running(&session_id, true);
+        app.mark_session_status(&session_id, SessionStatus::Active);
+        app.selected_left = 1;
+        app.session_surface = SessionSurface::Agent;
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        app.drain_events();
+
+        assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
+        assert!(
+            app.status.text().contains("custom provider failed"),
+            "status should include provider output, got: {:?}",
+            app.status.text()
+        );
+    }
+
+    #[test]
     fn startup_auto_reopens_eligible_sessions() {
         let mut app = test_app(default_bindings());
         let session_id = app.sessions[0].id.clone();
@@ -12058,7 +12088,7 @@ cyan = "#00ffff"
             "codex".to_string(),
             crate::config::ProviderCommandConfig {
                 command: "/bin/sh".to_string(),
-                args: vec!["-c".to_string(), "exit 1".to_string()],
+                args: Vec::new(),
                 resume_args: Some(vec!["-c".to_string(), "sleep 5".to_string()]),
                 ..Default::default()
             },

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -421,13 +421,8 @@ impl App {
             .buffer_mut()
             .set_style(frame_area, Style::default().bg(self.theme.app_bg));
 
-        let term_w = frame_area.width as usize;
-        let status_text_len = self.status.text().len() + 3; // " ● " prefix
-        let status_lines: u16 = if term_w > 0 && status_text_len > term_w {
-            2
-        } else {
-            1
-        };
+        let status_text = self.status.text();
+        let status_lines = status_footer_lines(&status_text, frame_area.width);
         let footer_h = 1 + status_lines; // 1 for hints + status lines
         let [header, body, footer] = Layout::default()
             .direction(Direction::Vertical)
@@ -6783,12 +6778,8 @@ impl App {
     fn render_dim_overlay(&self, frame: &mut Frame) {
         let full = frame.area();
         // Keep the statusline (bottom rows) undimmed so errors stay visible.
-        let status_text_len = self.status.text().len() + 3;
-        let status_lines: u16 = if full.width > 0 && status_text_len > full.width as usize {
-            2
-        } else {
-            1
-        };
+        let status_text = self.status.text();
+        let status_lines = status_footer_lines(&status_text, full.width);
         let footer_h = 1 + status_lines; // hints bar + status line(s)
         let dim_h = full.height.saturating_sub(footer_h);
         let buf = frame.buffer_mut();
@@ -7255,12 +7246,31 @@ fn set_cell(buf: &mut ratatui::buffer::Buffer, x: u16, y: u16, symbol: &str, sty
 /// trimmed. Using char-based counting avoids panics when the text contains
 /// multi-byte UTF-8 (e.g. box-drawing or block characters).
 fn truncate_status_text(text: &str, available: usize) -> String {
-    if text.chars().count() > available && available > 1 {
-        let mut truncated: String = text.chars().take(available - 1).collect();
-        truncated.push('…');
-        truncated
+    let char_count = text.chars().count();
+    if char_count <= available {
+        return text.to_owned();
+    }
+
+    match available {
+        0 => String::new(),
+        1 => "…".to_string(),
+        _ => {
+            let mut truncated: String = text.chars().take(available - 1).collect();
+            truncated.push('…');
+            truncated
+        }
+    }
+}
+
+fn status_footer_lines(status_text: &str, width: u16) -> u16 {
+    if width == 0 {
+        return 1;
+    }
+    let status_text_len = status_text.chars().count() + 3; // " ● " prefix
+    if status_text_len > width as usize {
+        2
     } else {
-        text.to_owned()
+        1
     }
 }
 
@@ -7630,18 +7640,23 @@ mod tests {
 
     #[test]
     fn truncate_status_text_available_zero() {
-        // Edge case: zero available should not panic.
-        assert_eq!(truncate_status_text("hello", 0), "hello");
+        assert_eq!(truncate_status_text("hello", 0), "");
     }
 
     #[test]
     fn truncate_status_text_available_one() {
-        // With only 1 char available, no room for truncation marker.
-        assert_eq!(truncate_status_text("hello", 1), "hello");
+        assert_eq!(truncate_status_text("hello", 1), "…");
     }
 
     #[test]
     fn truncate_status_text_empty_input() {
         assert_eq!(truncate_status_text("", 10), "");
+    }
+
+    #[test]
+    fn status_footer_lines_allows_at_most_two_status_rows() {
+        assert_eq!(status_footer_lines("short", 40), 1);
+        assert_eq!(status_footer_lines("this message is too wide", 10), 2);
+        assert_eq!(status_footer_lines("anything", 0), 1);
     }
 }

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -1675,24 +1675,64 @@ fn agent_exit_status_message(
     excerpt: &str,
     reconnect_key: &str,
 ) -> String {
+    const MAX_EXIT_OUTPUT_CHARS: usize = 120;
+
     let outcome = match exit_success {
         Some(false) => "exited with an error",
         Some(true) => "exited",
         None => "exited",
     };
-    let excerpt = excerpt
+    let output = excerpt
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>()
-        .join(" | ");
-    if is_minimal && !excerpt.is_empty() {
+        .join(" ");
+    if output.is_empty() {
+        return format!("Agent CLI process has exited. Press \"{reconnect_key}\" to relaunch.");
+    }
+    if is_minimal {
+        let output = truncate_status_output(&output, MAX_EXIT_OUTPUT_CHARS);
+        let more = if output.truncated {
+            " Full output is visible in the agent pane."
+        } else {
+            ""
+        };
         return format!(
-            "Agent CLI process {outcome}. Output: {excerpt}. Press \"{reconnect_key}\" to relaunch."
+            "Agent CLI process {outcome}. Output: {}.{more} Press \"{reconnect_key}\" to relaunch.",
+            output.text
         );
     }
 
     format!("Agent CLI process has exited. Press \"{reconnect_key}\" to relaunch.")
+}
+
+struct TruncatedStatusOutput {
+    text: String,
+    truncated: bool,
+}
+
+fn truncate_status_output(text: &str, max_chars: usize) -> TruncatedStatusOutput {
+    let mut chars = text.chars();
+    let mut truncated = false;
+    let mut output = String::new();
+    for _ in 0..max_chars {
+        let Some(ch) = chars.next() else {
+            return TruncatedStatusOutput {
+                text: output,
+                truncated,
+            };
+        };
+        output.push(ch);
+    }
+    if chars.next().is_some() {
+        truncated = true;
+        output.push('…');
+    }
+    TruncatedStatusOutput {
+        text: output,
+        truncated,
+    }
 }
 
 /// Background job for "Add Project" when the user opted to have dux switch to
@@ -2891,6 +2931,30 @@ mod tests {
             _ => panic!("expected launch failure"),
         }
         assert!(worker_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn agent_exit_status_message_caps_long_provider_output() {
+        let long_output = "x".repeat(200);
+
+        let message = agent_exit_status_message(Some(false), true, &long_output, "r");
+
+        assert!(message.contains("Output: "));
+        assert!(message.contains("…"));
+        assert!(message.contains("Full output is visible in the agent pane."));
+        assert!(
+            !message.contains(&long_output),
+            "status should not embed the full provider output"
+        );
+    }
+
+    #[test]
+    fn agent_exit_status_message_concats_short_provider_output() {
+        let message = agent_exit_status_message(Some(false), true, "first\nsecond", "r");
+
+        assert!(message.contains("Output: first second."));
+        assert!(!message.contains('|'));
+        assert!(!message.contains("Full output is visible"));
     }
 
     #[test]

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -643,7 +643,13 @@ impl App {
         for (session_id, provider) in &mut self.providers {
             let exit_success = provider.try_wait().map(|status| status.success());
             if exit_success.is_some() || provider.is_exited() {
-                exited.push((session_id.clone(), exit_success));
+                let is_minimal = provider.has_minimal_output(5);
+                let excerpt = if is_minimal {
+                    provider.visible_text_excerpt(3)
+                } else {
+                    String::new()
+                };
+                exited.push((session_id.clone(), exit_success, is_minimal, excerpt));
             }
         }
 
@@ -651,7 +657,7 @@ impl App {
         // producing any output, retry with regular args (fresh session).
         // This handles `claude --continue || claude` style fallback.
         let mut retried = HashSet::new();
-        for (session_id, _) in &exited {
+        for (session_id, _, is_minimal, _) in &exited {
             if self.resume_fallback_candidates.remove(session_id).is_none() {
                 continue;
             }
@@ -659,11 +665,6 @@ impl App {
             // (no scrollback and ≤5 visible lines). A failed `--continue`
             // typically prints 1-2 lines of error; a real session produces
             // far more output and scrollback history.
-            let is_minimal = self
-                .providers
-                .get(session_id)
-                .map(|p| p.has_minimal_output(5))
-                .unwrap_or(true);
             if !is_minimal {
                 continue;
             }
@@ -696,7 +697,7 @@ impl App {
             }
         }
 
-        for (session_id, exit_success) in &exited {
+        for (session_id, exit_success, _, _) in &exited {
             if retried.contains(session_id) {
                 continue;
             }
@@ -712,17 +713,22 @@ impl App {
             // If the currently-viewed session just exited (and was not retried),
             // leave interactive mode.
             if let Some(current) = self.selected_session()
-                && exited.iter().any(|(id, _)| id == &current.id)
+                && let Some((_, exit_success, is_minimal, excerpt)) =
+                    exited.iter().find(|(id, _, _, _)| id == &current.id)
                 && !retried.contains(&current.id)
             {
                 let key = self.bindings.label_for(Action::ReconnectAgent);
                 if self.session_surface == SessionSurface::Agent {
+                    let status =
+                        agent_exit_status_message(*exit_success, *is_minimal, excerpt, &key);
                     self.input_target = InputTarget::None;
                     self.fullscreen_overlay = FullscreenOverlay::None;
                     self.focus = FocusPane::Left;
-                    self.set_info(format!(
-                        "Agent CLI process has exited. Press \"{key}\" to relaunch."
-                    ));
+                    if *exit_success == Some(false) {
+                        self.set_error(status);
+                    } else {
+                        self.set_info(status);
+                    }
                 } else {
                     self.set_info(format!(
                         "Agent CLI process exited. Companion terminal is still available; press \"{key}\" to relaunch the agent."
@@ -731,8 +737,9 @@ impl App {
             }
             // Trigger PR status check for exited agents.
             for sid in &exited {
-                if !retried.contains(&sid.0) {
-                    self.spawn_pr_check_for_session(&sid.0);
+                let session_id = &sid.0;
+                if !retried.contains(session_id) {
+                    self.spawn_pr_check_for_session(session_id);
                 }
             }
         }
@@ -1169,6 +1176,13 @@ impl App {
                 self.set_info(status_message);
             }
             AgentLaunchKind::ResumeFallback { status_message } => {
+                if self.selected_session().map(|selected| selected.id.as_str())
+                    == Some(session.id.as_str())
+                {
+                    self.show_agent_surface();
+                    self.input_target = InputTarget::Agent;
+                    self.fullscreen_overlay = FullscreenOverlay::Agent;
+                }
                 self.set_info(status_message);
             }
             AgentLaunchKind::StartupAutoReopen => {}
@@ -1653,6 +1667,32 @@ impl App {
             }
         }
     }
+}
+
+fn agent_exit_status_message(
+    exit_success: Option<bool>,
+    is_minimal: bool,
+    excerpt: &str,
+    reconnect_key: &str,
+) -> String {
+    let outcome = match exit_success {
+        Some(false) => "exited with an error",
+        Some(true) => "exited",
+        None => "exited",
+    };
+    let excerpt = excerpt
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    if is_minimal && !excerpt.is_empty() {
+        return format!(
+            "Agent CLI process {outcome}. Output: {excerpt}. Press \"{reconnect_key}\" to relaunch."
+        );
+    }
+
+    format!("Agent CLI process has exited. Press \"{reconnect_key}\" to relaunch.")
 }
 
 /// Background job for "Add Project" when the user opted to have dux switch to
@@ -2380,9 +2420,33 @@ pub(crate) fn run_agent_launch_job(request: AgentLaunchRequest, worker_tx: Sende
         request.provider_config.supports_session_resume()
     ));
 
+    if let Err(message) = check_provider_available(&request.provider_config) {
+        logger::error(&format!(
+            "provider availability check failed for {}: {message}",
+            request.session.id
+        ));
+        if let AgentLaunchKind::Create {
+            repo_path,
+            owns_worktree,
+            ..
+        } = &request.kind
+            && *owns_worktree
+        {
+            let _ = git::remove_worktree(
+                Path::new(repo_path),
+                Path::new(&request.session.worktree_path),
+                &request.session.branch_name,
+            );
+        }
+        let _ = worker_tx.send(WorkerEvent::AgentLaunchFailed(Box::new(
+            AgentLaunchFailedData { request, message },
+        )));
+        return;
+    }
+
     let client = match PtyClient::spawn_with_env(
         &request.provider_config.command,
-        launch_args,
+        &launch_args,
         Path::new(&request.session.worktree_path),
         rows,
         cols,
@@ -2776,6 +2840,57 @@ mod tests {
             cwd.display(),
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    fn test_session(worktree: &Path) -> AgentSession {
+        AgentSession {
+            id: "session-1".to_string(),
+            project_id: "project-1".to_string(),
+            project_path: Some(worktree.to_string_lossy().to_string()),
+            provider: ProviderKind::from_str("custom"),
+            source_branch: "main".to_string(),
+            branch_name: "agent-branch".to_string(),
+            worktree_path: worktree.to_string_lossy().to_string(),
+            title: None,
+            started_providers: Vec::new(),
+            desired_running: true,
+            auto_reopen_enabled: true,
+            status: SessionStatus::Active,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn launch_job_fails_before_pty_when_provider_command_is_missing() {
+        let tmp = tempdir().expect("tempdir");
+        let (worker_tx, worker_rx) = mpsc::channel();
+        let request = AgentLaunchRequest {
+            session: test_session(tmp.path()),
+            provider_config: ProviderCommandConfig {
+                command: "definitely-missing-provider-command".to_string(),
+                args: vec!["--ignored".to_string()],
+                ..Default::default()
+            },
+            resume: false,
+            pty_size: (24, 80),
+            scrollback_lines: 1_000,
+            env: Vec::new(),
+            kind: AgentLaunchKind::Reconnect {
+                status_message: "reconnect".to_string(),
+            },
+        };
+
+        run_agent_launch_job(request, worker_tx);
+
+        match worker_rx.recv().expect("worker event") {
+            WorkerEvent::AgentLaunchFailed(data) => {
+                assert!(data.message.contains("definitely-missing-provider-command"));
+                assert!(data.message.contains("not found on PATH"));
+            }
+            _ => panic!("expected launch failure"),
+        }
+        assert!(worker_rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,13 +317,14 @@ impl Default for ProviderCommandConfig {
 }
 
 impl ProviderCommandConfig {
-    pub fn interactive_args(&self, resume_session: bool) -> &[String] {
+    pub fn interactive_args(&self, resume_session: bool) -> Vec<String> {
+        let mut args = self.args.clone();
         if resume_session
             && let Some(resume_args) = self.resume_args.as_deref().filter(|args| !args.is_empty())
         {
-            return resume_args;
+            args.extend(resume_args.iter().cloned());
         }
-        &self.args
+        args
     }
 
     pub fn supports_session_resume(&self) -> bool {
@@ -1790,26 +1791,58 @@ pub fn validate_keys(keys: &KeysConfig) -> Result<(), String> {
 /// Check whether a provider command is available on PATH.
 /// Returns `Ok(())` if found, or `Err(message)` with a user-friendly install hint.
 pub fn check_provider_available(config: &ProviderCommandConfig) -> std::result::Result<(), String> {
-    use std::process::Command as StdCommand;
-    match StdCommand::new("which").arg(&config.command).output() {
-        Ok(output) if output.status.success() => Ok(()),
-        _ => {
-            let hint = config
-                .install_hint
-                .as_ref()
-                .map(|h| format!("Install with: {h}"))
-                .unwrap_or_else(|| {
-                    format!(
-                        "Make sure '{}' is installed and on your PATH.",
-                        config.command
-                    )
-                });
-            Err(format!(
-                "CLI tool '{}' not found on PATH. {hint}",
-                config.command
-            ))
-        }
+    if provider_command_available(&config.command) {
+        return Ok(());
     }
+
+    let hint = config
+        .install_hint
+        .as_ref()
+        .map(|h| format!("Install with: {h}"))
+        .unwrap_or_else(|| {
+            format!(
+                "Make sure '{}' is installed and on your PATH.",
+                config.command
+            )
+        });
+    Err(format!(
+        "CLI tool '{}' not found on PATH. {hint}",
+        config.command
+    ))
+}
+
+fn provider_command_available(command: &str) -> bool {
+    if command.trim().is_empty() {
+        return false;
+    }
+
+    let path = Path::new(command);
+    if path.components().count() > 1 {
+        return is_executable_file(path);
+    }
+
+    env::var_os("PATH")
+        .map(|paths| provider_command_available_in_path(command, &paths))
+        .unwrap_or(false)
+}
+
+fn provider_command_available_in_path(command: &str, paths: &std::ffi::OsStr) -> bool {
+    env::split_paths(paths).any(|dir| {
+        let candidate = dir.join(command);
+        is_executable_file(&candidate)
+    })
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    use std::os::unix::fs::PermissionsExt;
+    metadata.permissions().mode() & 0o111 != 0
 }
 
 fn resolve_root(
@@ -2058,6 +2091,8 @@ fn is_valid_var_name(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
 
     /// Render config using default keybinding labels (for tests that don't need custom bindings).
@@ -2065,6 +2100,16 @@ mod tests {
         let bindings =
             crate::keybindings::RuntimeBindings::from_keys_config(&KeysConfig::default());
         render_config(config, &bindings)
+    }
+
+    fn write_executable(path: &Path) {
+        std::fs::write(path, "#!/bin/sh\nexit 0\n").expect("write fixture command");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path)
+            .expect("fixture metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("chmod fixture command");
     }
 
     #[test]
@@ -2451,7 +2496,7 @@ dangerous = true
     }
 
     #[test]
-    fn provider_command_config_selects_resume_args_only_when_available() {
+    fn provider_command_config_appends_resume_args_when_available() {
         let cfg = ProviderCommandConfig {
             command: "example".to_string(),
             args: vec!["--interactive".to_string()],
@@ -2463,7 +2508,10 @@ dangerous = true
             forward_scroll: false,
         };
         assert_eq!(cfg.interactive_args(false), ["--interactive"]);
-        assert_eq!(cfg.interactive_args(true), ["--resume", "--last"]);
+        assert_eq!(
+            cfg.interactive_args(true),
+            ["--interactive", "--resume", "--last"]
+        );
 
         let unsupported = ProviderCommandConfig {
             command: "example".to_string(),
@@ -2477,6 +2525,61 @@ dangerous = true
         };
         assert_eq!(unsupported.interactive_args(true), ["--interactive"]);
         assert!(!unsupported.supports_session_resume());
+    }
+
+    #[test]
+    fn provider_command_path_lookup_accepts_executable_from_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let command = dir.path().join("custom-tool");
+        write_executable(&command);
+        let paths = std::env::join_paths([dir.path()]).expect("join path");
+
+        assert!(provider_command_available_in_path(
+            "custom-tool",
+            paths.as_os_str()
+        ));
+    }
+
+    #[test]
+    fn provider_command_path_lookup_rejects_missing_command() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let paths = std::env::join_paths([dir.path()]).expect("join path");
+
+        assert!(!provider_command_available_in_path(
+            "missing-tool",
+            paths.as_os_str()
+        ));
+    }
+
+    #[test]
+    fn provider_command_path_lookup_accepts_absolute_executable() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let command = dir.path().join("custom-tool");
+        write_executable(&command);
+
+        assert!(provider_command_available(&command.to_string_lossy()));
+    }
+
+    #[test]
+    fn provider_command_path_lookup_rejects_non_executable_path() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let command = dir.path().join("custom-tool");
+        std::fs::write(&command, "#!/bin/sh\n").expect("write fixture command");
+
+        assert!(!provider_command_available(&command.to_string_lossy()));
+    }
+
+    #[test]
+    fn provider_availability_error_uses_install_hint() {
+        let cfg = ProviderCommandConfig {
+            command: "definitely-missing-provider-command".to_string(),
+            install_hint: Some("install custom-tool".to_string()),
+            ..Default::default()
+        };
+
+        let err = check_provider_available(&cfg).expect_err("command should be missing");
+        assert!(err.contains("definitely-missing-provider-command"));
+        assert!(err.contains("Install with: install custom-tool"));
     }
 
     #[test]

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -461,6 +461,14 @@ impl PtyClient {
             .unwrap_or(true)
     }
 
+    /// Returns a short plain-text excerpt from the visible terminal viewport.
+    pub fn visible_text_excerpt(&self, max_lines: usize) -> String {
+        self.terminal
+            .lock()
+            .map(|t| t.visible_text_excerpt(max_lines))
+            .unwrap_or_default()
+    }
+
     /// Returns `true` if the PTY received data since the last call, then
     /// clears the flag. Used to detect streaming activity for UI indicators
     /// without interfering with the snapshot dirty flag.
@@ -624,6 +632,29 @@ impl TerminalState {
     /// Used to detect failed `--continue` exits that print a short error message.
     fn has_minimal_output(&self, threshold: usize) -> bool {
         self.term.grid().history_size() == 0 && self.visible_line_count() <= threshold
+    }
+
+    fn visible_text_excerpt(&self, max_lines: usize) -> String {
+        let mut rows = vec![String::new(); usize::from(self.rows)];
+        for indexed in self.term.renderable_content().display_iter {
+            let Ok(row) = usize::try_from(indexed.point.line.0) else {
+                continue;
+            };
+            let Some(line) = rows.get_mut(row) else {
+                continue;
+            };
+            while line.chars().count() < indexed.point.column.0 {
+                line.push(' ');
+            }
+            line.push(indexed.cell.c);
+        }
+
+        rows.into_iter()
+            .map(|line| line.trim_end().to_string())
+            .filter(|line| !line.trim().is_empty())
+            .take(max_lines)
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Whether the child process has enabled any mouse tracking mode


### PR DESCRIPTION
This makes provider launches fail earlier and more clearly when the configured command is missing or cannot be started. Provider command checks are generic, so custom providers are treated the same way as built-in ones.

It also keeps base provider arguments when resuming by appending resume arguments, which better matches wrapper-style commands. If a provider exits immediately with a small error message, Dux now surfaces that output instead of only saying the agent process exited.

The resume fallback path now restores the selected agent into interactive fullscreen mode after starting the fresh session, so the agent is ready for input without needing an extra activation step.