### PR TITLE
Keep the card badge from wedging between title and subtitle

### DIFF
--- a/website/src/components/ToolCard.astro
+++ b/website/src/components/ToolCard.astro
@@ -20,10 +20,8 @@ const label = url && !url.includes("github.com") ? "Visit site" : "View on GitHu
 <div class="tool-card">
   <div class="tool-card-head">
     <div class="tool-card-head-text">
-      <div class="tool-card-title-wrap">
-        <h3 class="tool-card-title">{name}</h3>
-        {tag && <span class="tool-card-tag">{tag}</span>}
-      </div>
+      <h3 class="tool-card-title">{name}</h3>
+      {tag && <span class="tool-card-tag">{tag}</span>}
       {repo && <span class="tool-card-repo">{repo}</span>}
     </div>
     {repo && <GhStars repo={repo} />}

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -222,29 +222,39 @@
     justify-content: space-between;
     gap: 0.5rem;
   }
+  /* Title, tag, and subtitle share one wrapping flex row. The subtitle takes a
+     full line of its own; the tag sits next to the title when there's room and
+     drops below the subtitle when there isn't (see the container query). */
   .tool-card-head-text {
+    flex: 1;
     min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: 0.4rem;
+    row-gap: 0.2rem;
+    container-type: inline-size;
   }
   .tool-card-repo {
-    display: block;
-    margin-top: 0.2rem;
+    flex-basis: 100%;
+    order: 1;
     font-family: var(--font-mono);
     font-size: 0.7rem;
     line-height: 1.2;
     color: var(--color-dim);
     word-break: break-word;
   }
+  /* Too narrow to fit the tag beside the title: move it below the subtitle
+     rather than wedging it between the title and subtitle. */
+  @container (max-width: 400px) {
+    .tool-card-tag {
+      order: 2;
+    }
+  }
   /* No repo subtitle (e.g. a non-GitHub link): keep a fair gap between the
      title and the description instead of letting them sit too close. */
   .tool-card-head:not(:has(.tool-card-repo)) {
     margin-bottom: 0.35rem;
-  }
-  .tool-card-title-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.4rem;
-    min-width: 0;
   }
   .tool-card-title {
     font-family: var(--font-display);


### PR DESCRIPTION
On the Recommended tools cards, the small badge (such as `same dev as dux`) could wrap onto its own line between the tool's title and its repo subtitle when the card was too narrow to fit it beside the title. That left the badge awkwardly stuck in the middle of the title block.

The title, badge, and subtitle now share a single wrapping flex row in which the subtitle always takes its own full-width line. A container query reorders the badge to sit **below** the subtitle when the card is too narrow to keep it next to the title, and leaves it beside the title when there's room. Cards without a badge or repo are unaffected.