### PR TITLE
Fix IME composition appearing at the wrong position in the agent terminal

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -12295,6 +12295,184 @@ cyan = "#00ffff"
         assert_eq!(app.fullscreen_overlay, FullscreenOverlay::None);
     }
 
+    /// Deterministically wait until the agent PTY child has parked its cursor
+    /// at the given (row, col), polling the live snapshot instead of guessing a
+    /// fixed sleep. Requires `session_surface == Agent` and a selected session
+    /// whose provider is in `app.providers`. Panics with the observed cursor if
+    /// the child does not reach the expected position within ~2s.
+    fn wait_for_agent_cursor(app: &mut App, row: u16, col: u16) {
+        for _ in 0..200 {
+            app.refresh_snapshot_buf();
+            if matches!(app.snapshot_buf.cursor, Some(c) if c.row == row && c.col == col) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        panic!(
+            "PTY did not park its cursor at row {row}, col {col} within 2s (got {:?})",
+            app.snapshot_buf.cursor
+        );
+    }
+
+    /// Regression test for issue #258: while the interactive agent terminal is
+    /// rendered, the real (hardware) terminal cursor must be moved onto the
+    /// embedded PTY cursor cell. IME composition popups (e.g. a Korean IME) are
+    /// drawn by the terminal/OS at the hardware cursor position, so if it is
+    /// left at the origin the composing character appears detached from the
+    /// prompt near the top-left instead of at the agent's cursor.
+    #[test]
+    fn interactive_agent_aligns_hardware_cursor_with_pty_cursor() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+
+        // `ESC[5;9H` parks the cursor at row 5, col 9 (1-based); printing 'X'
+        // then advances it to row 4, col 9 (0-based). `sleep` keeps the child
+        // alive so the snapshot keeps a live cursor.
+        let args = vec![
+            "-c".to_string(),
+            "printf '\\033[5;9HX'; sleep 30".to_string(),
+        ];
+        let client = PtyClient::spawn("/bin/sh", &args, std::path::Path::new("."), 24, 80, 100)
+            .expect("spawn pty");
+        app.providers.insert(session_id, client);
+
+        // Enter interactive fullscreen agent mode.
+        app.input_target = InputTarget::Agent;
+        app.session_surface = SessionSurface::Agent;
+        app.fullscreen_overlay = FullscreenOverlay::Agent;
+
+        // Wait until the child's cursor escape has been parsed (no fixed sleep).
+        wait_for_agent_cursor(&mut app, 4, 9);
+
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let term_area = app
+            .mouse_layout
+            .agent_term
+            .expect("agent terminal area should be recorded after render");
+        // Confirm the renderer's input cursor really is the parked PTY cursor,
+        // then derive the expected screen cell from the KNOWN (row 4, col 9)
+        // literals — not from snapshot_buf — so a transposed or mis-offset
+        // production computation cannot make this assertion tautologically true.
+        let cursor = app
+            .snapshot_buf
+            .cursor
+            .expect("interactive agent snapshot should expose a PTY cursor");
+        assert_eq!(
+            (cursor.row, cursor.col),
+            (4, 9),
+            "PTY should have parked its cursor at the expected cell"
+        );
+        let expected = (term_area.x + 9, term_area.y + 4);
+        terminal.backend_mut().assert_cursor_position(expected);
+    }
+
+    /// The same hardware-cursor alignment must hold in the normal (non-
+    /// fullscreen) center-pane agent view, not just the fullscreen overlay.
+    #[test]
+    fn inline_agent_aligns_hardware_cursor_with_pty_cursor() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let args = vec![
+            "-c".to_string(),
+            "printf '\\033[5;9HX'; sleep 30".to_string(),
+        ];
+        let client = PtyClient::spawn("/bin/sh", &args, std::path::Path::new("."), 24, 80, 100)
+            .expect("spawn pty");
+        app.providers.insert(session_id, client);
+
+        // Inline agent view: no fullscreen overlay, center pane focused.
+        app.input_target = InputTarget::Agent;
+        app.session_surface = SessionSurface::Agent;
+        app.fullscreen_overlay = FullscreenOverlay::None;
+        app.center_mode = CenterMode::Agent;
+        app.focus = FocusPane::Center;
+
+        wait_for_agent_cursor(&mut app, 4, 9);
+
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let term_area = app
+            .mouse_layout
+            .agent_term
+            .expect("agent terminal area should be recorded after render");
+        let cursor = app
+            .snapshot_buf
+            .cursor
+            .expect("inline agent snapshot should expose a PTY cursor");
+        assert_eq!((cursor.row, cursor.col), (4, 9));
+        let expected = (term_area.x + 9, term_area.y + 4);
+        terminal.backend_mut().assert_cursor_position(expected);
+    }
+
+    /// The hardware cursor must only track the PTY in interactive (input) mode.
+    /// In a non-interactive agent view there is no IME input, so the cursor
+    /// must not be repositioned — otherwise it leaves a stray blinking cursor
+    /// over read-only output.
+    #[test]
+    fn non_interactive_agent_leaves_hardware_cursor_at_origin() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = test_app(default_bindings());
+        let session_id = app.sessions[0].id.clone();
+        let args = vec![
+            "-c".to_string(),
+            "printf '\\033[5;9HX'; sleep 30".to_string(),
+        ];
+        let client = PtyClient::spawn("/bin/sh", &args, std::path::Path::new("."), 24, 80, 100)
+            .expect("spawn pty");
+        app.providers.insert(session_id, client);
+
+        // session_surface is Agent so the snapshot is populated, but input is
+        // NOT routed to the agent.
+        app.session_surface = SessionSurface::Agent;
+        app.fullscreen_overlay = FullscreenOverlay::Agent;
+        wait_for_agent_cursor(&mut app, 4, 9);
+        app.input_target = InputTarget::None;
+
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| app.render(frame))
+            .expect("render frame");
+
+        let term_area = app
+            .mouse_layout
+            .agent_term
+            .expect("agent terminal area should be recorded after render");
+        // The PTY genuinely has an off-origin cursor that the renderer COULD
+        // have placed: term_area is offset and the PTY cursor is at (4, 9), so
+        // a regression that wrongly set the hardware cursor would move it away
+        // from the origin and fail the assertion below.
+        assert!(
+            term_area.x > 0 || term_area.y > 0,
+            "test setup: agent terminal should be offset from the origin"
+        );
+        assert!(
+            app.snapshot_buf.cursor.is_some(),
+            "test setup: the PTY should still expose a cursor to (not) place"
+        );
+
+        // Not in input mode → the hardware cursor is never positioned and stays
+        // at the backend origin.
+        terminal.backend_mut().assert_cursor_position((0u16, 0u16));
+    }
+
     #[test]
     fn timed_out_bare_esc_can_exit_interactive() {
         let bindings = bindings_with_overrides(&[(Action::ExitInteractive, &["esc"])]);

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1398,6 +1398,19 @@ impl App {
                                 .fg(self.theme.input_cursor_fg)
                                 .bg(self.theme.prompt_cursor),
                         );
+                        // Move the real terminal cursor onto the embedded PTY
+                        // cursor cell. IME composition popups (e.g. a Korean
+                        // IME) are drawn by the terminal/OS at the hardware
+                        // cursor; without this the composing character appears
+                        // at the terminal origin instead of the agent prompt
+                        // (issue #258). The styled cell above keeps the block
+                        // cursor look; this aligns the hardware cursor with it.
+                        //
+                        // This must stay the last use of `buf` in this block:
+                        // `set_cursor_position` reborrows `frame`, which is only
+                        // valid because the `buf = frame.buffer_mut()` borrow
+                        // above has ended. Do not add `buf[...]` accesses below.
+                        frame.set_cursor_position((cx, cy));
                     }
                 }
 

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -96,6 +96,9 @@ pub struct PtyClient {
     /// the terminal parser on resume. Bounded by `PAUSE_BUFFER_CAP`; oldest
     /// bytes are dropped on overflow.
     pending_bytes: Arc<Mutex<PendingIngest>>,
+    /// Handle to the background reader thread. Joined in `Drop` (after the
+    /// child is killed and reaped) so the thread does not outlive the client.
+    reader_thread: Option<thread::JoinHandle<()>>,
 }
 
 #[derive(Default)]
