### PR TITLE
Add search to the website documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -104,6 +104,14 @@ jobs:
             echo "::error::index.html missing from build output."
             exit 1
           fi
+          if [ ! -f website/dist/pagefind/pagefind.js ]; then
+            echo "::error::pagefind search index missing from build output."
+            exit 1
+          fi
+
+      - name: Verify search index (docs-only scope)
+        working-directory: website
+        run: npm run test:search
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -57,6 +57,10 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Unit tests
+        working-directory: website
+        run: npm test
+
       - name: Build
         working-directory: website
         env:
@@ -65,10 +69,14 @@ jobs:
 
       - name: Verify build output
         run: |
-          for f in index.html CNAME install.sh dux-logo.png dux-screenshot.svg; do
+          for f in index.html CNAME install.sh dux-logo.png dux-screenshot.svg pagefind/pagefind.js; do
             if [ ! -f "website/dist/$f" ]; then
               echo "::error::website/dist/$f missing from build output."
               exit 1
             fi
           done
           echo "Site built successfully."
+
+      - name: Verify search index (docs-only scope)
+        working-directory: website
+        run: npm run test:search

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,8 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";
+import pagefind from "astro-pagefind";
+import { unified } from "@astrojs/markdown-remark";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 
@@ -10,32 +12,44 @@ export default defineConfig({
   trailingSlash: "ignore",
   // mdx() inherits the markdown config below (heading anchors, Shiki) so .mdx
   // docs get the same treatment as .md, plus inline components.
-  integrations: [mdx(), sitemap()],
+  //
+  // pagefind() builds the static search index on `astro build` (shipped in
+  // dist/pagefind/) and serves a prebuilt index during `astro dev`. Only pages
+  // carrying `data-pagefind-body` are indexed — see DocsLayout.astro — so the
+  // index stays scoped to the docs and excludes the marketing homepage.
+  integrations: [mdx(), pagefind(), sitemap()],
   build: {
     inlineStylesheets: "auto",
   },
   markdown: {
     // GitHub's dark theme reads cleanly on the site's near-black panels and
-    // ships its token colors calibrated for that background.
+    // ships its token colors calibrated for that background. shikiConfig and
+    // syntaxHighlight stay at the markdown level — Astro forwards them to the
+    // processor's renderer, so highlighting is unaffected by the processor.
     shikiConfig: { theme: "github-dark-default", wrap: false },
-    rehypePlugins: [
-      // Give every heading a stable slug id, then append a clickable "#"
-      // anchor so docs headings are linkable.
-      rehypeSlug,
-      [
-        rehypeAutolinkHeadings,
-        {
-          behavior: "append",
-          properties: {
-            className: ["heading-anchor"],
-            ariaHidden: "true",
-            tabIndex: -1,
+    // Astro 6 deprecated top-level markdown.rehypePlugins/remarkPlugins in
+    // favor of a processor built with unified() from @astrojs/markdown-remark.
+    processor: unified({
+      rehypePlugins: [
+        // Give every heading a stable slug id, then append a clickable "#"
+        // anchor so docs headings are linkable. The slug ids also power the
+        // heading-level deep links in docs search (see DocsSearch.astro).
+        rehypeSlug,
+        [
+          rehypeAutolinkHeadings,
+          {
+            behavior: "append",
+            properties: {
+              className: ["heading-anchor"],
+              ariaHidden: "true",
+              tabIndex: -1,
+            },
+            // Empty anchor: the visible "#" is added via CSS so it never leaks
+            // into the heading text that the table of contents is built from.
+            content: { type: "element", tagName: "span", properties: {}, children: [] },
           },
-          // Empty anchor: the visible "#" is added via CSS so it never leaks
-          // into the heading text that the table of contents is built from.
-          content: { type: "element", tagName: "span", properties: {}, children: [] },
-        },
+        ],
       ],
-    ],
+    }),
   },
 });

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,13 +8,18 @@
       "name": "getdux-website",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/mdx": "^5.0.6",
-        "@astrojs/sitemap": "^3.7.2",
+        "@astrojs/mdx": "^6.0.1",
+        "@astrojs/sitemap": "^3.7.3",
         "@tailwindcss/postcss": "^4.3.0",
-        "astro": "^6.3.7",
+        "astro": "^6.4.3",
+        "astro-pagefind": "^2.0.0",
+        "pagefind": "^1.5.2",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
         "tailwindcss": "^4.3.0"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -36,26 +41,32 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.1.tgz",
-      "integrity": "sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+      "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.4"
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.2.tgz",
-      "integrity": "sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+      "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.9.1",
+        "@astrojs/internal-helpers": "0.10.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
@@ -63,9 +74,6 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "retext-smartypants": "^6.2.0",
-        "shiki": "^4.0.0",
-        "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.1.0",
@@ -74,12 +82,13 @@
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-5.0.6.tgz",
-      "integrity": "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-6.0.1.tgz",
+      "integrity": "sha512-J5K8F7A1LMH+cj+dcxm+uAeIznkfwxMcRpG7DD6ABNDOt8da98ph6ie4TD+4FV/ojVOJK0PQGWY4hmxQORLv0w==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@mdx-js/mdx": "^3.1.1",
         "acorn": "^8.16.0",
         "es-module-lexer": "^2.0.0",
@@ -97,7 +106,13 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "astro": "^6.0.0"
+        "@astrojs/markdown-satteri": "0.2.1",
+        "astro": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-satteri": {
+          "optional": true
+        }
       }
     },
     "node_modules/@astrojs/prism": {
@@ -113,9 +128,9 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
-      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
+      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
       "license": "MIT",
       "dependencies": {
         "sitemap": "^9.0.0",
@@ -744,9 +759,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -762,9 +774,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -782,9 +791,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -800,9 +806,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -820,9 +823,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -838,9 +838,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -858,9 +855,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -877,9 +871,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -895,9 +886,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -921,9 +909,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -945,9 +930,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -971,9 +953,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -995,9 +974,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1021,9 +997,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1046,9 +1019,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1070,9 +1040,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1262,6 +1229,113 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/component-ui": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/component-ui/-/component-ui-1.5.2.tgz",
+      "integrity": "sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==",
+      "license": "MIT",
+      "dependencies": {
+        "adequate-little-templates": "^1.0.2",
+        "bcp-47": "^2.1.0"
+      }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1369,9 +1443,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1455,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1401,9 +1469,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,9 +1481,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1433,9 +1495,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1448,9 +1507,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1465,9 +1521,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1480,9 +1533,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1497,9 +1547,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1512,9 +1559,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1529,9 +1573,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1545,9 +1586,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1560,9 +1598,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1748,6 +1783,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -1873,9 +1915,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1891,9 +1930,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1911,9 +1947,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1929,9 +1962,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2016,6 +2046,17 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2024,6 +2065,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2109,11 +2157,135 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2128,6 +2300,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adequate-little-templates": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/adequate-little-templates/-/adequate-little-templates-1.0.2.tgz",
+      "integrity": "sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/anymatch": {
@@ -2186,6 +2367,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -2196,14 +2387,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.3.7.tgz",
-      "integrity": "sha512-zIeDRrI0qNgN1lcCjNqt6/IVCVej7VwSa326cO8uP9BOk1cg4QuffhLnOn2gCgWQr32/wxpSRFfXiLKHglu1Tw==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.3.tgz",
+      "integrity": "sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
-        "@astrojs/internal-helpers": "0.9.1",
-        "@astrojs/markdown-remark": "7.1.2",
+        "@astrojs/internal-helpers": "0.10.0",
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/telemetry": "3.3.2",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2215,7 +2407,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
@@ -2273,6 +2465,20 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-pagefind": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-2.0.0.tgz",
+      "integrity": "sha512-i270YlJ/8aX/eRkvtuAPANSk+WK1uyp9DEj/TuuWem4pA0xBUGQk7agNFdu71nRxtH0j7TZxee2qwQRlrfZa1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/component-ui": "^1.5.0",
+        "pagefind": "^1.5.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5 || ^6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2292,6 +2498,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -2306,6 +2527,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -2424,6 +2655,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2909,6 +3147,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3469,9 +3717,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3622,9 +3880,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3644,9 +3899,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3668,9 +3920,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3690,9 +3939,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -5014,6 +5260,24 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5068,6 +5332,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
@@ -5531,6 +5802,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5661,6 +5933,27 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5725,6 +6018,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
@@ -5814,6 +6121,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
@@ -5846,6 +6160,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/trim-lines": {
@@ -6208,6 +6541,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6296,6 +6630,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6313,6 +6737,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/website/package.json
+++ b/website/package.json
@@ -8,15 +8,22 @@
     "start": "astro dev",
     "build": "node scripts/copy-install.mjs && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest run",
+    "test:search": "node scripts/verify-search-index.mjs"
   },
   "dependencies": {
-    "@astrojs/mdx": "^5.0.6",
-    "@astrojs/sitemap": "^3.7.2",
+    "@astrojs/mdx": "^6.0.1",
+    "@astrojs/sitemap": "^3.7.3",
     "@tailwindcss/postcss": "^4.3.0",
-    "astro": "^6.3.7",
+    "astro": "^6.4.3",
+    "astro-pagefind": "^2.0.0",
+    "pagefind": "^1.5.2",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "tailwindcss": "^4.3.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.8"
   }
 }

--- a/website/scripts/verify-search-index.mjs
+++ b/website/scripts/verify-search-index.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Post-build guard for the docs search index. Run after `astro build` (the
+// Pagefind index is generated into dist/pagefind/). It proves three things so a
+// future change can't silently break or re-scope search:
+//
+//   1. The Pagefind runtime (pagefind.js) actually shipped.
+//   2. The docs are in the index (at least one /docs URL).
+//   3. The marketing homepage is NOT in the index (docs-only scope holds).
+//
+// Pagefind stores each indexed page as a gzip-compressed JSON "fragment"; we
+// decompress them to read the indexed URLs without booting the WASM runtime.
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, "..", "dist");
+const pagefindDir = join(distDir, "pagefind");
+
+function fail(message) {
+  console.error(`verify-search-index: ${message}`);
+  process.exit(1);
+}
+
+// 1. The runtime must exist, or the modal can never load.
+const runtime = join(pagefindDir, "pagefind.js");
+if (!existsSync(runtime)) {
+  fail(
+    `${runtime} is missing. Did the astro-pagefind integration run during \`astro build\`?`,
+  );
+}
+
+// Recursively collect every Pagefind fragment file (*.pf_fragment).
+function findFragments(dir) {
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...findFragments(full));
+    } else if (entry.endsWith(".pf_fragment")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const fragments = findFragments(pagefindDir);
+if (fragments.length === 0) {
+  fail(
+    "no indexed pages found (no *.pf_fragment files). Is `data-pagefind-body` present on the docs <article>?",
+  );
+}
+
+// Decode each fragment's indexed URL. A decompressed fragment is a short
+// `pagefind_*` marker followed by a JSON object, so we parse from the first
+// `{` to the last `}`.
+const urls = [];
+for (const file of fragments) {
+  try {
+    const raw = gunzipSync(readFileSync(file)).toString("utf8");
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    if (start === -1 || end === -1) {
+      fail(`fragment ${file} has no JSON payload.`);
+    }
+    const json = JSON.parse(raw.slice(start, end + 1));
+    if (typeof json.url === "string") urls.push(json.url);
+  } catch (error) {
+    fail(`could not decode fragment ${file}: ${error.message}`);
+  }
+}
+
+const norm = (u) => u.replace(/index\.html$/i, "").replace(/\.html$/i, "");
+const isDocs = (u) => norm(u).includes("/docs");
+const isHomepage = (u) => {
+  const p = norm(u).split(/[?#]/)[0].replace(/\/+$/, "");
+  return p === "" || p === "/";
+};
+
+// 2. The docs must be indexed.
+if (!urls.some(isDocs)) {
+  fail(
+    `no /docs pages are indexed. Indexed URLs: ${JSON.stringify(urls)}`,
+  );
+}
+
+// 3. The homepage must NOT be indexed (docs-only scope).
+const leaked = urls.filter(isHomepage);
+if (leaked.length > 0) {
+  fail(
+    `the homepage leaked into the search index (${JSON.stringify(
+      leaked,
+    )}). Search scope must stay docs-only — only docs pages should carry \`data-pagefind-body\`.`,
+  );
+}
+
+console.log(
+  `verify-search-index: OK — ${urls.length} docs page(s) indexed, homepage excluded.`,
+);

--- a/website/src/components/DocsSearch.astro
+++ b/website/src/components/DocsSearch.astro
@@ -1,0 +1,577 @@
+---
+// Docs search modal. Mounted once globally in Layout.astro and opened from the
+// header button (which dispatches the `open-search` event) or via the
+// Cmd/Ctrl-K and "/" shortcuts. The Pagefind engine is dynamically imported
+// only on first open, so pages that never search ship none of it.
+//
+// All visuals derive from the tokens in global.css — no hardcoded colors.
+---
+
+<div id="docs-search" class="search-overlay" hidden>
+  <div class="search-backdrop" data-search-close aria-hidden="true"></div>
+
+  <div
+    class="search-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="docs-search-label"
+  >
+    <h2 id="docs-search-label" class="sr-only">Search the documentation</h2>
+
+    <div class="search-input-row">
+      <svg
+        class="search-icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="8"></circle>
+        <path d="m21 21-4.3-4.3"></path>
+      </svg>
+
+      <input
+        id="docs-search-input"
+        type="search"
+        class="search-input"
+        placeholder="Search the docs…"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+        role="combobox"
+        aria-expanded="false"
+        aria-controls="docs-search-results"
+        aria-autocomplete="list"
+        aria-activedescendant=""
+      />
+
+      <kbd class="search-esc">Esc</kbd>
+    </div>
+
+    <div
+      id="docs-search-status"
+      class="search-status"
+      role="status"
+      aria-live="polite"
+    >
+      Type to search the docs.
+    </div>
+
+    <ul
+      id="docs-search-results"
+      class="search-results"
+      role="listbox"
+      aria-label="Search results"
+    >
+    </ul>
+  </div>
+</div>
+
+<script>
+  import { mapResult, nextIndex } from "../lib/search-ui";
+  import type { SearchResult } from "../lib/search-ui";
+
+  // Minimal shape of the Pagefind module we load at runtime.
+  interface PagefindModule {
+    init?: () => Promise<void>;
+    options?: (opts: Record<string, unknown>) => Promise<void>;
+    debouncedSearch: (
+      query: string,
+    ) => Promise<{ results: Array<{ data: () => Promise<unknown> }> } | null>;
+  }
+
+  const overlay = document.getElementById("docs-search");
+  const input = document.getElementById(
+    "docs-search-input",
+  ) as HTMLInputElement | null;
+  const status = document.getElementById("docs-search-status");
+  const list = document.getElementById("docs-search-results");
+
+  // Bail quietly if the markup isn't present (defensive; it always is).
+  if (overlay && input && status && list) {
+    let pagefind: PagefindModule | null = null;
+    let pagefindFailed = false;
+    let loading: Promise<PagefindModule | null> | null = null;
+    let selected = -1; // index into the flat list of selectable anchors
+    let lastFocused: HTMLElement | null = null;
+    let searchToken = 0; // guards against out-of-order async responses
+
+    const isOpen = () => !overlay.hasAttribute("hidden");
+
+    // Lazy-load the Pagefind runtime on first open. The specifier is built from
+    // BASE_URL so the import is non-static — Vite leaves it alone and the file
+    // (generated into /pagefind/ at build time) resolves at runtime.
+    function loadPagefind(): Promise<PagefindModule | null> {
+      if (pagefind) return Promise.resolve(pagefind);
+      if (pagefindFailed) return Promise.resolve(null);
+      if (loading) return loading;
+      const url = `${import.meta.env.BASE_URL}pagefind/pagefind.js`.replace(
+        /\/{2,}/g,
+        "/",
+      );
+      loading = import(/* @vite-ignore */ url)
+        .then(async (mod: PagefindModule) => {
+          await mod.init?.();
+          pagefind = mod;
+          return mod;
+        })
+        .catch(() => {
+          pagefindFailed = true;
+          return null;
+        });
+      return loading;
+    }
+
+    function setStatus(message: string) {
+      status!.textContent = message;
+    }
+
+    function clearResults() {
+      list!.innerHTML = "";
+      selected = -1;
+      input!.setAttribute("aria-expanded", "false");
+      input!.setAttribute("aria-activedescendant", "");
+    }
+
+    // Every selectable anchor in render order, for keyboard navigation.
+    function anchors(): HTMLAnchorElement[] {
+      return Array.from(
+        list!.querySelectorAll<HTMLAnchorElement>("a[data-result]"),
+      );
+    }
+
+    function applySelection() {
+      const items = anchors();
+      items.forEach((a, i) => {
+        const active = i === selected;
+        a.classList.toggle("is-active", active);
+        a.setAttribute("aria-selected", active ? "true" : "false");
+        if (active) {
+          input!.setAttribute("aria-activedescendant", a.id);
+          a.scrollIntoView({ block: "nearest" });
+        }
+      });
+      if (selected < 0) input!.setAttribute("aria-activedescendant", "");
+    }
+
+    function renderResults(results: SearchResult[], query: string) {
+      if (results.length === 0) {
+        clearResults();
+        setStatus(`No results for "${query}".`);
+        return;
+      }
+
+      const frag = document.createDocumentFragment();
+      let counter = 0;
+      for (const r of results) {
+        const li = document.createElement("li");
+        li.className = "search-result-group";
+
+        const main = document.createElement("a");
+        main.id = `docs-search-opt-${counter++}`;
+        main.href = r.url;
+        main.dataset.result = "";
+        main.setAttribute("role", "option");
+        main.className = "search-result";
+        main.innerHTML = `<span class="search-result-title">${escapeHtml(
+          r.title,
+        )}</span>${
+          r.excerpt
+            ? `<span class="search-result-excerpt">${r.excerpt}</span>`
+            : ""
+        }`;
+        li.appendChild(main);
+
+        for (const sub of r.subResults) {
+          const subAnchor = document.createElement("a");
+          subAnchor.id = `docs-search-opt-${counter++}`;
+          subAnchor.href = sub.url;
+          subAnchor.dataset.result = "";
+          subAnchor.setAttribute("role", "option");
+          subAnchor.className = "search-subresult";
+          subAnchor.innerHTML = `<span class="search-subresult-title">${escapeHtml(
+            sub.title,
+          )}</span>${
+            sub.excerpt
+              ? `<span class="search-result-excerpt">${sub.excerpt}</span>`
+              : ""
+          }`;
+          li.appendChild(subAnchor);
+        }
+
+        frag.appendChild(li);
+      }
+
+      list!.innerHTML = "";
+      list!.appendChild(frag);
+      selected = -1;
+      input!.setAttribute("aria-expanded", "true");
+      setStatus(
+        `${results.length} result${results.length === 1 ? "" : "s"}.`,
+      );
+    }
+
+    function escapeHtml(value: string): string {
+      const div = document.createElement("div");
+      div.textContent = value;
+      return div.innerHTML;
+    }
+
+    async function runSearch(query: string) {
+      const trimmed = query.trim();
+      if (trimmed === "") {
+        clearResults();
+        setStatus("Type to search the docs.");
+        return;
+      }
+
+      const token = ++searchToken;
+      const pf = await loadPagefind();
+      if (token !== searchToken) return; // a newer keystroke superseded us
+
+      if (!pf) {
+        clearResults();
+        setStatus("Search index isn't built yet — run `npm run build`.");
+        return;
+      }
+
+      setStatus("Searching…");
+      const search = await pf.debouncedSearch(trimmed);
+      if (token !== searchToken) return;
+      // debouncedSearch resolves to null when a later call debounced this one.
+      if (!search) return;
+
+      const data = await Promise.all(search.results.map((r) => r.data()));
+      if (token !== searchToken) return;
+
+      renderResults(
+        data.map((d) => mapResult(d as Parameters<typeof mapResult>[0])),
+        trimmed,
+      );
+    }
+
+    function openSearch() {
+      if (isOpen()) return;
+      lastFocused = document.activeElement as HTMLElement | null;
+      overlay!.removeAttribute("hidden");
+      document.body.style.overflow = "hidden";
+      // Warm the engine up so the first keystroke feels instant.
+      void loadPagefind();
+      requestAnimationFrame(() => {
+        input!.focus();
+        input!.select();
+      });
+    }
+
+    function closeSearch() {
+      if (!isOpen()) return;
+      overlay!.setAttribute("hidden", "");
+      document.body.style.overflow = "";
+      input!.value = "";
+      clearResults();
+      setStatus("Type to search the docs.");
+      lastFocused?.focus?.();
+    }
+
+    function moveSelection(delta: number) {
+      const items = anchors();
+      selected = nextIndex(selected, delta, items.length);
+      applySelection();
+    }
+
+    // ---- Wiring -----------------------------------------------------------
+
+    document.addEventListener("open-search", openSearch);
+
+    // Any element marked `data-open-search` (the header button) opens the modal.
+    document.addEventListener("click", (event) => {
+      if ((event.target as HTMLElement).closest("[data-open-search]")) {
+        event.preventDefault();
+        openSearch();
+      }
+    });
+
+    overlay.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement;
+      if (target.closest("[data-search-close]")) closeSearch();
+    });
+
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    input.addEventListener("input", () => {
+      clearTimeout(debounceTimer);
+      const value = input!.value;
+      debounceTimer = setTimeout(() => void runSearch(value), 120);
+    });
+
+    input.addEventListener("keydown", (event) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          moveSelection(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          moveSelection(-1);
+          break;
+        case "Enter": {
+          const items = anchors();
+          if (selected >= 0 && items[selected]) {
+            event.preventDefault();
+            window.location.href = items[selected].href;
+          }
+          break;
+        }
+        case "Escape":
+          event.preventDefault();
+          closeSearch();
+          break;
+      }
+    });
+
+    // Pointer hover updates the active row so mouse and keyboard agree.
+    list.addEventListener("mousemove", (event) => {
+      const anchor = (event.target as HTMLElement).closest<HTMLAnchorElement>(
+        "a[data-result]",
+      );
+      if (!anchor) return;
+      const items = anchors();
+      const index = items.indexOf(anchor);
+      if (index !== -1 && index !== selected) {
+        selected = index;
+        applySelection();
+      }
+    });
+
+    // Global shortcuts: Cmd/Ctrl-K toggles; "/" opens when not already typing
+    // in a field; both work from anywhere on the page.
+    document.addEventListener("keydown", (event) => {
+      const target = event.target as HTMLElement | null;
+      const typing =
+        !!target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        isOpen() ? closeSearch() : openSearch();
+        return;
+      }
+      if (event.key === "/" && !typing && !isOpen()) {
+        event.preventDefault();
+        openSearch();
+      }
+    });
+
+    // Keep focus inside the dialog while it's open (simple Tab trap).
+    overlay.addEventListener("keydown", (event) => {
+      if (event.key !== "Tab" || !isOpen()) return;
+      const focusable = overlay!.querySelectorAll<HTMLElement>(
+        'input, a[href], button, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+  }
+</script>
+
+<style>
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .search-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 12vh 1rem 1rem;
+  }
+
+  .search-overlay[hidden] {
+    display: none;
+  }
+
+  .search-backdrop {
+    position: absolute;
+    inset: 0;
+    background: color-mix(in oklab, var(--color-ink) 78%, transparent);
+    backdrop-filter: blur(4px);
+  }
+
+  .search-dialog {
+    position: relative;
+    width: 100%;
+    max-width: 40rem;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 0.85rem;
+    border: 1px solid var(--color-border);
+    background: color-mix(in oklab, var(--color-panel) 96%, transparent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--color-accent) 8%, transparent),
+      0 24px 70px -20px color-mix(in oklab, var(--color-ink) 90%, transparent);
+    animation: search-pop 0.14s ease-out;
+  }
+
+  @keyframes search-pop {
+    from {
+      opacity: 0;
+      transform: translateY(-0.5rem) scale(0.99);
+    }
+  }
+
+  .search-input-row {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid var(--color-border-soft);
+  }
+
+  .search-icon {
+    width: 1.1rem;
+    height: 1.1rem;
+    flex-shrink: 0;
+    color: var(--color-dim);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: 0;
+    outline: none;
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: 1rem;
+  }
+
+  .search-input::placeholder {
+    color: var(--color-dim);
+  }
+
+  /* Hide the native search "clear" affordance; Esc / backdrop close instead. */
+  .search-input::-webkit-search-cancel-button {
+    display: none;
+  }
+
+  .search-esc {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--color-dim);
+    padding: 0.15rem 0.45rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.4rem;
+    background: var(--color-panel-2);
+  }
+
+  .search-status {
+    padding: 0.5rem 1rem;
+    font-size: 0.75rem;
+    color: var(--color-dim);
+    border-bottom: 1px solid var(--color-border-soft);
+  }
+
+  .search-results {
+    list-style: none;
+    margin: 0;
+    padding: 0.4rem;
+    overflow-y: auto;
+  }
+
+  /* The result rows below are built in JavaScript (document.createElement), so
+     they never receive Astro's scoping attribute. Their rules must therefore be
+     `:global()` — but every one is nested under the templated `.search-results`
+     container, so the styles reach the dynamic children without leaking to the
+     rest of the site. */
+  .search-results :global(.search-result-group + .search-result-group) {
+    margin-top: 0.15rem;
+  }
+
+  .search-results :global(.search-result),
+  .search-results :global(.search-subresult) {
+    display: block;
+    padding: 0.55rem 0.7rem;
+    border-radius: 0.55rem;
+    text-decoration: none;
+    color: var(--color-text);
+    border: 1px solid transparent;
+  }
+
+  .search-results :global(.search-subresult) {
+    margin-left: 1rem;
+    padding-top: 0.4rem;
+    padding-bottom: 0.4rem;
+    border-left: 1px solid var(--color-border-soft);
+    border-radius: 0 0.55rem 0.55rem 0;
+  }
+
+  .search-results :global(.search-result.is-active),
+  .search-results :global(.search-subresult.is-active) {
+    background: color-mix(in oklab, var(--color-accent) 12%, transparent);
+    border-color: color-mix(in oklab, var(--color-accent) 45%, transparent);
+  }
+
+  .search-results :global(.search-result-title) {
+    display: block;
+    font-family: var(--font-display);
+    font-size: 0.92rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .search-results :global(.search-subresult-title) {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--color-muted);
+  }
+
+  .search-results :global(.search-result-excerpt) {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: var(--color-dim);
+  }
+
+  /* Pagefind wraps matched terms in <mark>; tint them with the accent. */
+  .search-results :global(mark) {
+    background: color-mix(in oklab, var(--color-accent) 22%, transparent);
+    color: var(--color-text);
+    border-radius: 0.2rem;
+    padding: 0 0.1em;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .search-dialog {
+      animation: none;
+    }
+  }
+</style>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -9,26 +9,129 @@ const nav = [
 ---
 
 <header class="sticky top-0 z-50 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-ink)]/70 backdrop-blur-xl">
-  <div class="container-app flex h-14 items-center justify-between">
-    <a href="/" class="flex items-center gap-2.5 group">
+  <div class="container-app flex h-14 items-center justify-between gap-3">
+    <a href="/" class="flex items-center gap-2.5 group min-w-0">
       <img
         src="/dux-logo.png"
         alt="dux"
         width="28"
         height="28"
-        class="h-7 w-7 object-contain transition-transform group-hover:-rotate-6"
+        class="h-7 w-7 shrink-0 object-contain transition-transform group-hover:-rotate-6"
       />
-      <span class="heading text-[15px] font-semibold tracking-tight">
+      <span class="heading truncate text-[15px] font-semibold tracking-tight">
         dux<span class="text-[color:var(--color-dim)]"> · getdux.app</span>
       </span>
     </a>
 
-    <nav class="hidden items-center gap-1 sm:flex">
+    <div class="flex items-center gap-1.5">
+      {/* Opens the global docs search modal (see DocsSearch.astro). Also bound
+          to Cmd/Ctrl-K and "/". Icon-only on small screens; the label and
+          shortcut hint appear at lg, where the inline nav also has room. */}
+      <button
+        type="button"
+        data-open-search
+        aria-label="Search the documentation"
+        aria-keyshortcuts="Meta+K Control+K"
+        class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-panel)]/60 text-sm text-[color:var(--color-muted)] transition-colors hover:border-[color:var(--color-accent)]/50 hover:text-[color:var(--color-text)] lg:w-auto lg:justify-start lg:px-2.5"
+      >
+        <svg
+          class="h-4 w-4 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <path d="m21 21-4.3-4.3"></path>
+        </svg>
+        <span class="hidden lg:inline">Search docs</span>
+        <kbd
+          class="mono hidden rounded border border-[color:var(--color-border)] bg-[color:var(--color-panel-2)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-dim)] lg:inline"
+          aria-hidden="true">⌘K</kbd
+        >
+      </button>
+
+      {/* Full inline nav — desktop only. Below lg it collapses into the
+          hamburger menu so the bar never crowds or wraps. */}
+      <nav class="hidden items-center gap-1 lg:flex">
+        {
+          nav.map((n) => (
+            <a
+              href={n.href}
+              class="rounded-md px-3 py-1.5 text-sm text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] hover:bg-[color:var(--color-panel-2)] transition-colors"
+              {...(n.external ? { target: "_blank", rel: "noopener" } : {})}
+            >
+              {n.label}
+            </a>
+          ))
+        }
+        <a
+          href="/#install"
+          class="ml-2 inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-accent)]/50 bg-[color:var(--color-accent)]/10 px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent)] hover:bg-[color:var(--color-accent)]/20 transition-colors"
+        >
+          <span class="mono">$</span> install
+        </a>
+      </nav>
+
+      {/* Hamburger — small/medium screens only. Toggles the panel below. */}
+      <button
+        type="button"
+        data-menu-toggle
+        aria-label="Toggle navigation menu"
+        aria-expanded="false"
+        aria-controls="mobile-nav"
+        class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-panel)]/60 text-[color:var(--color-muted)] hover:border-[color:var(--color-accent)]/50 hover:text-[color:var(--color-text)] transition-colors lg:hidden"
+      >
+        <svg
+          data-menu-icon-open
+          class="h-5 w-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+        <svg
+          data-menu-icon-close
+          class="hidden h-5 w-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  {/* Collapsible nav panel for small/medium screens. Hidden at lg where the
+      inline nav takes over. */}
+  <nav
+    id="mobile-nav"
+    aria-label="Site navigation"
+    hidden
+    class="lg:hidden border-t border-[color:var(--color-border-soft)] bg-[color:var(--color-ink)]/95 backdrop-blur-xl"
+  >
+    <div class="container-app flex flex-col gap-1 py-3">
       {
         nav.map((n) => (
           <a
             href={n.href}
-            class="rounded-md px-3 py-1.5 text-sm text-[color:var(--color-muted)] hover:text-[color:var(--color-text)] hover:bg-[color:var(--color-panel-2)] transition-colors"
+            class="rounded-md px-3 py-2.5 text-sm text-[color:var(--color-muted)] hover:bg-[color:var(--color-panel-2)] hover:text-[color:var(--color-text)] transition-colors"
             {...(n.external ? { target: "_blank", rel: "noopener" } : {})}
           >
             {n.label}
@@ -37,10 +140,62 @@ const nav = [
       }
       <a
         href="/#install"
-        class="ml-2 inline-flex items-center gap-1.5 rounded-md border border-[color:var(--color-accent)]/50 bg-[color:var(--color-accent)]/10 px-3 py-1.5 text-sm font-medium text-[color:var(--color-accent)] hover:bg-[color:var(--color-accent)]/20 transition-colors"
+        class="mt-1 inline-flex items-center justify-center gap-1.5 rounded-md border border-[color:var(--color-accent)]/50 bg-[color:var(--color-accent)]/10 px-3 py-2.5 text-sm font-medium text-[color:var(--color-accent)] hover:bg-[color:var(--color-accent)]/20 transition-colors"
       >
         <span class="mono">$</span> install
       </a>
-    </nav>
-  </div>
+    </div>
+  </nav>
 </header>
+
+<script>
+  // Hamburger menu toggle for small/medium screens. The panel is plain markup
+  // (works without JS for crawlers); this only manages open/close state,
+  // accessibility, and dismissal.
+  const toggle = document.querySelector<HTMLButtonElement>("[data-menu-toggle]");
+  const panel = document.getElementById("mobile-nav");
+  const iconOpen = document.querySelector<SVGElement>("[data-menu-icon-open]");
+  const iconClose = document.querySelector<SVGElement>("[data-menu-icon-close]");
+
+  if (toggle && panel && iconOpen && iconClose) {
+    const setOpen = (open: boolean) => {
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+      panel.hidden = !open;
+      iconOpen.classList.toggle("hidden", open);
+      iconClose.classList.toggle("hidden", !open);
+    };
+
+    toggle.addEventListener("click", () => {
+      setOpen(toggle.getAttribute("aria-expanded") !== "true");
+    });
+
+    // Close after picking a destination (covers same-page anchor links that
+    // don't trigger a full navigation).
+    panel.addEventListener("click", (event) => {
+      if ((event.target as HTMLElement).closest("a")) setOpen(false);
+    });
+
+    // Dismiss on Escape or a click outside the header.
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && toggle.getAttribute("aria-expanded") === "true") {
+        setOpen(false);
+        toggle.focus();
+      }
+    });
+    document.addEventListener("click", (event) => {
+      if (
+        toggle.getAttribute("aria-expanded") === "true" &&
+        !(event.target as HTMLElement).closest("header")
+      ) {
+        setOpen(false);
+      }
+    });
+
+    // If the viewport grows to the desktop breakpoint, drop the open state so
+    // the panel never lingers behind the inline nav.
+    const desktop = window.matchMedia("(min-width: 1024px)");
+    desktop.addEventListener("change", (event) => {
+      if (event.matches) setOpen(false);
+    });
+  }
+</script>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -108,7 +108,12 @@ const gridClass =
           </div>
         </details>
 
