### PR TITLE
Show all-time npm downloads on the website instead of the monthly count

### DIFF
--- a/website/src/components/Stats.astro
+++ b/website/src/components/Stats.astro
@@ -2,14 +2,14 @@
 // A compact, build-time strip of live download counters, sized to sit directly
 // under the install widget in the hero. Any counter whose lookup fails is
 // dropped; if all fail, nothing renders.
-import { getReleaseDownloads, getNpmLastMonth, formatCount } from "../lib/stats";
+import { getReleaseDownloads, getNpmTotal, formatCount } from "../lib/stats";
 
 const repo = "patrickdappollonio/dux";
 const pkg = "@patrickdappollonio/dux";
 
 const [downloads, npm] = await Promise.all([
   getReleaseDownloads(repo),
-  getNpmLastMonth(pkg),
+  getNpmTotal(pkg),
 ]);
 
 interface Stat {
@@ -29,8 +29,8 @@ if (downloads !== null) {
 if (npm !== null) {
   stats.push({
     value: formatCount(npm),
-    label: "npm / month",
-    note: "last 30 days",
+    label: "npm",
+    note: "all time",
   });
 }
 // Combined total, shown only when both sources are present. The "=" beside it

--- a/website/src/lib/stats.ts
+++ b/website/src/lib/stats.ts
@@ -1,7 +1,7 @@
 // Build-time project stats for the homepage: total release-asset downloads
-// (Homebrew pulls these too) and npm downloads over the last month. Both are
-// fetched once at build and baked into the HTML. Either returns `null` on
-// failure, and the caller hides that counter.
+// (Homebrew pulls these too) and all-time npm downloads. Both are fetched once
+// at build and baked into the HTML. Either returns `null` on failure, and the
+// caller hides that counter.
 import { fetchJson, githubHeaders } from "./remote-json";
 
 interface Release {
@@ -23,11 +23,49 @@ export async function getReleaseDownloads(repo: string): Promise<number | null> 
   return total;
 }
 
-export async function getNpmLastMonth(pkg: string): Promise<number | null> {
-  const data = await fetchJson<{ downloads?: number }>(
-    `https://api.npmjs.org/downloads/point/last-month/${pkg}`,
+// Earliest day npm exposes download statistics for any package.
+const NPM_STATS_EPOCH = "2015-01-10";
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// First-publish day for a package, used as the lower bound when summing
+// all-time downloads. Falls back to the npm stats epoch when the registry
+// lookup fails or the package predates it.
+async function getNpmFirstPublish(pkg: string): Promise<string> {
+  const data = await fetchJson<{ time?: { created?: string } }>(
+    `https://registry.npmjs.org/${pkg}`,
   );
-  return typeof data?.downloads === "number" ? data.downloads : null;
+  const created = data?.time?.created?.slice(0, 10);
+  return created && created > NPM_STATS_EPOCH ? created : NPM_STATS_EPOCH;
+}
+
+// Total npm downloads across the package's whole lifetime. npm's point API
+// caps each query at 18 months, so we sum consecutive (non-overlapping)
+// 17-month windows from the first-publish day up to today. Returns null only
+// when no window yields data, so the caller hides the counter just as it would
+// on a failed lookup.
+export async function getNpmTotal(pkg: string): Promise<number | null> {
+  const today = new Date();
+  let windowStart = new Date(await getNpmFirstPublish(pkg));
+  let total = 0;
+  let seen = false;
+  while (windowStart <= today) {
+    const windowEnd = new Date(windowStart);
+    windowEnd.setMonth(windowEnd.getMonth() + 17);
+    if (windowEnd > today) windowEnd.setTime(today.getTime());
+    const data = await fetchJson<{ downloads?: number }>(
+      `https://api.npmjs.org/downloads/point/${isoDay(windowStart)}:${isoDay(windowEnd)}/${pkg}`,
+    );
+    if (typeof data?.downloads === "number") {
+      total += data.downloads;
+      seen = true;
+    }
+    windowStart = new Date(windowEnd);
+    windowStart.setDate(windowStart.getDate() + 1);
+  }
+  return seen ? total : null;
 }
 
 export function formatCount(n: number): string {


### PR DESCRIPTION
The website hero strip showed npm downloads over a rolling 30-day window, which meant the number drifted up and down every day as old days fell out of the window. This swaps that counter for the package's all-time download total so it only ever grows, and updates the combined "Total" stat (GitHub + Homebrew + npm) accordingly.

npm's download API caps any single query at 18 months, so there is no direct "all time" endpoint. To work around this, the new `getNpmTotal` helper looks up the package's first-publish date from the registry and sums consecutive non-overlapping windows up to today. It degrades the same way the old lookup did: if the data can't be fetched, it returns `null` and the counter is simply hidden rather than failing the build.

The counter is also relabeled from `npm / month` / `last 30 days` to `npm` / `all time` so the meaning stays clear, and the fallback to npm's earliest stats date keeps the sum correct even as the package ages past the 18-month limit.
