### PR TITLE
Fix install script latest release download

### DIFF
--- a/.github/workflows/install-script-ci.yml
+++ b/.github/workflows/install-script-ci.yml
@@ -1,0 +1,59 @@
+name: Install script
+
+on:
+  pull_request:
+    paths:
+      - "install.sh"
+      - ".github/workflows/install-script-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "install.sh"
+      - ".github/workflows/install-script-ci.yml"
+
+concurrency:
+  group: install-script-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Install ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: v0.1.0
+            version: v0.1.0
+          - name: latest
+            version: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run install.sh
+        env:
+          DUX_VERSION: ${{ matrix.version }}
+        run: |
+          set -euo pipefail
+
+          install_dir="$RUNNER_TEMP/dux-${{ matrix.name }}/bin"
+          mkdir -p "$install_dir"
+
+          echo "$install_dir" >> "$GITHUB_PATH"
+          export PATH="$install_dir:$PATH"
+
+          DUX_INSTALL_DIR="$install_dir" bash ./install.sh
+
+          if ! command -v dux >/dev/null 2>&1; then
+            echo "::error::dux was not found on PATH after install"
+            exit 1
+          fi
+
+          if [ ! -x "$install_dir/dux" ]; then
+            echo "::error::install.sh did not create an executable dux binary"
+            exit 1
+          fi

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,13 @@ BINARY="dux"
 # Allow overriding the version and install directory via environment variables.
 VERSION="${DUX_VERSION:-}"
 INSTALL_DIR="${DUX_INSTALL_DIR:-}"
+DUX_TMPDIR=""
 
-log() { printf '%s\n' "$@"; }
-err() { log "$@" >&2; exit 1; }
+log() { printf '%s\n' "$@" >&2; }
+err() { log "$@"; exit 1; }
+cleanup() {
+    [ -n "$DUX_TMPDIR" ] && rm -rf "$DUX_TMPDIR"
+}
 
 detect_os() {
     local os
@@ -97,7 +101,7 @@ resolve_install_dir() {
 }
 
 main() {
-    local os arch version install_dir archive url tmpdir
+    local os arch version install_dir archive url
 
     os="$(detect_os)"
     arch="$(detect_arch)"
@@ -108,20 +112,20 @@ main() {
 
     log "Installing ${BINARY} ${version} (${os}/${arch}) to ${install_dir}"
 
-    tmpdir="$(mktemp -d)"
-    trap 'rm -rf "$tmpdir"' EXIT
+    DUX_TMPDIR="$(mktemp -d)"
+    trap cleanup EXIT
 
     log "Downloading ${url}..."
-    http_download "$url" "${tmpdir}/${archive}"
+    http_download "$url" "${DUX_TMPDIR}/${archive}"
 
-    tar xzf "${tmpdir}/${archive}" -C "$tmpdir"
+    tar xzf "${DUX_TMPDIR}/${archive}" -C "$DUX_TMPDIR"
 
     # Install the binary — use sudo only if the target directory is not writable.
     if [ -w "$install_dir" ]; then
-        install -m 755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}"
+        install -m 755 "${DUX_TMPDIR}/${BINARY}" "${install_dir}/${BINARY}"
     else
         log "Installation directory ${install_dir} is not writable, using sudo..."
-        sudo install -m 755 "${tmpdir}/${BINARY}" "${install_dir}/${BINARY}"
+        sudo install -m 755 "${DUX_TMPDIR}/${BINARY}" "${install_dir}/${BINARY}"
     fi
 
     log ""


### PR DESCRIPTION
This fixes the shell installer path used by both GitHub release assets and `getdux.app/install.sh`.

The latest-release lookup now sends status output to stderr, so command substitution captures only the release tag. Cleanup also uses a script-scope temp directory variable, avoiding the `set -u` trap failure after a failed download.

Installer changes now run through a focused CI workflow that exercises both `DUX_VERSION=v0.1.0` and the latest-release path with a temporary install directory on `PATH`.