@@ -181,7 +184,7 @@ impl PtyClient {
         let received_data_ref = Arc::clone(&received_data);
         let scroll_paused_ref = Arc::clone(&scroll_paused);
         let pending_bytes_ref = Arc::clone(&pending_bytes);
-        thread::spawn(move || {
+        let reader_thread = thread::spawn(move || {
             Self::reader_loop(
                 reader,
                 terminal_ref,
@@ -207,6 +210,7 @@ impl PtyClient {
             last_resize_at: Mutex::new(None),
             scroll_paused,
             pending_bytes,
+            reader_thread: Some(reader_thread),
         })
     }
 
@@ -532,7 +536,16 @@ impl PtyClient {
 
 impl Drop for PtyClient {
     fn drop(&mut self) {
+        // Kill the child, then reap it so it does not linger as a zombie.
         let _ = self.child.kill();
+        let _ = self.child.wait();
+        // The child is dead, so the PTY slave is closed and the reader thread
+        // observes EOF (or a read error) and returns. Join it so the thread
+        // does not outlive this client — otherwise detached reader threads
+        // accumulate across a long session and across the test suite.
+        if let Some(handle) = self.reader_thread.take() {
+            let _ = handle.join();
+        }
     }
 }
 
@@ -1254,6 +1267,26 @@ mod tests {
         panic!(
             "expected custom env output, got {:?}",
             viewport_lines(&snapshot)
+        );
+    }
+
+    #[test]
+    fn drop_kills_child_and_joins_reader_without_hanging() {
+        // The child sleeps far longer than the test. Drop must kill + reap it
+        // and join the reader thread promptly — it must NOT block until the
+        // child would have exited on its own, and the join must not deadlock.
+        let args = vec!["-c".to_string(), "sleep 120".to_string()];
+        let client =
+            PtyClient::spawn("/bin/sh", &args, Path::new("."), 5, 40, 100).expect("spawn pty");
+
+        let start = Instant::now();
+        drop(client);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_secs(10),
+            "PtyClient::drop took {elapsed:?}; it must kill the child and join \
+             the reader thread promptly, not wait for the child to finish"
         );
     }
 


### PR DESCRIPTION
Typing with an IME — a Korean IME in the original report — in an interactive agent terminal placed the committed text correctly at the prompt, but the in-progress composition character showed up in the top-left corner of the screen. The agent terminal drew its cursor only as a styled cell and never moved the **real** terminal cursor, and terminal IMEs anchor their composition popup to the hardware cursor, so the composing character ended up detached from where input was actually going. Closes #258.

The renderer now moves the hardware cursor onto the embedded PTY cursor cell via `set_cursor_position` while an agent or companion terminal surface is interactive, so the real cursor tracks the same cell as the on-screen block cursor and composition appears at the prompt. The behavior is gated to input mode, leaving non-interactive panes and scrolled-back history untouched.

As part of the same change, `PtyClient` now reaps its child process and joins its background reader thread when it is dropped, so ending or swapping an agent session no longer leaves behind zombie processes or detached reader threads.