### PR TITLE
Add a blog with an RSS feed to the website

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -26,3 +26,6 @@ pnpm-debug.log*
 public/install.sh
 public/dux-logo.png
 public/dux-screenshot.svg
+
+# generated at build time from raster images by scripts/generate-webp.mjs
+public/**/*.webp

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -5,6 +5,8 @@ import pagefind from "astro-pagefind";
 import { unified } from "@astrojs/markdown-remark";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypeProseImages from "./src/lib/rehype-prose-images.mjs";
+import remarkGemoji from "remark-gemoji";
 
 export default defineConfig({
   site: "https://getdux.app",
@@ -15,9 +17,17 @@ export default defineConfig({
   //
   // pagefind() builds the static search index on `astro build` (shipped in
   // dist/pagefind/) and serves a prebuilt index during `astro dev`. Only pages
-  // carrying `data-pagefind-body` are indexed — see DocsLayout.astro — so the
-  // index stays scoped to the docs and excludes the marketing homepage.
-  integrations: [mdx(), pagefind(), sitemap()],
+  // carrying `data-pagefind-body` are indexed — the docs (DocsLayout.astro) and
+  // blog posts (BlogLayout.astro) — so the index covers docs and blog while
+  // excluding the marketing homepage.
+  // The sitemap excludes the RSS endpoint (it's a feed, not a page). Draft
+  // posts never reach the sitemap because they're dropped from the production
+  // build entirely (see src/pages/blog/[...slug].astro).
+  integrations: [
+    mdx(),
+    pagefind(),
+    sitemap({ filter: (page) => !page.endsWith("/rss.xml") }),
+  ],
   build: {
     inlineStylesheets: "auto",
   },
@@ -30,6 +40,10 @@ export default defineConfig({
     // Astro 6 deprecated top-level markdown.rehypePlugins/remarkPlugins in
     // favor of a processor built with unified() from @astrojs/markdown-remark.
     processor: unified({
+      // GitHub-style emoji shortcodes (`:smile:` -> 😄) in any Markdown page.
+      // Operates on text nodes only, so shortcodes inside code spans/blocks are
+      // left literal.
+      remarkPlugins: [remarkGemoji],
       rehypePlugins: [
         // Give every heading a stable slug id, then append a clickable "#"
         // anchor so docs headings are linkable. The slug ids also power the
@@ -49,6 +63,9 @@ export default defineConfig({
             content: { type: "element", tagName: "span", properties: {}, children: [] },
           },
         ],
+        // Markdown image upgrades: `#left|#right|#center|#full` alignment via
+        // the URL hash, plus a <picture>/webp wrapper for local raster images.
+        rehypeProseImages,
       ],
     }),
   },

--- a/website/blog/introducing-the-dux-blog.md
+++ b/website/blog/introducing-the-dux-blog.md
@@ -1,0 +1,31 @@
+---
+title: Introducing the dux blog
+description: A little corner of getdux.app for release notes, works-in-progress, and the occasional rabbit hole.
+author: Patrick D'appollonio
+pubDate: 2026-06-08
+---
+
+![The dux duck logo.](/dux-logo.png#right) dux now has a blog. This is it. You're reading it. 🦆
+
+If you're unaware, dux is a terminal multiplexer for the modern era. It allows you to run multiple AI agent sessions in Git worktrees in the same terminal window, and it handles all the messy details of keeping them alive and organized. It's an open source tool, free to use, and [available on GitHub](https://github.com/patrickdappollonio/dux).
+
+The blog is a new section of the website where I can share news, updates, and deep dives about dux and related topics...
+## Wait, a blog?
+
+Yeah! The dux blog is a place for me to share news, updates, potentially deep dives about features and functionality, keep the community updated in terms of new versions, new features and everything else in between. It's not a marketing channel or a newsletter; it's just a spot on the website where I can post things that might be interesting to dux users and people interested in terminal tools, AI agents, and software development.
+
+Concretely, you can expect to see things like:
+
+- **Release notes**: what shipped, and why it's worth your attention. Sometimes there might be a feature that warrants more than just the release notes from GitHub, and that's where the blog comes in.
+- **Works in progress**: things being built, sometimes before they're done. This helps me gauge interest, user experiences and get feedback before the feature is fully baked.
+- **AI tools and features**: Although [we have a section in the docs](https://getdux.app/docs/recommended-tools/) for AI tools, the blog will allow me to spotlight specific tools, integrations, and how to use them effectively with or without dux.
+
+## Subscribe
+
+There's an [RSS feed](/rss.xml). Drop it into your reader of choice and you'll catch new posts without having to remember this page exists.
+
+I wouldn't expect a massive influx of content, but more or less an occasional post here and there as things come up. If you want to stay in the loop, the RSS feed is the way to go.
+
+## Next steps
+
+If you have not yet downloaded or tried [`dux`](https://getdux.app), now is a great time to do so! It's free, open source, and designed to make your terminal experience with AI agents smoother and more organized. I would encourage you to visit the homepage and use any of the download options, I won't judge :smile:

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^6.0.1",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.3",
         "@tailwindcss/postcss": "^4.3.0",
         "astro": "^6.4.3",
@@ -16,6 +17,8 @@
         "pagefind": "^1.5.2",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
+        "remark-gemoji": "^8.0.0",
+        "sharp": "^0.34.5",
         "tailwindcss": "^4.3.0"
       },
       "devDependencies": {
@@ -125,6 +128,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -671,7 +685,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -1222,6 +1235,18 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -2285,7 +2310,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2391,7 +2415,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.3.tgz",
       "integrity": "sha512-heArIk8zLcxuoj1WgBH2zGdAD8zKSU1mEcBvS6hYMEHRPlbtvB+4Y8ri9Z27hzeryvGaFgrH32zjghEfV2y07g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
         "@astrojs/internal-helpers": "0.10.0",
@@ -3188,6 +3211,44 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3247,6 +3308,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gemoji": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/gemoji/-/gemoji-8.1.0.tgz",
+      "integrity": "sha512-HA4Gx59dw2+tn+UAa7XEV4ufUKI4fH1KgcbenVA9YKSj1QJTT0xh5Mwv5HMFNN3l2OtUe3ZIfuRwSyZS5pLIWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5333,6 +5404,21 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5632,6 +5718,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gemoji": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gemoji/-/remark-gemoji-8.0.0.tgz",
+      "integrity": "sha512-/fL9rc72FYwFGtOKcT+QeQdx9Q9t5v4N6KLXSDOTEgaedzK85I9judBqB2eqz+g4b0ERMejlwSOuPK+wket6aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "gemoji": "^8.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -5802,7 +5903,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5875,7 +5975,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -6052,6 +6151,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -6541,7 +6652,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6754,6 +6864,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "node scripts/copy-install.mjs && astro build",
+    "build": "node scripts/copy-install.mjs && node scripts/generate-webp.mjs && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run",
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^6.0.1",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
     "@tailwindcss/postcss": "^4.3.0",
     "astro": "^6.4.3",
@@ -21,6 +22,8 @@
     "pagefind": "^1.5.2",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
+    "remark-gemoji": "^8.0.0",
+    "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {

--- a/website/scripts/generate-webp.mjs
+++ b/website/scripts/generate-webp.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Build step: write a `.webp` sibling next to every raster image (png/jpg/jpeg)
+// under `public/`, so the <picture> sources emitted by rehype-prose-images can
+// always resolve. Run before `astro build` (which copies `public/` into the
+// final output). Converting the handful of chrome images (favicons, og.png)
+// alongside content images is harmless — those are referenced by extension in
+// <link>/<meta>, so their unused .webp siblings just sit unreferenced.
+//
+// Kept separate from copy-install.mjs so it can run after it: copy-install
+// drops the canonical logo/screenshot into `public/`, then this converts them.
+
+import sharp from "sharp";
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const publicDir = resolve(here, "..", "public");
+
+const RASTER = new Set([".png", ".jpg", ".jpeg"]);
+
+async function convertTree(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      await convertTree(full);
+      continue;
+    }
+    const ext = extname(entry).toLowerCase();
+    if (!RASTER.has(ext)) continue;
+    const out = `${full.slice(0, -ext.length)}.webp`;
+    await sharp(full).webp({ quality: 82 }).toFile(out);
+    console.log(`generate-webp: ${entry} -> ${entry.slice(0, -ext.length)}.webp`);
+  }
+}
+
+if (!existsSync(publicDir)) {
+  console.log("generate-webp: no public/ directory, nothing to do.");
+} else {
+  await convertTree(publicDir);
+}

--- a/website/scripts/verify-search-index.mjs
+++ b/website/scripts/verify-search-index.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-// Post-build guard for the docs search index. Run after `astro build` (the
-// Pagefind index is generated into dist/pagefind/). It proves three things so a
-// future change can't silently break or re-scope search:
+// Post-build guard for the search index. Run after `astro build` (the Pagefind
+// index is generated into dist/pagefind/). It proves four things so a future
+// change can't silently break or re-scope search:
 //
 //   1. The Pagefind runtime (pagefind.js) actually shipped.
 //   2. The docs are in the index (at least one /docs URL).
-//   3. The marketing homepage is NOT in the index (docs-only scope holds).
+//   3. The blog is in the index (at least one /blog URL).
+//   4. The marketing homepage is NOT in the index (scope stays docs + blog).
 //
 // Pagefind stores each indexed page as a gzip-compressed JSON "fragment"; we
 // decompress them to read the indexed URLs without booting the WASM runtime.
@@ -75,6 +76,7 @@ for (const file of fragments) {
 
 const norm = (u) => u.replace(/index\.html$/i, "").replace(/\.html$/i, "");
 const isDocs = (u) => norm(u).includes("/docs");
+const isBlog = (u) => norm(u).includes("/blog");
 const isHomepage = (u) => {
   const p = norm(u).split(/[?#]/)[0].replace(/\/+$/, "");
   return p === "" || p === "/";
@@ -87,16 +89,25 @@ if (!urls.some(isDocs)) {
   );
 }
 
-// 3. The homepage must NOT be indexed (docs-only scope).
+// 3. The blog must be indexed.
+if (!urls.some(isBlog)) {
+  fail(
+    `no /blog pages are indexed. Is \`data-pagefind-body\` present on the blog post <article> (BlogLayout.astro)? Indexed URLs: ${JSON.stringify(urls)}`,
+  );
+}
+
+// 4. The homepage must NOT be indexed (scope stays docs + blog).
 const leaked = urls.filter(isHomepage);
 if (leaked.length > 0) {
   fail(
     `the homepage leaked into the search index (${JSON.stringify(
       leaked,
-    )}). Search scope must stay docs-only — only docs pages should carry \`data-pagefind-body\`.`,
+    )}). Search scope must stay docs + blog — only docs and blog pages should carry \`data-pagefind-body\`.`,
   );
 }
 
+const docsCount = urls.filter(isDocs).length;
+const blogCount = urls.filter(isBlog).length;
 console.log(
-  `verify-search-index: OK — ${urls.length} docs page(s) indexed, homepage excluded.`,
+  `verify-search-index: OK — ${docsCount} docs + ${blogCount} blog page(s) indexed, homepage excluded.`,
 );

--- a/website/src/components/DocsSearch.astro
+++ b/website/src/components/DocsSearch.astro
@@ -1,6 +1,7 @@
 ---
-// Docs search modal. Mounted once globally in Layout.astro and opened from the
-// header button (which dispatches the `open-search` event) or via the
+// Site search modal — covers the docs and the blog (every page that carries
+// `data-pagefind-body`). Mounted once globally in Layout.astro and opened from
+// the header button (which dispatches the `open-search` event) or via the
 // Cmd/Ctrl-K and "/" shortcuts. The Pagefind engine is dynamically imported
 // only on first open, so pages that never search ship none of it.
 //
@@ -16,7 +17,7 @@
     aria-modal="true"
     aria-labelledby="docs-search-label"
   >
-    <h2 id="docs-search-label" class="sr-only">Search the documentation</h2>
+    <h2 id="docs-search-label" class="sr-only">Search across documentation and blog posts</h2>
 
     <div class="search-input-row">
       <svg
@@ -37,7 +38,7 @@
         id="docs-search-input"
         type="search"
         class="search-input"
-        placeholder="Search the docs…"
+        placeholder="Search across documentation and blog posts"
         autocomplete="off"
         autocorrect="off"
         autocapitalize="off"
@@ -58,7 +59,7 @@
       role="status"
       aria-live="polite"
     >
-      Type to search the docs.
+      Type to search the docs and the blog.
     </div>
 
     <ul
@@ -99,6 +100,23 @@
     let selected = -1; // index into the flat list of selectable anchors
     let lastFocused: HTMLElement | null = null;
     let searchToken = 0; // guards against out-of-order async responses
+
+    // Sassy prompt-state lines, rotated one at a time so the empty search box
+    // always has a bit of dux personality. Sequential (not random) so the same
+    // line never repeats back to back.
+    const DUX_FACTS = [
+      "Type to search the docs and the blog. dux runs your agents in parallel, one git worktree each.",
+      "Looking for something? dux spawns real CLIs in real PTYs. No protocol layer, no JSON-RPC, no nonsense.",
+      "Search away. And yes, it really is pronounced dooks.",
+      "Start typing. dux can write your commit messages too, so you don't have to.",
+      "Find your answer here while dux juggles Claude, Codex, Gemini, and OpenCode side by side.",
+      "Type to begin. dux is a Rust TUI, so it sips RAM while the agents do the heavy lifting.",
+    ];
+    let factIndex = 0;
+    function promptStatus() {
+      setStatus(DUX_FACTS[factIndex % DUX_FACTS.length]);
+      factIndex += 1;
+    }
 
     const isOpen = () => !overlay.hasAttribute("hidden");
 
@@ -225,7 +243,7 @@
       const trimmed = query.trim();
       if (trimmed === "") {
         clearResults();
-        setStatus("Type to search the docs.");
+        promptStatus();
         return;
       }
 
@@ -235,7 +253,7 @@
 
       if (!pf) {
         clearResults();
-        setStatus("Search index isn't built yet — run `npm run build`.");
+        setStatus("Search index isn't built yet. Run `npm run build` first.");
         return;
       }
 
@@ -259,6 +277,8 @@
       lastFocused = document.activeElement as HTMLElement | null;
       overlay!.removeAttribute("hidden");
       document.body.style.overflow = "hidden";
+      // Fresh sassy line each time the box opens.
+      promptStatus();
       // Warm the engine up so the first keystroke feels instant.
       void loadPagefind();
       requestAnimationFrame(() => {
@@ -273,7 +293,7 @@
       document.body.style.overflow = "";
       input!.value = "";
       clearResults();
-      setStatus("Type to search the docs.");
+      promptStatus();
       lastFocused?.focus?.();
     }
 

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -18,6 +18,8 @@ const year = new Date().getFullYear();
       </div>
       <nav class="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/docs">Docs</a>
+        <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/blog">Blog</a>
+        <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/rss.xml">RSS</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="https://github.com/patrickdappollonio/dux">GitHub</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="https://github.com/patrickdappollonio/dux/releases">Releases</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="https://www.npmjs.com/package/@patrickdappollonio/dux">npm</a>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -3,13 +3,14 @@ const nav = [
   { href: "/#demo", label: "Demo" },
   { href: "/#features", label: "Features" },
   { href: "/docs", label: "Docs" },
+  { href: "/blog", label: "Blog" },
   { href: "/#install", label: "Install" },
   { href: "https://github.com/patrickdappollonio/dux", label: "GitHub", external: true },
 ];
 ---
 
 <header class="sticky top-0 z-50 border-b border-[color:var(--color-border-soft)] bg-[color:var(--color-ink)]/70 backdrop-blur-xl">
-  <div class="container-app flex h-14 items-center justify-between gap-3">
+  <div class="container-app flex h-14 items-center gap-3">
     <a href="/" class="flex items-center gap-2.5 group min-w-0">
       <img
         src="/dux-logo.png"
@@ -23,37 +24,44 @@ const nav = [
       </span>
     </a>
 
-    <div class="flex items-center gap-1.5">
-      {/* Opens the global docs search modal (see DocsSearch.astro). Also bound
-          to Cmd/Ctrl-K and "/". Icon-only on small screens; the label and
-          shortcut hint appear at lg, where the inline nav also has room. */}
-      <button
-        type="button"
-        data-open-search
-        aria-label="Search the documentation"
-        aria-keyshortcuts="Meta+K Control+K"
-        class="inline-flex h-9 w-9 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-panel)]/60 text-sm text-[color:var(--color-muted)] transition-colors hover:border-[color:var(--color-accent)]/50 hover:text-[color:var(--color-text)] lg:w-auto lg:justify-start lg:px-2.5"
+    {/* Opens the global search modal (docs + blog; see DocsSearch.astro). Also
+        bound to Cmd/Ctrl-K and "/". Icon-only on small screens; the label and
+        shortcut hint appear at lg. `lg:mx-auto` gives it auto margins on both
+        sides so it centres in the free space between the logo and the nav
+        (without forcing either to a fixed width and squeezing the links); on
+        small screens `ml-auto` parks it next to the hamburger. */}
+    <button
+      type="button"
+      data-open-search
+      aria-label="Search docs and blog"
+      aria-keyshortcuts="Meta+K Control+K"
+      class="ml-auto inline-flex h-9 w-9 items-center justify-center gap-2 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-panel)]/60 text-sm text-[color:var(--color-muted)] transition-colors hover:border-[color:var(--color-accent)]/50 hover:text-[color:var(--color-text)] lg:mx-auto lg:w-auto lg:justify-start lg:px-2.5"
+    >
+      <svg
+        class="h-4 w-4 shrink-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
       >
-        <svg
-          class="h-4 w-4 shrink-0"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          aria-hidden="true"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="m21 21-4.3-4.3"></path>
-        </svg>
-        <span class="hidden lg:inline">Search docs</span>
-        <kbd
-          class="mono hidden rounded border border-[color:var(--color-border)] bg-[color:var(--color-panel-2)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-dim)] lg:inline"
-          aria-hidden="true">⌘K</kbd
-        >
-      </button>
+        <circle cx="11" cy="11" r="8"></circle>
+        <path d="m21 21-4.3-4.3"></path>
+      </svg>
+      <span class="hidden lg:inline">Search</span>
+      <kbd
+        class="mono hidden rounded border border-[color:var(--color-border)] bg-[color:var(--color-panel-2)] px-1.5 py-0.5 text-[10px] text-[color:var(--color-dim)] lg:inline"
+        aria-hidden="true">⌘K</kbd
+      >
+    </button>
 
+    {/* Right cluster: the desktop nav and (on small screens) the hamburger.
+        Natural width — the search button's auto margins center it in the gap to
+        the left of this cluster, so the nav keeps its full width and the links
+        never get squeezed. */}
+    <div class="flex items-center gap-1.5">
       {/* Full inline nav — desktop only. Below lg it collapses into the
           hamburger menu so the bar never crowds or wraps. */}
       <nav class="hidden items-center gap-1 lg:flex">

--- a/website/src/components/LatestPosts.astro
+++ b/website/src/components/LatestPosts.astro
@@ -1,0 +1,55 @@
+---
+// "Latest from the blog" teaser for the homepage. Shows the most recent few
+// published posts; renders nothing at all when the blog is empty so the
+// homepage never shows a hollow section.
+import { getPublishedPosts } from "../lib/blog";
+import PostMeta from "./PostMeta.astro";
+
+const posts = (await getPublishedPosts()).slice(0, 3);
+---
+
+{
+  posts.length > 0 && (
+    <section class="anchor-offset py-16 sm:py-24">
+      <div class="container-app">
+        <div class="flex flex-wrap items-end justify-between gap-4">
+          <div class="max-w-2xl">
+            <span class="pill">▸ from the blog</span>
+            <h2 class="heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+              Latest <span class="text-[color:var(--color-accent)]">updates</span>
+            </h2>
+            <p class="mt-4 text-[color:var(--color-muted)] leading-relaxed">
+              Release notes, what's being worked on, and the occasional deep dive.
+            </p>
+          </div>
+          <a
+            href="/blog"
+            class="inline-flex items-center gap-1.5 text-sm font-medium text-[color:var(--color-accent)] hover:text-[color:var(--color-accent-soft)]"
+          >
+            Read the blog
+            <span aria-hidden="true">→</span>
+          </a>
+        </div>
+
+        <div class="mt-8 grid gap-4 sm:grid-cols-3">
+          {posts.map((post) => (
+            <div class="card relative flex flex-col p-5 transition-colors hover:border-[color:var(--color-accent)]/50">
+              <PostMeta pubDate={post.data.pubDate} author={post.data.author} />
+              <div class="heading mt-1.5 font-semibold text-[color:var(--color-text)]">
+                <a
+                  href={`/blog/${post.id}`}
+                  class="transition-colors after:absolute after:inset-0 after:content-[''] hover:text-[color:var(--color-accent)]"
+                >
+                  {post.data.title}
+                </a>
+              </div>
+              <p class="mt-1.5 text-sm text-[color:var(--color-muted)]">
+                {post.data.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/website/src/components/PostMeta.astro
+++ b/website/src/components/PostMeta.astro
@@ -1,0 +1,98 @@
+---
+// The byline shared by every place a post is listed: the post page header, the
+// /blog index, and the homepage teaser. Keeps the date/author treatment (and
+// its icons) identical everywhere. The author name links to their site when the
+// authors registry knows one; `relative z-10` keeps that link clickable when it
+// sits inside a stretched-link card (see LatestPosts / blog index).
+import { formatDate, isoDate } from "../lib/date";
+import { getAuthor } from "../lib/authors";
+
+interface Props {
+  pubDate: Date;
+  /** Optional last-updated date; rendered as "Updated …" when present. */
+  updatedDate?: Date;
+  /** Author name, resolved to an optional site link via the registry. */
+  author: string;
+}
+
+const { pubDate, updatedDate, author: authorName } = Astro.props;
+const author = getAuthor(authorName);
+---
+
+<div class="mono flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-[color:var(--color-dim)]">
+  <span class="inline-flex items-center gap-1.5">
+    <svg
+      class="h-3.5 w-3.5 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+    </svg>
+    <time datetime={isoDate(pubDate)}>{formatDate(pubDate)}</time>
+  </span>
+
+  <span aria-hidden="true">·</span>
+
+  <span class="inline-flex items-center gap-1.5 text-[color:var(--color-muted)]">
+    <svg
+      class="h-3.5 w-3.5 shrink-0 text-[color:var(--color-dim)]"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+      <circle cx="12" cy="7" r="4" />
+    </svg>
+    {
+      author.url ? (
+        <a
+          href={author.url}
+          target="_blank"
+          rel="noopener"
+          data-no-ext-icon
+          class="relative z-10 transition-colors hover:text-[color:var(--color-accent)]"
+        >
+          {author.name}
+        </a>
+      ) : (
+        author.name
+      )
+    }
+  </span>
+
+  {
+    updatedDate && (
+      <>
+        <span aria-hidden="true">·</span>
+        <span class="inline-flex items-center gap-1.5">
+          <svg
+            class="h-3.5 w-3.5 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+            <path d="M21 3v5h-5" />
+          </svg>
+          <span>
+            Updated <time datetime={isoDate(updatedDate)}>{formatDate(updatedDate)}</time>
+          </span>
+        </span>
+      </>
+    )
+  }
+</div>

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -20,4 +20,33 @@ const docs = defineCollection({
   }),
 });
 
-export const collections = { docs };
+// Blog posts are plain Markdown files in `website/blog/`. Drop a new `.md` file
+// in there, give it frontmatter, and it becomes a post at `/blog/<filename>`
+// automatically — listed on the blog index, in the RSS feed, in search, and in
+// the homepage teaser. Posts are a flat reverse-chronological feed (no tags or
+// categories); ordering comes from `pubDate`.
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./blog" }),
+  schema: z.object({
+    // Post title. Shown as the <h1>, the browser tab, and the list label.
+    title: z.string(),
+    // One-sentence summary. Used for the meta description, the blog index, the
+    // RSS item description, and the homepage teaser.
+    description: z.string(),
+    // Post author. Defaults to the project maintainer. Known authors (see
+    // src/lib/authors.ts) get their byline auto-linked to their site; add a
+    // contributor there once rather than repeating their URL on each post.
+    author: z.string().default("Patrick D'appollonio"),
+    // Publish date. Drives reverse-chronological sort order and the RSS
+    // pubDate. `coerce` lets the frontmatter write a plain `2026-06-08` string.
+    pubDate: z.coerce.date(),
+    // Optional last-updated date. When present, shown as "Updated …" under the
+    // title.
+    updatedDate: z.coerce.date().optional(),
+    // Drafts are excluded from the index, RSS, sitemap, and search. They still
+    // build, so you can preview one by visiting its URL directly during dev.
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { docs, blog };

--- a/website/src/layouts/BlogLayout.astro
+++ b/website/src/layouts/BlogLayout.astro
@@ -1,0 +1,159 @@
+---
+import Layout from "./Layout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import PostMeta from "../components/PostMeta.astro";
+import { getAuthor } from "../lib/authors";
+
+interface Props {
+  title: string;
+  description: string;
+  /** Author name. Resolved to an optional site link via the authors registry. */
+  author: string;
+  /** Publish date. Shown under the title and used for the BlogPosting JSON-LD. */
+  pubDate: Date;
+  /** Optional last-updated date. Rendered as "Updated …" when present. */
+  updatedDate?: Date;
+  /** Path to the markdown source, relative to website/blog, for the edit link. */
+  editPath: string;
+}
+
+const { title, description, author: authorName, pubDate, updatedDate, editPath } =
+  Astro.props;
+
+const author = getAuthor(authorName);
+
+const pageTitle = `${title} | getdux.app`;
+
+const site = Astro.site ?? new URL("https://getdux.app");
+const postUrl = new URL(Astro.url.pathname, site).toString();
+
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "Home", item: site.toString() },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "Blog",
+      item: new URL("/blog", site).toString(),
+    },
+    { "@type": "ListItem", position: 3, name: title },
+  ],
+};
+
+const posting = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: title,
+  description,
+  url: postUrl,
+  datePublished: pubDate.toISOString(),
+  ...(updatedDate ? { dateModified: updatedDate.toISOString() } : {}),
+  author: {
+    "@type": "Person",
+    name: author.name,
+    ...(author.url ? { url: author.url } : {}),
+  },
+};
+
+const editUrl = `https://github.com/patrickdappollonio/dux/blob/main/website/blog/${editPath}`;
+---
+
+<Layout title={pageTitle} description={description} emitStructuredData={false}>
+  <Header />
+  <main class="container-app py-10 lg:py-14">
+    <nav class="mb-6 flex items-center gap-2 text-xs text-[color:var(--color-dim)]" aria-label="Breadcrumb">
+      <a href="/" class="inline-flex items-center gap-1.5 hover:text-[color:var(--color-accent)]">
+        <svg
+          class="h-3.5 w-3.5 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <polyline points="9 22 9 12 15 12 15 22" />
+        </svg>
+        Home
+      </a>
+      <span>/</span>
+      <a href="/blog" class="hover:text-[color:var(--color-accent)]">Blog</a>
+      <span>/</span>
+      <span class="text-[color:var(--color-muted)]">{title}</span>
+    </nav>
+
+    <div class="mx-auto max-w-3xl">
+      {/* `data-pagefind-body` puts the post in the same Cmd/Ctrl-K search as the
+          docs (see Layout.astro / DocsSearch.astro). The <h1> becomes the result
+          title and heading ids (from rehype-slug) become deep-linkable
+          sub-results. */}
+      <article data-pagefind-body>
+        <header class="mb-8 border-b border-[color:var(--color-border-soft)] pb-6">
+          <PostMeta pubDate={pubDate} updatedDate={updatedDate} author={authorName} />
+          <h1 class="mt-3 text-3xl font-bold tracking-tight text-[color:var(--color-text)] sm:text-4xl">
+            {title}
+          </h1>
+          <p class="mt-3 text-[color:var(--color-muted)] leading-relaxed">
+            {description}
+          </p>
+        </header>
+
+        <div class="prose-docs">
+          <slot />
+        </div>
+
+        <div data-pagefind-ignore class="mt-12 flex flex-wrap items-center justify-between gap-4 border-t border-[color:var(--color-border-soft)] pt-6 text-sm">
+          <a
+            href="/blog"
+            class="inline-flex items-center gap-2 text-[color:var(--color-dim)] transition-colors hover:text-[color:var(--color-accent)]"
+          >
+            <svg
+              class="h-3.5 w-3.5 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m12 19-7-7 7-7" />
+              <path d="M19 12H5" />
+            </svg>
+            All posts
+          </a>
+          <a
+            href={editUrl}
+            target="_blank"
+            rel="noopener"
+            data-no-ext-icon
+            class="inline-flex items-center gap-2 rounded-md border border-[color:var(--color-border)] px-3 py-1.5 text-[color:var(--color-dim)] transition-colors hover:border-[color:var(--color-accent)]/50 hover:bg-[color:var(--color-accent)]/5 hover:text-[color:var(--color-accent)]"
+          >
+            <svg
+              class="h-3.5 w-3.5 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z" />
+            </svg>
+            Submit a correction on GitHub
+          </a>
+        </div>
+      </article>
+    </div>
+  </main>
+  <Footer />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumb)} />
+  <script type="application/ld+json" set:html={JSON.stringify(posting)} />
+</Layout>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -124,6 +124,7 @@ const sd = {
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
+    <link rel="alternate" type="application/rss+xml" title="dux blog" href="/rss.xml" />
 
     {/* Open Graph */}
     <meta property="og:type" content="website" />
@@ -182,8 +183,8 @@ const sd = {
   <body class="text-[color:var(--color-text)]">
     <slot />
 
-    {/* Global docs search modal. Opened from the header button or Cmd/Ctrl-K;
-        the Pagefind engine is lazy-loaded only when first opened. */}
+    {/* Global search modal (docs + blog). Opened from the header button or
+        Cmd/Ctrl-K; the Pagefind engine is lazy-loaded only when first opened. */}
     <DocsSearch />
 
     {/* Mark every off-site link: open in a new tab, harden rel, and (for

--- a/website/src/lib/authors.test.ts
+++ b/website/src/lib/authors.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { getAuthor } from "./authors";
+
+describe("getAuthor", () => {
+  it("links a known author to their site", () => {
+    expect(getAuthor("Patrick D'appollonio")).toEqual({
+      name: "Patrick D'appollonio",
+      url: "https://www.patrickdap.com",
+    });
+  });
+
+  it("returns a bare name (no link) for an unknown author", () => {
+    expect(getAuthor("Guest Writer")).toEqual({ name: "Guest Writer" });
+  });
+});

--- a/website/src/lib/authors.ts
+++ b/website/src/lib/authors.ts
@@ -1,0 +1,20 @@
+// Known blog authors and their personal links. Add a contributor here once and
+// every post with `author: "<their name>"` gets their byline auto-linked — posts
+// never repeat the URL. An author not listed here renders as plain text (no
+// link), so a one-off guest writer still works without an entry.
+
+export interface Author {
+  name: string;
+  /** Personal site. Absent for authors with no link. */
+  url?: string;
+}
+
+const AUTHOR_LINKS: Record<string, string> = {
+  "Patrick D'appollonio": "https://www.patrickdap.com",
+};
+
+// Resolve an author name to a name + optional link.
+export function getAuthor(name: string): Author {
+  const url = AUTHOR_LINKS[name];
+  return url ? { name, url } : { name };
+}

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -1,0 +1,15 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+export type BlogPost = CollectionEntry<"blog">;
+
+// Published posts, newest first. Drafts are excluded everywhere a post would be
+// publicly listed — the blog index, the RSS feed, the sitemap, and the homepage
+// teaser all source from here so they can't drift on which posts are visible.
+// (Drafts still build so their URL can be previewed during dev; see the blog
+// route's getStaticPaths.)
+export async function getPublishedPosts(): Promise<BlogPost[]> {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  return posts.sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+  );
+}

--- a/website/src/lib/date.test.ts
+++ b/website/src/lib/date.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { formatDate, isoDate } from "./date";
+
+describe("formatDate", () => {
+  it("formats a date as a long human date", () => {
+    expect(formatDate(new Date("2026-06-08"))).toBe("June 8, 2026");
+  });
+
+  it("formats in UTC so a bare frontmatter date keeps its day", () => {
+    // 2026-01-01 parsed as UTC midnight must not slip to Dec 31 on a build
+    // machine west of UTC.
+    expect(formatDate(new Date("2026-01-01"))).toBe("January 1, 2026");
+  });
+});
+
+describe("isoDate", () => {
+  it("returns a YYYY-MM-DD string", () => {
+    expect(isoDate(new Date("2026-06-08"))).toBe("2026-06-08");
+  });
+});

--- a/website/src/lib/date.ts
+++ b/website/src/lib/date.ts
@@ -1,0 +1,24 @@
+// Shared date formatting for the blog (index list, post header, RSS dates).
+// Keeping one helper means the listing, the post page, and the feed never drift
+// in how a date reads.
+
+// Format a publish/updated date as a long, human date, e.g. "June 8, 2026".
+//
+// Frontmatter dates written as a bare `2026-06-08` are parsed as UTC midnight.
+// Formatting in UTC keeps the displayed day stable regardless of the build
+// machine's timezone — otherwise a build west of UTC would render the previous
+// day.
+export function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+// Machine-readable `YYYY-MM-DD` for the <time datetime> attribute, also in UTC
+// for the same stability reason.
+export function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/website/src/lib/rehype-prose-images.mjs
+++ b/website/src/lib/rehype-prose-images.mjs
@@ -1,0 +1,93 @@
+// Markdown image enhancements for prose pages (docs + blog). Runs as a rehype
+// plugin on the shared markdown processor (see astro.config.mjs), so plain
+// Markdown images get two upgrades without any HTML in the post:
+//
+//   1. Alignment via URL hash. `![alt](/img.png#right)` drops the `#right` from
+//      the src and adds an `align-right` class. Supported: left, right, center,
+//      full (full-width). No hash → default block image.
+//
+//   2. Modern formats. A local raster image (png/jpg/jpeg) is wrapped in a
+//      <picture> that offers a .webp <source> with the original as the <img>
+//      fallback, so the browser picks the smaller format. SVGs (already
+//      vector) and remote images are left as a plain <img>. The .webp siblings
+//      are produced at build time by scripts/generate-webp.mjs, which scans the
+//      same public rasters — so a <source> this plugin emits always resolves.
+//
+// Written as a small manual hast walk to avoid a unist-util-visit dependency.
+
+const ALIGN_CLASS = {
+  left: "align-left",
+  right: "align-right",
+  center: "align-center",
+  full: "full-width",
+};
+
+// A local raster path we can offer a webp sibling for (served from /public).
+const LOCAL_RASTER = /^\/.+\.(png|jpe?g)$/i;
+
+const toWebp = (src) => src.replace(/\.(png|jpe?g)$/i, ".webp");
+
+function addClass(properties, cls) {
+  const existing = properties.className;
+  if (Array.isArray(existing)) existing.push(cls);
+  else if (typeof existing === "string")
+    properties.className = [existing, cls];
+  else properties.className = [cls];
+}
+
+// Mutates an <img> node (alignment + cleaned src). Returns a replacement node
+// (a <picture> wrapper) when the image should be wrapped, otherwise null.
+function transformImg(node) {
+  const properties = node.properties ?? (node.properties = {});
+  let src = typeof properties.src === "string" ? properties.src : "";
+  if (!src) return null;
+
+  // 1. Pull a trailing #alignment off the URL.
+  const hash = src.indexOf("#");
+  if (hash !== -1) {
+    const keyword = src.slice(hash + 1).toLowerCase();
+    src = src.slice(0, hash);
+    properties.src = src;
+    if (ALIGN_CLASS[keyword]) addClass(properties, ALIGN_CLASS[keyword]);
+  }
+
+  // 2. Wrap a local raster in <picture> with a webp source.
+  if (LOCAL_RASTER.test(src)) {
+    return {
+      type: "element",
+      tagName: "picture",
+      properties: {},
+      children: [
+        {
+          type: "element",
+          tagName: "source",
+          properties: { srcset: toWebp(src), type: "image/webp" },
+          children: [],
+        },
+        node,
+      ],
+    };
+  }
+  return null;
+}
+
+function walk(node) {
+  if (!node || !Array.isArray(node.children)) return;
+  for (let i = 0; i < node.children.length; i++) {
+    const child = node.children[i];
+    if (child.type === "element" && child.tagName === "img") {
+      const replacement = transformImg(child);
+      if (replacement) {
+        // Swap the <img> for its <picture> wrapper; the wrapped <img> is
+        // already processed, so don't descend into it.
+        node.children[i] = replacement;
+        continue;
+      }
+    }
+    walk(child);
+  }
+}
+
+export default function rehypeProseImages() {
+  return (tree) => walk(tree);
+}

--- a/website/src/pages/blog/[...slug].astro
+++ b/website/src/pages/blog/[...slug].astro
@@ -1,0 +1,30 @@
+---
+import { getCollection, render } from "astro:content";
+import BlogLayout from "../../layouts/BlogLayout.astro";
+
+export async function getStaticPaths() {
+  // Drafts build in dev so a URL can be previewed, but are dropped from the
+  // production build (and so never published, indexed, or linked).
+  const posts = await getCollection("blog", ({ data }) =>
+    import.meta.env.PROD ? !data.draft : true,
+  );
+  return posts.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+---
+
+<BlogLayout
+  title={entry.data.title}
+  description={entry.data.description}
+  author={entry.data.author}
+  pubDate={entry.data.pubDate}
+  updatedDate={entry.data.updatedDate}
+  editPath={`${entry.id}.md`}
+>
+  <Content />
+</BlogLayout>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,0 +1,100 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { getPublishedPosts } from "../../lib/blog";
+import PostMeta from "../../components/PostMeta.astro";
+
+const posts = await getPublishedPosts();
+
+const pageTitle = "Blog | getdux.app";
+const description =
+  "Updates, release notes, and what's being worked on in dux, the terminal UI for running AI coding agents in parallel.";
+---
+
+<Layout title={pageTitle} description={description} emitStructuredData={false}>
+  <Header />
+  <main class="container-app py-10 lg:py-14">
+    <nav class="mb-6 flex items-center gap-2 text-xs text-[color:var(--color-dim)]" aria-label="Breadcrumb">
+      <a href="/" class="inline-flex items-center gap-1.5 hover:text-[color:var(--color-accent)]">
+        <svg
+          class="h-3.5 w-3.5 shrink-0"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <polyline points="9 22 9 12 15 12 15 22" />
+        </svg>
+        Home
+      </a>
+      <span>/</span>
+      <span class="text-[color:var(--color-muted)]">Blog</span>
+    </nav>
+
+    <div class="mx-auto max-w-3xl">
+      <header class="mb-10 flex flex-wrap items-end justify-between gap-4 border-b border-[color:var(--color-border-soft)] pb-6">
+        <div>
+          <h1 class="text-3xl font-bold tracking-tight text-[color:var(--color-text)] sm:text-4xl">
+            Blog
+          </h1>
+          <p class="mt-3 text-[color:var(--color-muted)] leading-relaxed">
+            {description}
+          </p>
+        </div>
+        <a
+          href="/rss.xml"
+          class="inline-flex shrink-0 items-center gap-2 rounded-md border border-[color:var(--color-border)] px-3 py-1.5 text-sm text-[color:var(--color-dim)] transition-colors hover:border-[color:var(--color-accent)]/50 hover:bg-[color:var(--color-accent)]/5 hover:text-[color:var(--color-accent)]"
+        >
+          <svg
+            class="h-3.5 w-3.5 shrink-0"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M4 11a9 9 0 0 1 9 9" />
+            <path d="M4 4a16 16 0 0 1 16 16" />
+            <circle cx="5" cy="19" r="1" />
+          </svg>
+          RSS
+        </a>
+      </header>
+
+      {
+        posts.length === 0 ? (
+          <p class="text-[color:var(--color-muted)]">
+            No posts yet. Check back soon.
+          </p>
+        ) : (
+          <ul class="space-y-8">
+            {posts.map((post) => (
+              <li class="relative">
+                <PostMeta pubDate={post.data.pubDate} author={post.data.author} />
+                <h2 class="heading mt-1 text-xl font-semibold tracking-tight text-[color:var(--color-text)]">
+                  <a
+                    href={`/blog/${post.id}`}
+                    class="transition-colors after:absolute after:inset-0 after:content-[''] hover:text-[color:var(--color-accent)]"
+                  >
+                    {post.data.title}
+                  </a>
+                </h2>
+                <p class="mt-1.5 text-[color:var(--color-muted)]">
+                  {post.data.description}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    </div>
+  </main>
+  <Footer />
+</Layout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -8,6 +8,7 @@ import RealCLI from "../components/RealCLI.astro";
 import FeatureGrid from "../components/FeatureGrid.astro";
 import ConfigPeek from "../components/ConfigPeek.astro";
 import InstallSection from "../components/InstallSection.astro";
+import LatestPosts from "../components/LatestPosts.astro";
 import Footer from "../components/Footer.astro";
 
 const title =
@@ -26,6 +27,7 @@ const description =
     <FeatureGrid />
     <ConfigPeek />
     <InstallSection />
+    <LatestPosts />
   </main>
   <Footer />
 </Layout>

--- a/website/src/pages/rss.xml.ts
+++ b/website/src/pages/rss.xml.ts
@@ -1,0 +1,25 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getPublishedPosts } from "../lib/blog";
+
+// RSS feed for the blog, served at /rss.xml. Sources the same published (non-
+// draft), newest-first posts as the blog index. @astrojs/rss handles XML
+// escaping, CDATA, and RFC-822 pubDate formatting.
+export async function GET(context: APIContext) {
+  const posts = await getPublishedPosts();
+  const site = context.site ?? new URL("https://getdux.app");
+
+  return rss({
+    title: "dux blog",
+    description:
+      "Updates, release notes, and what's being worked on in dux, the terminal UI for running AI coding agents in parallel.",
+    site,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      link: `/blog/${post.id}`,
+    })),
+    customData: "<language>en-us</language>",
+  });
+}

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -449,8 +449,44 @@
     max-width: 100%;
     height: auto;
     border-radius: 0.5rem;
-    border: 1px solid var(--color-border);
     margin: 1.25rem 0;
+  }
+  /* Image layout helpers for prose. The classes are applied from Markdown via
+     a URL-hash convention (`![alt](/img.png#right)`) handled by the
+     rehype-prose-images plugin — never hand-written HTML. `full-width` fills
+     the column; `align-left`/`align-right` float the image so text wraps beside
+     it; `align-center` centers a block. On narrow screens the floats drop to
+     full width so they're never squeezed into an unreadable sliver. */
+  .prose-docs img.full-width {
+    width: 100%;
+  }
+  .prose-docs img.align-center {
+    display: block;
+    margin-inline: auto;
+  }
+  .prose-docs img.align-left {
+    float: left;
+    width: min(45%, 14rem);
+    margin: 0.35rem 1.5rem 1rem 0;
+  }
+  .prose-docs img.align-right {
+    float: right;
+    width: min(45%, 14rem);
+    margin: 0.35rem 0 1rem 1.5rem;
+  }
+  @media (max-width: 640px) {
+    .prose-docs img.align-left,
+    .prose-docs img.align-right {
+      float: none;
+      width: 100%;
+      margin: 1.25rem 0;
+    }
+  }
+  /* The <picture> wrapper (rehype-prose-images, for webp) is layout-neutral so
+     the alignment/sizing on the inner <img> behaves as if it were in the flow
+     directly. */
+  .prose-docs picture {
+    display: contents;
   }
   /* Clickable "#" appended to each heading by rehype-autolink-headings. The
      anchor itself is empty; the glyph is drawn here so it stays out of the


### PR DESCRIPTION
This adds a **blog** to `website/`, built the same way as the existing docs. Every post is a plain Markdown file in `website/blog/`, and dropping one in publishes it automatically with its own page, a reverse-chronological listing, and metadata. It is meant for sharing release notes, work in progress, and the occasional deep dive, and a new **`/rss.xml`** feed (with autodiscovery) lets readers subscribe.

The blog is wired into the rest of the site. It gets a **Blog** link in the header and footer, a *latest posts* teaser on the homepage, and its pages join both the sitemap and the existing `Cmd/Ctrl-K` search, which now spans docs **and** blog. Authoring a post also picks up a few conveniences: image alignment through a URL hash (`#left`, `#right`, `#center`, `#full`), automatic **WebP** versions of raster images, GitHub-style emoji shortcodes like `:smile:`, and author bylines that link back to the author's own site.

A few small site touch-ups ride along too: the header search box now sits centered between the logo and the nav, article images lost their stray border, and the search copy reflects its wider scope. Adding a post needs nothing more than a Markdown file with `title`, `description`, and `pubDate` frontmatter.