### PR TITLE
Stop timing-dependent tests from intermittently failing CI

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -8359,9 +8359,10 @@ not_a_real_action = ["x"]
         app.clipboard = Clipboard::from_fn(clipboard_ok);
 
         app.copy_selected_path().unwrap();
-        // Result arrives via WorkerEvent; drain it.
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        // Result arrives via WorkerEvent; wait for it.
+        drain_until(&mut app, |app| {
+            app.status.text() == "Agent's path copied to clipboard."
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert_eq!(app.status.text(), "Agent's path copied to clipboard.");
@@ -8374,8 +8375,9 @@ not_a_real_action = ["x"]
         app.clipboard = Clipboard::from_fn(clipboard_ok);
 
         app.copy_selected_path().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text() == "Agent's path copied to clipboard."
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert_eq!(app.status.text(), "Agent's path copied to clipboard.");
@@ -8403,8 +8405,9 @@ not_a_real_action = ["x"]
         app.clipboard = Clipboard::from_fn(clipboard_fail);
 
         app.copy_selected_path().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text().contains("Clipboard copy failed")
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
         assert!(app.status.text().contains("Clipboard copy failed"));
@@ -11518,8 +11521,9 @@ cyan = "#00ffff"
         app.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 44, 5));
         app.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 52, 5));
         app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 52, 5));
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text() == "Startup command log text copied to clipboard."
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert_eq!(
@@ -11632,8 +11636,7 @@ cyan = "#00ffff"
         std::fs::write(log_dir.join("20260515T020000Z-new.log"), "new log").expect("new log");
 
         app.open_startup_command_logs().expect("open logs");
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| app.startup_log_viewer.is_some());
 
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::StartupLog);
         let viewer = app.startup_log_viewer.as_ref().expect("log viewer");
@@ -11721,8 +11724,9 @@ cyan = "#00ffff"
             body.x + 4,
             body.y,
         ));
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text() == "Startup command log text copied to clipboard."
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Info);
         assert_eq!(
@@ -11923,7 +11927,9 @@ cyan = "#00ffff"
 
         // Wait for the process to produce output and exit.
         std::thread::sleep(std::time::Duration::from_millis(200));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.sessions[0].status == SessionStatus::Detached
+        });
 
         // Since the PTY had substantial output (>5 lines), the fallback
         // should NOT have triggered. The session should be detached.
@@ -12002,7 +12008,7 @@ cyan = "#00ffff"
         app.session_surface = SessionSurface::Agent;
 
         std::thread::sleep(std::time::Duration::from_millis(200));
-        app.drain_events();
+        drain_until(&mut app, |app| !app.providers.contains_key(&session_id));
 
         // Without being a candidate, the session should just go to detached.
         assert!(
@@ -12025,7 +12031,7 @@ cyan = "#00ffff"
         app.mark_session_status(&session_id, SessionStatus::Active);
 
         std::thread::sleep(std::time::Duration::from_millis(200));
-        app.drain_events();
+        drain_until(&mut app, |app| !app.providers.contains_key(&session_id));
 
         assert!(!app.sessions[0].desired_running);
         let loaded = app.session_store.load_sessions().expect("load sessions");
@@ -12045,7 +12051,7 @@ cyan = "#00ffff"
         app.mark_session_status(&session_id, SessionStatus::Active);
 
         std::thread::sleep(std::time::Duration::from_millis(200));
-        app.drain_events();
+        drain_until(&mut app, |app| !app.providers.contains_key(&session_id));
 
         assert!(app.sessions[0].desired_running);
         let loaded = app.session_store.load_sessions().expect("load sessions");
@@ -12070,7 +12076,9 @@ cyan = "#00ffff"
         app.session_surface = SessionSurface::Agent;
 
         std::thread::sleep(std::time::Duration::from_millis(200));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text().contains("custom provider failed")
+        });
 
         assert_eq!(app.status.tone(), crate::statusline::StatusTone::Error);
         assert!(
@@ -13867,8 +13875,9 @@ cyan = "#00ffff"
 
         app.apply_change_project_default_provider()
             .expect("apply project provider");
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status.text().contains("changed to claude")
+        });
 
         assert_eq!(app.config.defaults.provider, "codex");
         let persisted = app.session_store.load_projects().expect("load projects");
@@ -13923,8 +13932,11 @@ cyan = "#00ffff"
 
         app.apply_change_project_default_provider()
             .expect("apply inherit global");
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        app.drain_events();
+        drain_until(&mut app, |app| {
+            app.status
+                .text()
+                .contains("now inherits the global default provider")
+        });
 
         let persisted = app.session_store.load_projects().expect("load projects");
         let config = persisted


### PR DESCRIPTION
A recent `Test` run on `main` went red even though the code was fine: the exact same commit passed on the branch push and failed on the `v0.6.0` tag push moments later. The culprit was `change_project_default_provider_can_revert_to_global_default`, which reverts a project's provider to the global default and then waits a fixed 50ms before checking the in-memory result. That revert dispatches a background worker that writes to SQLite and only afterwards posts the event that recomputes the in-memory provider, so on a busier runner the worker hadn't reported back in time and the assertion saw the stale pre-revert value.

The waits are now condition-based: instead of guessing how long the work takes, the affected tests poll with the existing `drain_until` helper until the expected state actually appears. The provider, clipboard, and startup-log tests drop their fixed sleep entirely, while the PTY child-exit tests keep the small sleep that lets the child process run and only swap the bare drain for `drain_until` — matching the pattern their sibling tests already use. Genuine timing waits (the ESC-ambiguity window, scrollback setup, and the test that asserts a retry does **not** happen) are left untouched.

The change is confined to `src/app/input.rs` and touches test code only; no application behavior changes. Beyond fixing the flakiness, polling for the real condition also lets these tests finish as soon as the work is done rather than always paying the full sleep.