-        <article>
+        {/* `data-pagefind-body` scopes the search index to docs pages only:
+            Pagefind indexes nothing on pages that lack this attribute, so the
+            marketing homepage stays out of results. The page <h1> becomes the
+            result title and heading ids (from rehype-slug) become deep-linkable
+            sub-results. */}
+        <article data-pagefind-body>
           <header class="mb-8 border-b border-[color:var(--color-border-soft)] pb-6">
             <h1 class="text-3xl font-bold tracking-tight text-[color:var(--color-text)] sm:text-4xl">
               {title}
@@ -124,7 +129,7 @@ const gridClass =
 
           {
             editUrl && (
-              <div class="mt-12 border-t border-[color:var(--color-border-soft)] pt-6 text-sm">
+              <div data-pagefind-ignore class="mt-12 border-t border-[color:var(--color-border-soft)] pt-6 text-sm">
                 <a
                   href={editUrl}
                   target="_blank"

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import DocsSearch from "../components/DocsSearch.astro";
 
 interface Props {
   title?: string;
@@ -180,6 +181,10 @@ const sd = {
   </head>
   <body class="text-[color:var(--color-text)]">
     <slot />
+
+    {/* Global docs search modal. Opened from the header button or Cmd/Ctrl-K;
+        the Pagefind engine is lazy-loaded only when first opened. */}
+    <DocsSearch />
 
     {/* Mark every off-site link: open in a new tab, harden rel, and (for
         inline links) append an external-link glyph. Runs once on load and

--- a/website/src/lib/search-ui.test.ts
+++ b/website/src/lib/search-ui.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl, mapResult, nextIndex } from "./search-ui";
+
+describe("normalizeUrl", () => {
+  it("strips a trailing index.html", () => {
+    expect(normalizeUrl("/docs/themes/index.html")).toBe("/docs/themes");
+  });
+
+  it("strips a trailing .html", () => {
+    expect(normalizeUrl("/docs/themes.html")).toBe("/docs/themes");
+  });
+
+  it("preserves an anchor for heading deep links", () => {
+    expect(normalizeUrl("/docs/themes/index.html#opaline-format")).toBe(
+      "/docs/themes#opaline-format",
+    );
+  });
+
+  it("preserves a query string", () => {
+    expect(normalizeUrl("/docs/themes.html?x=1")).toBe("/docs/themes?x=1");
+  });
+
+  it("ensures a leading slash", () => {
+    expect(normalizeUrl("docs/themes")).toBe("/docs/themes");
+  });
+
+  it("collapses accidental double slashes", () => {
+    expect(normalizeUrl("/docs//themes/index.html")).toBe("/docs/themes");
+  });
+
+  it("leaves the root path intact", () => {
+    expect(normalizeUrl("/index.html")).toBe("/");
+    expect(normalizeUrl("/")).toBe("/");
+  });
+
+  it("falls back to root for empty input", () => {
+    expect(normalizeUrl(undefined)).toBe("/");
+    expect(normalizeUrl("")).toBe("/");
+  });
+});
+
+describe("mapResult", () => {
+  it("normalizes the url, title, and excerpt", () => {
+    const result = mapResult({
+      url: "/docs/themes/index.html",
+      excerpt: "  Pick a   <mark>theme</mark> for dux.  ",
+      meta: { title: "Themes" },
+      sub_results: [],
+    });
+    expect(result).toEqual({
+      url: "/docs/themes",
+      title: "Themes",
+      excerpt: "Pick a <mark>theme</mark> for dux.",
+      subResults: [],
+    });
+  });
+
+  it("falls back to 'Untitled' when no title is present", () => {
+    expect(mapResult({ url: "/docs/x.html" }).title).toBe("Untitled");
+  });
+
+  it("keeps heading sub-results and deep-links them", () => {
+    const result = mapResult({
+      url: "/docs/themes.html",
+      meta: { title: "Themes" },
+      sub_results: [
+        {
+          title: "Opaline format",
+          url: "/docs/themes.html#opaline-format",
+          excerpt: "TOML <mark>theme</mark> files.",
+        },
+      ],
+    });
+    expect(result.subResults).toEqual([
+      {
+        title: "Opaline format",
+        url: "/docs/themes#opaline-format",
+        excerpt: "TOML <mark>theme</mark> files.",
+      },
+    ]);
+  });
+
+  it("drops a sub-result that resolves to the page itself", () => {
+    const result = mapResult({
+      url: "/docs/themes.html",
+      meta: { title: "Themes" },
+      sub_results: [
+        { title: "Themes", url: "/docs/themes/index.html", excerpt: "top" },
+        { title: "Opaline", url: "/docs/themes.html#opaline", excerpt: "x" },
+      ],
+    });
+    expect(result.subResults.map((s) => s.url)).toEqual([
+      "/docs/themes#opaline",
+    ]);
+  });
+
+  it("de-duplicates sub-results by normalized url", () => {
+    const result = mapResult({
+      url: "/docs/a.html",
+      meta: { title: "A" },
+      sub_results: [
+        { title: "S", url: "/docs/a.html#s", excerpt: "1" },
+        { title: "S again", url: "/docs/a/index.html#s", excerpt: "2" },
+      ],
+    });
+    expect(result.subResults).toHaveLength(1);
+  });
+
+  it("caps sub-results at maxSub", () => {
+    const result = mapResult(
+      {
+        url: "/docs/a.html",
+        meta: { title: "A" },
+        sub_results: [
+          { title: "1", url: "/docs/a.html#1", excerpt: "" },
+          { title: "2", url: "/docs/a.html#2", excerpt: "" },
+          { title: "3", url: "/docs/a.html#3", excerpt: "" },
+          { title: "4", url: "/docs/a.html#4", excerpt: "" },
+        ],
+      },
+      2,
+    );
+    expect(result.subResults).toHaveLength(2);
+  });
+});
+
+describe("nextIndex", () => {
+  it("returns -1 when there are no items", () => {
+    expect(nextIndex(-1, 1, 0)).toBe(-1);
+    expect(nextIndex(3, -1, 0)).toBe(-1);
+  });
+
+  it("selects the first item from nothing on ArrowDown", () => {
+    expect(nextIndex(-1, 1, 3)).toBe(0);
+  });
+
+  it("selects the last item from nothing on ArrowUp", () => {
+    expect(nextIndex(-1, -1, 3)).toBe(2);
+  });
+
+  it("moves forward within bounds", () => {
+    expect(nextIndex(0, 1, 3)).toBe(1);
+  });
+
+  it("wraps forward past the end", () => {
+    expect(nextIndex(2, 1, 3)).toBe(0);
+  });
+
+  it("wraps backward past the start", () => {
+    expect(nextIndex(0, -1, 3)).toBe(2);
+  });
+});

--- a/website/src/lib/search-ui.ts
+++ b/website/src/lib/search-ui.ts
@@ -1,0 +1,119 @@
+// Pure, framework-free logic for the docs search modal. Kept separate from the
+// DOM glue in DocsSearch.astro so it can be unit-tested without a browser. The
+// `.astro` script imports these helpers and only handles wiring (events, focus,
+// rendering).
+
+/** A single sub-result Pagefind returns, anchored to a heading on the page. */
+export interface PagefindSubResult {
+  title?: string;
+  url?: string;
+  excerpt?: string;
+  anchor?: { id?: string };
+}
+
+/** The shape of the object returned by Pagefind's `result.data()`. Only the
+ *  fields we consume are typed; Pagefind returns more. */
+export interface PagefindData {
+  url?: string;
+  excerpt?: string;
+  meta?: { title?: string };
+  sub_results?: PagefindSubResult[];
+}
+
+/** A heading-level hit within a page, ready to render as a deep link. */
+export interface SearchSubResult {
+  title: string;
+  url: string;
+  excerpt: string;
+}
+
+/** A normalized, render-ready search result. */
+export interface SearchResult {
+  url: string;
+  title: string;
+  excerpt: string;
+  subResults: SearchSubResult[];
+}
+
+/**
+ * Normalize a built-output URL into a clean site path.
+ *
+ * Pagefind indexes the generated HTML, so URLs can arrive as
+ * `/docs/themes/index.html` or `/docs/themes.html`. We strip the `.html`
+ * artifact while preserving any `#anchor` (used by sub-results to deep-link to
+ * a heading) and any query string. The result always starts with `/`.
+ */
+export function normalizeUrl(raw: string | undefined): string {
+  if (!raw) return "/";
+  // Split off hash and query so we only rewrite the path segment.
+  const hashIndex = raw.indexOf("#");
+  const hash = hashIndex >= 0 ? raw.slice(hashIndex) : "";
+  const withoutHash = hashIndex >= 0 ? raw.slice(0, hashIndex) : raw;
+  const queryIndex = withoutHash.indexOf("?");
+  const query = queryIndex >= 0 ? withoutHash.slice(queryIndex) : "";
+  let path = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+
+  path = path.replace(/index\.html$/i, "").replace(/\.html$/i, "");
+  if (!path.startsWith("/")) path = `/${path}`;
+  // Collapse any accidental double slashes introduced by stripping.
+  path = path.replace(/\/{2,}/g, "/");
+  // Keep a trailing slash off unless the path is just the root.
+  if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1);
+
+  return `${path}${query}${hash}`;
+}
+
+/** Trim and collapse whitespace in a Pagefind excerpt's surrounding text while
+ *  preserving the `<mark>` highlight tags Pagefind injects. */
+function cleanExcerpt(excerpt: string | undefined): string {
+  return (excerpt ?? "").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Convert a raw Pagefind `result.data()` payload into a render-ready
+ * `SearchResult`. De-duplicates sub-results by normalized URL (Pagefind can
+ * emit the page-top result and a heading result that resolve to the same
+ * place) and drops a sub-result that just points back at the page itself.
+ *
+ * @param data   the object from `await result.data()`
+ * @param maxSub maximum heading sub-results to keep (default 3)
+ */
+export function mapResult(data: PagefindData, maxSub = 3): SearchResult {
+  const url = normalizeUrl(data.url);
+  const title = (data.meta?.title ?? "").trim() || "Untitled";
+  const excerpt = cleanExcerpt(data.excerpt);
+
+  const seen = new Set<string>([url]);
+  const subResults: SearchSubResult[] = [];
+  for (const sub of data.sub_results ?? []) {
+    const subUrl = normalizeUrl(sub.url);
+    // Skip sub-results that resolve to the page itself (no anchor) or that we
+    // have already added under a different raw form.
+    if (seen.has(subUrl)) continue;
+    seen.add(subUrl);
+    subResults.push({
+      title: (sub.title ?? "").trim() || title,
+      url: subUrl,
+      excerpt: cleanExcerpt(sub.excerpt),
+    });
+    if (subResults.length >= maxSub) break;
+  }
+
+  return { url, title, excerpt, subResults };
+}
+
+/**
+ * Compute the next selected index for keyboard navigation with wrap-around.
+ *
+ * @param current the currently selected index (-1 means "nothing selected")
+ * @param delta   +1 for down/next, -1 for up/previous
+ * @param length  number of selectable items
+ * @returns the new index, or -1 when there is nothing to select
+ */
+export function nextIndex(current: number, delta: number, length: number): number {
+  if (length <= 0) return -1;
+  // From "nothing selected", ArrowDown picks the first item and ArrowUp the
+  // last — the conventional command-palette behavior.
+  if (current < 0) return delta > 0 ? 0 : length - 1;
+  return (current + delta + length) % length;
+}


### PR DESCRIPTION
This adds full-text search to the `getdux.app` documentation, built on [Pagefind](https://pagefind.app) so it runs entirely on static hosting with no server or API. Search opens as a keyboard-driven command palette from a button in the header, or with `Cmd/Ctrl-K` and `/`, and returns ranked results with deep links straight to the matching heading on a page. The Pagefind engine is loaded lazily on first open, so pages that never search pay nothing for it, and the index is scoped to the docs only — the marketing homepage is left out of results.

Under the hood it uses the `astro-pagefind` integration to build the index during `astro build` and serve it in `astro dev`, and the docs `<article>` is tagged with `data-pagefind-body` to enforce that docs-only scope. Adding a search affordance to the header surfaced a pre-existing gap: the nav links were simply hidden on small screens. The header now collapses its links into a **hamburger menu on mobile and tablet** while keeping the search button visible, and shows the full inline nav only on desktop. This change also migrates the deprecated top-level `markdown.rehypePlugins` config to the new `unified()` processor introduced in the recent Astro upgrade, keeping heading anchors and syntax highlighting intact.

A small post-build script verifies that the index was generated, that the docs are present, and that the homepage stays out of it, and the search UI logic ships with unit tests. Both checks run in CI, and the deploy workflow now refuses to publish if the search index is missing.