### PR TITLE
Add repo subtitles and friendlier names to the Recommended tools cards

### DIFF
--- a/website/docs/recommended-tools.mdx
+++ b/website/docs/recommended-tools.mdx
@@ -55,13 +55,13 @@ would, and they work unchanged inside a dux agent.
     description="Gives agents Chrome DevTools to navigate, inspect, and debug pages, read the console, and watch the network. It can drive a browser you already have installed instead of downloading its own."
   />
   <ToolCard
-    name="mcp-netutils"
+    name="Network Debugging MCP"
     repo="patrickdappollonio/mcp-netutils"
     tag="same dev as dux"
     description="DNS lookups, WHOIS, connectivity tests, TLS inspection, and HTTP endpoint checks, all from the agent."
   />
   <ToolCard
-    name="mcp-kubernetes-ro"
+    name="Kubernetes Read-Only MCP"
     repo="patrickdappollonio/mcp-kubernetes-ro"
     tag="same dev as dux"
     description="Read-only Kubernetes access: list resources, read details, and pull pod logs with no risk of mutating the cluster."

--- a/website/src/components/ToolCard.astro
+++ b/website/src/components/ToolCard.astro
@@ -19,9 +19,12 @@ const label = url && !url.includes("github.com") ? "Visit site" : "View on GitHu
 
 <div class="tool-card">
   <div class="tool-card-head">
-    <div class="tool-card-title-wrap">
-      <h3 class="tool-card-title">{name}</h3>
-      {tag && <span class="tool-card-tag">{tag}</span>}
+    <div class="tool-card-head-text">
+      <div class="tool-card-title-wrap">
+        <h3 class="tool-card-title">{name}</h3>
+        {tag && <span class="tool-card-tag">{tag}</span>}
+      </div>
+      {repo && <span class="tool-card-repo">{repo}</span>}
     </div>
     {repo && <GhStars repo={repo} />}
   </div>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -208,6 +208,9 @@
   .tool-card {
     display: flex;
     flex-direction: column;
+    /* Reset the inherited prose line-height (1.75); the description sets its
+       own below, and the title/subtitle are tightened individually. */
+    line-height: 1.4;
     border: 1px solid var(--color-border);
     background: color-mix(in oklab, var(--color-panel) 80%, transparent);
     border-radius: 0.75rem;
@@ -227,8 +230,14 @@
     margin-top: 0.05rem;
     font-family: var(--font-mono);
     font-size: 0.7rem;
+    line-height: 1.2;
     color: var(--color-dim);
     word-break: break-word;
+  }
+  /* No repo subtitle (e.g. a non-GitHub link): keep a fair gap between the
+     title and the description instead of letting them sit too close. */
+  .tool-card-head:not(:has(.tool-card-repo)) {
+    margin-bottom: 0.35rem;
   }
   .tool-card-title-wrap {
     display: flex;
@@ -241,6 +250,7 @@
     font-family: var(--font-display);
     font-size: 1rem;
     font-weight: 600;
+    line-height: 1.2;
     letter-spacing: -0.01em;
     color: var(--color-text);
     margin: 0;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -224,7 +224,7 @@
   }
   .tool-card-repo {
     display: block;
-    margin-top: 0.15rem;
+    margin-top: 0.05rem;
     font-family: var(--font-mono);
     font-size: 0.7rem;
     color: var(--color-dim);

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -215,9 +215,20 @@
   }
   .tool-card-head {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 0.5rem;
+  }
+  .tool-card-head-text {
+    min-width: 0;
+  }
+  .tool-card-repo {
+    display: block;
+    margin-top: 0.15rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--color-dim);
+    word-break: break-word;
   }
   .tool-card-title-wrap {
     display: flex;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -227,7 +227,7 @@
   }
   .tool-card-repo {
     display: block;
-    margin-top: 0.05rem;
+    margin-top: 0.2rem;
     font-family: var(--font-mono);
     font-size: 0.7rem;
     line-height: 1.2;


### PR DESCRIPTION
Each card on the Recommended tools page now shows its `org/repo` slug as a faint monospace subtitle under the tool's name, so the friendly display name and where the tool actually lives are both clear at a glance. **Playwright MCP** now reads with `microsoft/playwright-mcp` beneath it, and the card header top-aligns so the star badge lines up with the title rather than floating against a taller block.

The title-to-subtitle spacing is tuned along the way. The cards no longer inherit the docs prose line-height, which had been loosening the two lines, and there's a small, deliberate gap between the name and the slug. Cards without a repo (a future non-GitHub link) fall back to title-only and still keep a fair gap before the description, since the subtitle and star badge are optional.

The two first-party MCP servers also get clearer names: **Network Debugging MCP** and **Kubernetes Read-Only MCP**, each still carrying its real package name in the subtitle and the `same dev as dux` badge.