### PR TITLE
Remove the Gemini CLI provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Principles that guide every decision in dux. If a change conflicts with a tenet,
 
 - **A provider is supported if and only if it supports PTY and oneshot mode.** PTY for interactive sessions; oneshot (headless: send a prompt, get one response) for automated tasks like commit message generation.
 - **Any CLI tool can be a provider.** Configure `command` in `config.toml` and dux spawns it. No adapters, no protocol layer. Adding a new provider is a config-only change, not a code change.
-- **Claude, Codex, OpenCode, and Gemini CLI are the defaults.**
+- **Claude, Codex, and OpenCode are the defaults.**
 - **No protocol layer.** No JSON-RPC, no custom message format, no adapter binaries. The CLI runs exactly as it would in a normal terminal.
 
 ### Git and Data Safety
@@ -60,7 +60,7 @@ The current app provides:
 - Commented user config in the platform-specific dux config directory (`~/.dux/` on macOS, `~/.config/dux/` on Linux)
 - Session persistence in `sessions.sqlite3` alongside the config
 - Logging in `dux.log` alongside the config
-- PTY-based agent startup: spawns CLI tools (`claude`, `codex`, `opencode`, `gemini`) directly in a pseudo-terminal
+- PTY-based agent startup: spawns CLI tools (`claude`, `codex`, `opencode`) directly in a pseudo-terminal
 
 ## Important Constraints
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Oh, and it's fast and consumes low resources: more RAM is left for Claude, Codex
 
 Most AI coding tools give you one agent in one directory. dux gives you **unlimited agents across unlimited worktrees**, all visible at once. Spawn five agents on five branches and let them work in parallel. Fork a session to try a different approach without losing the original. Open companion terminals next to your agents for builds, tests, or just poking around.
 
-Every agent runs through a PTY, the same pseudo-terminal your shell uses. That means the CLI tool (Claude, Codex, Gemini, OpenCode, or literally anything else) runs exactly like it would in your regular terminal. Your MCP servers, hooks, skills, slash commands, and permission dialogs all work. We don't mess with your setup.
+Every agent runs through a PTY, the same pseudo-terminal your shell uses. That means the CLI tool (Claude, Codex, OpenCode, or literally anything else) runs exactly like it would in your regular terminal. Your MCP servers, hooks, skills, slash commands, and permission dialogs all work. We don't mess with your setup.
 
 ## Install
 
@@ -86,7 +86,7 @@ Tab between panes. Resize them with keyboard or mouse. Collapse the sidebar or g
 
 ### Bring Any CLI
 
-Any terminal command can be a provider. The four defaults (Claude, Codex, Gemini, and OpenCode) are pre-configured, but adding your own is a config-only change:
+Any terminal command can be a provider. The built-in defaults include Claude, Codex, and OpenCode, but adding your own is a config-only change:
 
 ```toml
 [providers.my-agent]

--- a/npm/README.md
+++ b/npm/README.md
@@ -6,7 +6,7 @@ Your AI agents deserve a proper office. **dux** (pronounced "dooks") is a termin
 
 No protocol layers. No adapters. No JSON-RPC. Just real CLIs running in real terminals.
 
-dux is fast and keeps resource usage low, leaving more RAM for Claude, Codex, Gemini, OpenCode, or any other agent CLI you bring.
+dux is fast and keeps resource usage low, leaving more RAM for Claude, Codex, OpenCode, or any other agent CLI you bring.
 
 ## Why dux?
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -10513,8 +10513,8 @@ cyan = "#00ffff"
                 prompt.selected = prompt
                     .options
                     .iter()
-                    .position(|option| option.provider.as_str() == "gemini")
-                    .expect("gemini option");
+                    .position(|option| option.provider.as_str() == "opencode")
+                    .expect("opencode option");
             }
             other => panic!("expected change-agent-provider prompt, got {other:?}"),
         }
@@ -10525,15 +10525,95 @@ cyan = "#00ffff"
         // Exactly one session still exists; its provider was mutated in place.
         assert_eq!(app.sessions.len(), 1);
         assert_eq!(app.sessions[0].id, original_session_id);
-        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        assert_eq!(app.sessions[0].provider.as_str(), "opencode");
         assert_eq!(app.sessions[0].worktree_path, original_worktree);
         assert!(matches!(app.prompt, PromptState::None));
 
         let persisted = app.session_store.load_sessions().expect("load sessions");
         assert_eq!(persisted.len(), 1);
-        assert_eq!(persisted[0].provider.as_str(), "gemini");
+        assert_eq!(persisted[0].provider.as_str(), "opencode");
 
-        assert!(app.status.text().contains("will use gemini next launch"));
+        assert!(app.status.text().contains("will use opencode next launch"));
+    }
+
+    #[test]
+    fn dispatch_agent_launch_refuses_unconfigured_provider() {
+        let mut app = test_app(default_bindings());
+        // Pin the session to a provider that is not present in config — this is
+        // the state a worktree is in after Gemini was retired and its stock
+        // block pruned from config.
+        app.sessions[0].provider = ProviderKind::from_str("gemini");
+        assert!(
+            app.config.providers.get("gemini").is_none(),
+            "precondition: gemini must not be configured in the test app"
+        );
+        let session = app.sessions[0].clone();
+        let request = app.agent_launch_request(
+            session,
+            false,
+            AgentLaunchKind::Reconnect {
+                status_message: "ignored".to_string(),
+            },
+        );
+
+        let dispatched = app.dispatch_agent_launch(request);
+
+        assert!(!dispatched, "an unconfigured provider must not be launched");
+        assert!(
+            app.agent_launches_in_flight.is_empty(),
+            "a refused launch must not be marked in-flight"
+        );
+        assert_eq!(
+            app.status.tone(),
+            crate::statusline::StatusTone::Warning,
+            "a refused launch should warn, not silently swap or error"
+        );
+        let message = app.status.message().to_string();
+        assert!(
+            message.contains("gemini") && message.contains("config.toml"),
+            "warning must name the provider and point the user at config, got: {message}"
+        );
+    }
+
+    #[test]
+    fn restoring_gemini_in_config_makes_it_launchable_again() {
+        let mut app = test_app(default_bindings());
+        let gemini = ProviderKind::from_str("gemini");
+        assert!(
+            !app.provider_is_available(&gemini),
+            "gemini starts unconfigured after retirement"
+        );
+
+        // The user pastes a [gemini] block back into config.toml.
+        app.config.providers.commands.insert(
+            "gemini".to_string(),
+            crate::config::ProviderCommandConfig {
+                command: "gemini".to_string(),
+                ..Default::default()
+            },
+        );
+
+        assert!(
+            app.provider_is_available(&gemini),
+            "a restored [gemini] block makes the provider launchable again"
+        );
+
+        // It reappears in the change-provider picker, so the user can re-select it.
+        app.sessions[0].provider = ProviderKind::from_str("codex");
+        app.open_change_agent_provider_prompt()
+            .expect("open picker");
+        match &app.prompt {
+            PromptState::ChangeAgentProvider(prompt) => {
+                assert!(
+                    prompt
+                        .options
+                        .iter()
+                        .any(|option| option.provider.as_str() == "gemini"),
+                    "a restored gemini should appear in the provider picker"
+                );
+            }
+            other => panic!("expected picker, got {other:?}"),
+        }
     }
 
     #[test]
@@ -10569,8 +10649,8 @@ cyan = "#00ffff"
                 prompt.selected = prompt
                     .options
                     .iter()
-                    .position(|option| option.provider.as_str() == "gemini")
-                    .expect("gemini option");
+                    .position(|option| option.provider.as_str() == "opencode")
+                    .expect("opencode option");
             }
             other => panic!("expected change-agent-provider prompt, got {other:?}"),
         }
@@ -10580,9 +10660,9 @@ cyan = "#00ffff"
 
         // Provider is swapped now; the warning just tells the user the running
         // PTY hasn't caught up yet.
-        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        assert_eq!(app.sessions[0].provider.as_str(), "opencode");
         let persisted = app.session_store.load_sessions().expect("load sessions");
-        assert_eq!(persisted[0].provider.as_str(), "gemini");
+        assert_eq!(persisted[0].provider.as_str(), "opencode");
         assert!(
             app.providers.contains_key(&session_id),
             "the old PTY keeps running until the user exits it"
@@ -10594,7 +10674,7 @@ cyan = "#00ffff"
         );
         let message = app.status.message().to_string();
         assert!(
-            message.contains("still running") && message.contains("gemini"),
+            message.contains("still running") && message.contains("opencode"),
             "status should explain the agent still runs the old provider, got: {message}"
         );
         assert!(matches!(app.prompt, PromptState::None));
@@ -14145,16 +14225,16 @@ cyan = "#00ffff"
                 prompt.selected = prompt
                     .options
                     .iter()
-                    .position(|option| option.provider.as_str() == "gemini")
-                    .expect("gemini option");
+                    .position(|option| option.provider.as_str() == "opencode")
+                    .expect("opencode option");
             }
             other => panic!("expected picker, got {other:?}"),
         }
         app.apply_change_agent_provider().expect("apply swap");
 
-        // session.provider is now gemini, but the PTY is still running codex;
+        // session.provider is now opencode, but the PTY is still running codex;
         // running_provider_for should reflect that.
-        assert_eq!(app.sessions[0].provider.as_str(), "gemini");
+        assert_eq!(app.sessions[0].provider.as_str(), "opencode");
         assert_eq!(app.running_provider_for(&app.sessions[0]).as_str(), "codex");
 
         let backend = TestBackend::new(200, 30);
@@ -14174,22 +14254,22 @@ cyan = "#00ffff"
             "pane title should still say Codex (running) after the swap, got: {rendered}"
         );
         assert!(
-            !rendered.contains("Gemini agent"),
-            "pane title should NOT claim Gemini is running yet, got: {rendered}"
+            !rendered.contains("Opencode agent"),
+            "pane title should NOT claim Opencode is running yet, got: {rendered}"
         );
 
         // Sidebar entry should show the running → queued transition.
         assert!(
-            rendered.contains("(codex → gemini)"),
+            rendered.contains("(codex → opencode)"),
             "sidebar should show running provider → next provider, got: {rendered}"
         );
 
-        // Tearing down the PTY clears the pin — the next launch will be gemini.
+        // Tearing down the PTY clears the pin — the next launch will be opencode.
         app.providers.remove(&session_id);
         app.running_provider_pins.remove(&session_id);
         assert_eq!(
             app.running_provider_for(&app.sessions[0]).as_str(),
-            "gemini"
+            "opencode"
         );
 
         // After the PTY is gone, the sidebar collapses back to a single label.
@@ -14206,8 +14286,8 @@ cyan = "#00ffff"
             .map(|cell| cell.symbol())
             .collect();
         assert!(
-            rendered.contains("(gemini)"),
-            "sidebar should collapse to plain (gemini) after the PTY exits, got: {rendered}"
+            rendered.contains("(opencode)"),
+            "sidebar should collapse to plain (opencode) after the PTY exits, got: {rendered}"
         );
         assert!(
             !rendered.contains("→"),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -2068,7 +2068,7 @@ impl App {
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "Any CLI tool can be a provider: Claude, Codex, Gemini,",
+            "Any CLI tool can be a provider: Claude, Codex,",
             body_style,
         )));
         lines.push(Line::from(Span::styled(

--- a/src/app/sessions.rs
+++ b/src/app/sessions.rs
@@ -456,7 +456,39 @@ impl App {
         }
     }
 
+    /// Whether a worktree's provider can be launched. A provider must be present
+    /// in config to run; a worktree pinned to one that isn't configured (such as
+    /// the retired Gemini default after its stock block is pruned) is refused.
+    pub(crate) fn provider_is_available(&self, provider: &ProviderKind) -> bool {
+        self.config.providers.get(provider.as_str()).is_some()
+    }
+
+    /// Actionable warning shown when a worktree is pinned to a provider that
+    /// isn't configured. dux refuses to launch it and keeps running; the user
+    /// switches the provider or adds a `[providers.<name>]` block. Kept short
+    /// enough to read on one status line.
+    pub(crate) fn unavailable_provider_warning(
+        &self,
+        branch_name: &str,
+        provider: &ProviderKind,
+    ) -> String {
+        let change_key = self.bindings.label_for(Action::ChangeAgentProvider);
+        let name = provider.as_str();
+        format!(
+            "Agent \"{branch_name}\" uses provider \"{name}\", which isn't configured. \
+             Press {change_key} to switch providers, or add a [providers.{name}] block to config.toml."
+        )
+    }
+
     pub(crate) fn dispatch_agent_launch(&mut self, request: AgentLaunchRequest) -> bool {
+        if !self.provider_is_available(&request.session.provider) {
+            let warning = self.unavailable_provider_warning(
+                &request.session.branch_name,
+                &request.session.provider,
+            );
+            self.set_warning(warning);
+            return false;
+        }
         let session_id = request.session.id.clone();
         if !self.agent_launches_in_flight.insert(session_id.clone()) {
             self.set_info(format!(

--- a/src/app/workers.rs
+++ b/src/app/workers.rs
@@ -2375,6 +2375,30 @@ pub(crate) fn run_create_agent_job(
         updated_at: Utc::now(),
     };
     let provider_cfg = provider_config(&config, &session.provider);
+    // A provider must be configured to launch. A worktree pinned to one that
+    // isn't (e.g. a retired default like Gemini after its stock block is pruned)
+    // is refused rather than spawned as a bare command from PATH.
+    if config.providers.get(session.provider.as_str()).is_none() {
+        let name = session.provider.as_str();
+        let message = format!(
+            "Can't create agent \"{}\": provider \"{name}\" isn't configured. Add a \
+             [providers.{name}] block to config.toml, or change the project's provider.",
+            session.branch_name
+        );
+        logger::error(&format!(
+            "provider not configured for {}: {message}",
+            session.id
+        ));
+        if owns_worktree {
+            let _ = git::remove_worktree(
+                &repo_path,
+                Path::new(&session.worktree_path),
+                &session.branch_name,
+            );
+        }
+        let _ = worker_tx.send(WorkerEvent::CreateAgentFailed(message));
+        return;
+    }
     if let Err(hint) = check_provider_available(&provider_cfg) {
         logger::error(&format!("provider not found for {}: {hint}", session.id));
         if owns_worktree {
@@ -3095,6 +3119,87 @@ mod tests {
             _ => panic!("expected pre-create pull failure"),
         }
         assert!(worker_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn create_worker_refuses_provider_not_in_config() {
+        // A project pinned to a provider that isn't configured (the state a
+        // project is left in after a default like Gemini is retired and its
+        // stock block pruned). dux must refuse rather than spawn a bare command
+        // from PATH, and must point the user at config.
+        let repo = tempdir().expect("repo tempdir");
+        run_git(repo.path(), &["init", "-b", "main"]);
+        run_git(repo.path(), &["config", "user.email", "test@example.com"]);
+        run_git(repo.path(), &["config", "user.name", "Test"]);
+        std::fs::write(repo.path().join("README.md"), "hi").expect("seed file");
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-m", "init"]);
+
+        let work = tempdir().expect("work tempdir");
+        let paths = DuxPaths {
+            config_path: work.path().join("config.toml"),
+            sessions_db_path: work.path().join("sessions.sqlite3"),
+            worktrees_root: work.path().join("worktrees"),
+            lock_path: work.path().join("dux.lock"),
+            root: work.path().to_path_buf(),
+        };
+        std::fs::create_dir_all(&paths.worktrees_root).expect("worktrees root");
+
+        let project = Project {
+            id: "project-1".to_string(),
+            name: "demo".to_string(),
+            path: repo.path().to_string_lossy().to_string(),
+            explicit_default_provider: None,
+            default_provider: ProviderKind::from_str("no-such-provider"),
+            leading_branch: Some("main".to_string()),
+            auto_reopen_agents: None,
+            startup_command: None,
+            env: Default::default(),
+            current_branch: "main".to_string(),
+            branch_status: ProjectBranchStatus::Unknown,
+            path_missing: false,
+        };
+
+        let config = Config::default();
+        assert!(
+            config.providers.get("no-such-provider").is_none(),
+            "precondition: the pinned provider must be unconfigured"
+        );
+
+        let (worker_tx, worker_rx) = mpsc::channel();
+        run_create_agent_job(
+            CreateAgentRequest::NewProject {
+                project,
+                custom_name: Some("agent-branch".to_string()),
+                use_existing_branch: false,
+                pull_before_create: false,
+            },
+            paths,
+            config,
+            worker_tx,
+            (80, 24),
+        );
+
+        let mut failure = None;
+        loop {
+            match worker_rx.recv() {
+                Ok(WorkerEvent::CreateAgentFailed(message)) => {
+                    failure = Some(message);
+                    break;
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        let message = failure.expect("expected a create failure for the unconfigured provider");
+        assert!(
+            message.contains("no-such-provider"),
+            "failure should name the provider, got: {message}"
+        );
+        assert!(
+            message.contains("config.toml"),
+            "failure should point the user at config, got: {message}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,14 +160,14 @@ pub struct EditorConfig {
     pub default: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OneshotOutput {
     Stdout,
     Tempfile,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ProviderCommandConfig {
     pub command: String,
@@ -478,7 +478,9 @@ pub fn ensure_config(paths: &DuxPaths) -> Result<Config> {
     let mut doc: DocumentMut = raw
         .parse()
         .with_context(|| format!("failed to parse {}", paths.config_path.display()))?;
-    if apply_config_deprecations(&mut doc)? {
+    let deprecations_changed = apply_config_deprecations(&mut doc)?;
+    let retired_changed = prune_retired_providers(&mut doc);
+    if deprecations_changed || retired_changed {
         fs::write(&paths.config_path, doc.to_string())
             .with_context(|| format!("failed to write {}", paths.config_path.display()))?;
     }
@@ -587,6 +589,96 @@ fn migrate_prompt_for_name(
         table["enable_randomized_pet_name_by_default"] = toml_edit::value(!prompt_for_name);
     }
     Ok(())
+}
+
+/// Providers dux used to ship as defaults but has since retired. Each entry
+/// carries the exact stock config dux shipped, so an untouched block can be
+/// recognized and removed from existing configs while a user-customized block
+/// of the same name is preserved (config wins for explicit preferences).
+///
+/// A retired provider is no longer rendered into new configs and no longer
+/// added by [`ProvidersConfig::ensure_defaults`]. A worktree still pinned to it
+/// is refused at launch (see the provider availability guard) until the user
+/// restores a `[name]` block in config or switches the worktree's provider.
+fn retired_providers() -> [(&'static str, ProviderCommandConfig); 1] {
+    [("gemini", retired_stock_gemini())]
+}
+
+/// The exact `[gemini]` block dux shipped before Gemini was retired (Google
+/// deprecated the Gemini CLI in favor of Antigravity). Used to recognize an
+/// untouched stock block so it can be pruned from existing configs.
+fn retired_stock_gemini() -> ProviderCommandConfig {
+    ProviderCommandConfig {
+        command: "gemini".to_string(),
+        args: Vec::new(),
+        resume_args: Some(vec!["--resume".to_string()]),
+        resume_wait_timeout_ms: None,
+        oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
+        oneshot_output: OneshotOutput::Stdout,
+        install_hint: Some("brew install gemini-cli".to_string()),
+        forward_scroll: false,
+    }
+}
+
+/// Remove top-level provider tables for retired providers when they still match
+/// the stock block dux shipped. A customized block (or one a user adds back
+/// later) does not match and is left untouched. Returns whether the document
+/// changed.
+fn prune_retired_providers(doc: &mut DocumentMut) -> bool {
+    // Providers live under the `[providers.<name>]` table in config.toml.
+    let Some(providers) = doc.get_mut("providers").and_then(Item::as_table_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for (name, stock) in retired_providers() {
+        let matches = providers
+            .get(name)
+            .and_then(Item::as_table)
+            .is_some_and(|table| table_matches_provider_config(table, &stock));
+        if matches {
+            providers.remove(name);
+            changed = true;
+        }
+    }
+    changed
+}
+
+/// Parse a `[providers.<name>]` table (as it appears in config.toml) into a
+/// `ProviderCommandConfig`. Wrapping the table in a standalone document avoids
+/// any ambiguity about table headers when serializing it back to a string.
+fn provider_table_config(table: &Table) -> Option<ProviderCommandConfig> {
+    #[derive(serde::Deserialize)]
+    struct Wrapper {
+        provider: ProviderCommandConfig,
+    }
+    let mut doc = DocumentMut::new();
+    doc.insert("provider", Item::Table(table.clone()));
+    toml::from_str::<Wrapper>(&doc.to_string())
+        .ok()
+        .map(|wrapper| wrapper.provider)
+}
+
+/// The stock provider config dux shipped, normalized through the same
+/// render → parse round-trip a real config undergoes. This matters because the
+/// renderer writes optional fields explicitly (e.g. a `None`
+/// `resume_wait_timeout_ms` is written as `0`), so the on-disk block parses back
+/// with `Some(0)`. Round-tripping the stock the same way keeps the comparison
+/// honest instead of mismatching on representation.
+fn canonical_stock_config(stock: &ProviderCommandConfig) -> Option<ProviderCommandConfig> {
+    let mut rendered = String::new();
+    render_provider_config(&mut rendered, "probe", stock);
+    let doc: DocumentMut = rendered.parse().ok()?;
+    let table = doc.get("providers")?.get("probe")?.as_table()?;
+    provider_table_config(table)
+}
+
+/// Whether a config's provider table is the stock block dux shipped (so it can
+/// be retired), as opposed to one the user customized (which is preserved).
+fn table_matches_provider_config(table: &Table, stock: &ProviderCommandConfig) -> bool {
+    match (provider_table_config(table), canonical_stock_config(stock)) {
+        (Some(user), Some(canonical)) => user == canonical,
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1465,7 +1557,7 @@ fn default_terminal_args() -> Vec<String> {
     vec!["-l".to_string()]
 }
 
-fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 5] {
+fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 4] {
     [
         (
             "claude",
@@ -1511,19 +1603,6 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 5] {
             },
         ),
         (
-            "gemini",
-            ProviderCommandConfig {
-                command: "gemini".to_string(),
-                args: Vec::new(),
-                resume_args: Some(vec!["--resume".to_string()]),
-                resume_wait_timeout_ms: None,
-                oneshot_args: vec!["-p".to_string(), "{prompt}".to_string()],
-                oneshot_output: OneshotOutput::Stdout,
-                install_hint: Some("brew install gemini-cli".to_string()),
-                forward_scroll: false,
-            },
-        ),
-        (
             "opencode",
             ProviderCommandConfig {
                 command: "opencode".to_string(),
@@ -1543,8 +1622,8 @@ fn default_provider_commands() -> [(&'static str, ProviderCommandConfig); 5] {
                 args: Vec::new(),
                 // Copilot's --continue resumes the most recent session
                 // globally, not scoped to the current working directory.
-                // Unlike claude/codex/gemini/opencode, there is no flag
-                // to limit resume to the CWD, so we disable it.
+                // Unlike claude/codex/opencode, there is no flag to limit
+                // resume to the CWD, so we disable it.
                 resume_args: None,
                 resume_wait_timeout_ms: None,
                 oneshot_args: vec![
@@ -2371,6 +2450,94 @@ agent_scrollback_lines = 10000
     }
 
     #[test]
+    fn prune_retired_providers_removes_stock_gemini_block() {
+        // Render the stock gemini block with the real renderer (exactly how dux
+        // wrote it into existing configs), then confirm the migration prunes it.
+        let mut providers = ProvidersConfig::default();
+        providers
+            .commands
+            .insert("gemini".to_string(), retired_stock_gemini());
+        let mut rendered = String::new();
+        render_provider_configs(&mut rendered, &providers);
+        let mut doc: DocumentMut = rendered.parse().expect("parse rendered providers");
+        assert!(
+            doc["providers"].get("gemini").is_some(),
+            "precondition: the rendered config carries a gemini block"
+        );
+
+        let changed = prune_retired_providers(&mut doc);
+
+        assert!(changed, "stock gemini block should be pruned");
+        assert!(
+            doc["providers"].get("gemini").is_none(),
+            "stock gemini table should be removed from [providers]"
+        );
+        assert!(
+            doc["providers"].get("claude").is_some(),
+            "other provider tables must be left intact"
+        );
+    }
+
+    #[test]
+    fn prune_retired_providers_keeps_customized_gemini_block() {
+        // A user who points gemini at their own command keeps it (config wins).
+        let mut doc: DocumentMut = r#"
+[providers.gemini]
+command = "my-gemini-wrapper"
+oneshot_args = ["-p", "{prompt}"]
+oneshot_output = "stdout"
+"#
+        .parse()
+        .expect("parse doc");
+
+        let changed = prune_retired_providers(&mut doc);
+
+        assert!(!changed, "a customized gemini block must not be pruned");
+        assert!(
+            doc["providers"].get("gemini").is_some(),
+            "a customized gemini block must be preserved"
+        );
+    }
+
+    #[test]
+    fn ensure_config_prunes_stock_gemini_from_existing_config() {
+        use tempfile::tempdir;
+        let tmp = tempdir().expect("tempdir");
+        let paths = DuxPaths {
+            config_path: tmp.path().join("config.toml"),
+            sessions_db_path: tmp.path().join("sessions.sqlite3"),
+            worktrees_root: tmp.path().join("worktrees"),
+            lock_path: tmp.path().join("dux.lock"),
+            root: tmp.path().to_path_buf(),
+        };
+
+        // Seed an existing config that still ships the stock gemini provider,
+        // rendered exactly as dux would have written it.
+        let mut config = Config::default();
+        config
+            .providers
+            .commands
+            .insert("gemini".to_string(), retired_stock_gemini());
+        std::fs::write(&paths.config_path, render_config_default(&config)).expect("seed config");
+
+        let loaded = ensure_config(&paths).expect("load config");
+
+        assert!(
+            loaded.providers.get("gemini").is_none(),
+            "the loaded config must no longer expose the retired gemini provider"
+        );
+        assert!(
+            loaded.providers.get("claude").is_some(),
+            "surviving providers stay configured"
+        );
+        let on_disk = std::fs::read_to_string(&paths.config_path).expect("read config");
+        assert!(
+            !on_disk.contains("[providers.gemini]"),
+            "config.toml should be rewritten without the gemini block, got:\n{on_disk}"
+        );
+    }
+
+    #[test]
     fn config_deprecation_replace_migrates_prompt_for_name() {
         let mut doc: DocumentMut = r#"
 [defaults]
@@ -2869,14 +3036,12 @@ oneshot_output = "stdout"
     }
 
     #[test]
-    fn default_gemini_oneshot_uses_prompt_flag() {
+    fn default_provider_commands_excludes_retired_gemini() {
         let providers = default_provider_commands();
-        let gemini = providers.iter().find(|(n, _)| *n == "gemini").unwrap();
-        let cfg = &gemini.1;
-        assert_eq!(cfg.command, "gemini");
-        assert_eq!(cfg.oneshot_args, vec!["-p", "{prompt}"]);
-        assert!(matches!(cfg.oneshot_output, OneshotOutput::Stdout));
-        assert!(cfg.resume_args.is_some());
+        assert!(
+            providers.iter().all(|(name, _)| *name != "gemini"),
+            "gemini was retired and must not ship as a default provider"
+        );
     }
 
     #[test]
@@ -2895,7 +3060,7 @@ oneshot_output = "stdout"
     }
 
     #[test]
-    fn ensure_defaults_adds_opencode_and_gemini() {
+    fn ensure_defaults_adds_opencode_and_copilot_but_not_retired_gemini() {
         let mut providers = ProvidersConfig {
             commands: indexmap::IndexMap::from([(
                 "claude".to_string(),
@@ -2918,14 +3083,16 @@ oneshot_output = "stdout"
             providers.get("opencode").is_some(),
             "opencode should be added"
         );
-        assert!(providers.get("gemini").is_some(), "gemini should be added");
         assert!(providers.get("codex").is_some(), "codex should be added");
         assert!(
             providers.get("copilot").is_some(),
             "copilot should be added"
         );
+        assert!(
+            providers.get("gemini").is_none(),
+            "gemini was retired and must not be re-added by ensure_defaults"
+        );
         assert_eq!(providers.get("opencode").unwrap().command, "opencode");
-        assert_eq!(providers.get("gemini").unwrap().command, "gemini");
         assert_eq!(providers.get("copilot").unwrap().command, "copilot");
     }
 

--- a/website/docs/custom-agents.md
+++ b/website/docs/custom-agents.md
@@ -5,7 +5,7 @@ group: Guides
 order: 50
 ---
 
-A provider is the CLI behind an agent. Claude Code, Codex, OpenCode, and Gemini are
+A provider is the CLI behind an agent. Claude Code, Codex, and OpenCode are
 configured out of the box, but the whole point of dux's design is that **any CLI can
 be a provider.** Adding one is a config change, not a code change. There are no
 adapters and no protocol layer to implement. dux runs the command exactly as it

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -29,9 +29,15 @@ analytics, no JSON-RPC, no background uploads.
 
 ### Which AI tools can I use?
 
-Claude Code, Codex, OpenCode, and Gemini are wired in out of the box, and any
+Claude Code, Codex, and OpenCode are wired in out of the box, and any
 other CLI that supports an interactive session and a headless one-shot mode can
 be added. See [Custom CLI Agents](/docs/custom-agents).
+
+### Why was the Gemini provider removed?
+
+[Google deprecated the Gemini CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/),
+so dux no longer ships it as a built-in provider. If a worktree was still pinned
+to Gemini, dux won't launch it — switch it to a supported provider and relaunch.
 
 ### How do I add my own CLI as an agent?
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -6,7 +6,7 @@ order: 1
 ---
 
 `dux` is a terminal UI for running multiple AI coding agents in parallel, one git
-worktree each. It spawns the real CLI for each agent (Claude Code, Codex, Gemini,
+worktree each. It spawns the real CLI for each agent (Claude Code, Codex,
 OpenCode, or anything else you can run in a terminal) inside an embedded
 pseudo-terminal. No protocol layer, no adapters, no JSON-RPC. Just the tools you
 already use, side by side, each in its own branch.
@@ -20,7 +20,7 @@ dux has three nouns. Once they click, the whole app makes sense.
 - **Agents** are sessions running inside a project. Each agent gets its own git
   worktree on its own branch, so two agents working on the same repo never step on
   each other.
-- **Providers** are the CLIs that power agents. Claude, Codex, OpenCode, and Gemini
+- **Providers** are the CLIs that power agents. Claude, Codex, and OpenCode
   ship configured out of the box, and you can wire up any other command yourself.
 
 The flow is: add a project, spin up an agent, pick a provider. dux creates the

--- a/website/src/components/FeatureGrid.astro
+++ b/website/src/components/FeatureGrid.astro
@@ -26,7 +26,7 @@
         </div>
         <h3 class="heading text-base font-semibold text-[color:var(--color-text)]">Bring any CLI</h3>
         <p class="mt-1 text-sm text-[color:var(--color-muted)]">
-          Claude, Codex, Gemini, OpenCode ship as defaults. Anything else is a TOML block away. No adapters, no JSON-RPC, no protocol layer.
+          Claude, Codex, OpenCode ship as defaults. Anything else is a TOML block away. No adapters, no JSON-RPC, no protocol layer.
         </p>
       </article>
 

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -68,7 +68,7 @@ import Stats from "./Stats.astro";
         </div>
 
         <ul class="mt-8 grid grid-cols-2 gap-x-6 gap-y-2 text-xs text-[color:var(--color-dim)] sm:text-sm">
-          <li class="flex items-center gap-2"><span class="text-[color:var(--color-success)]">✓</span> Claude, Codex, Gemini, OpenCode</li>
+          <li class="flex items-center gap-2"><span class="text-[color:var(--color-success)]">✓</span> Claude, Codex, OpenCode</li>
           <li class="flex items-center gap-2"><span class="text-[color:var(--color-success)]">✓</span> Any CLI as a provider</li>
           <li class="flex items-center gap-2"><span class="text-[color:var(--color-success)]">✓</span> Git worktree per agent</li>
           <li class="flex items-center gap-2"><span class="text-[color:var(--color-success)]">✓</span> AI commit messages</li>

--- a/website/src/components/RealCLI.astro
+++ b/website/src/components/RealCLI.astro
@@ -29,7 +29,7 @@ const duck = [
           Real CLIs. Your setup. <span class="text-[color:var(--color-accent)]">No protocol tax.</span>
         </h2>
         <p class="mt-4 text-[color:var(--color-muted)] leading-relaxed">
-          dux spawns the <strong class="text-[color:var(--color-text)]">actual</strong> CLI (<span class="mono text-[color:var(--color-text)]">claude</span>, <span class="mono text-[color:var(--color-text)]">codex</span>, <span class="mono text-[color:var(--color-text)]">gemini</span>, <span class="mono text-[color:var(--color-text)]">opencode</span>) in a real pseudo-terminal, exactly as it would run in your shell. No ACP. No JSON-RPC. No adapter binary cosplaying as your agent.
+          dux spawns the <strong class="text-[color:var(--color-text)]">actual</strong> CLI (<span class="mono text-[color:var(--color-text)]">claude</span>, <span class="mono text-[color:var(--color-text)]">codex</span>, <span class="mono text-[color:var(--color-text)]">opencode</span>) in a real pseudo-terminal, exactly as it would run in your shell. No ACP. No JSON-RPC. No adapter binary cosplaying as your agent.
         </p>
 
         <div class="mt-6 space-y-4">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -12,8 +12,8 @@ interface Props {
 }
 
 const {
-  title = "dux: run multiple Claude Code, Codex & Gemini agents in parallel | getdux.app",
-  description = "dux is a fast terminal UI that runs multiple AI coding agents (Claude Code, Codex, Gemini, OpenCode, or any CLI) in parallel across git worktrees. Real CLIs, real PTYs, no protocol layers. Maximum throughput, minimum context switching.",
+  title = "dux: run multiple Claude Code, Codex & OpenCode agents in parallel | getdux.app",
+  description = "dux is a fast terminal UI that runs multiple AI coding agents (Claude Code, Codex, OpenCode, or any CLI) in parallel across git worktrees. Real CLIs, real PTYs, no protocol layers. Maximum throughput, minimum context switching.",
   ogImage = "/og.png",
   noIndex = false,
   emitStructuredData = true,
@@ -33,7 +33,6 @@ const keywords = [
   "AI coding agents",
   "Claude Code",
   "Codex CLI",
-  "Gemini CLI",
   "OpenCode",
   "parallel AI agents",
   "git worktrees",
@@ -74,7 +73,7 @@ const sd = {
     featureList: [
       "Run multiple AI coding agents in parallel",
       "One git worktree per agent",
-      "PTY-based, runs real CLIs (Claude, Codex, Gemini, OpenCode, any)",
+      "PTY-based, runs real CLIs (Claude, Codex, OpenCode, any)",
       "AI-generated Conventional Commit messages",
       "Macros for reusable prompts",
       "Fuzzy command palette",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -11,9 +11,9 @@ import InstallSection from "../components/InstallSection.astro";
 import Footer from "../components/Footer.astro";
 
 const title =
-  "dux: run multiple Claude Code, Codex & Gemini agents in parallel | getdux.app";
+  "dux: run multiple Claude Code, Codex & OpenCode agents in parallel | getdux.app";
 const description =
-  "dux is a fast terminal UI that runs multiple AI coding agents (Claude Code, Codex, Gemini, OpenCode, or any CLI) in parallel across git worktrees. Real CLIs, real PTYs, no protocol layers. Maximum throughput, minimum context switching.";
+  "dux is a fast terminal UI that runs multiple AI coding agents (Claude Code, Codex, OpenCode, or any CLI) in parallel across git worktrees. Real CLIs, real PTYs, no protocol layers. Maximum throughput, minimum context switching.";
 ---
 
 <Layout title={title} description={description}>


### PR DESCRIPTION
[Google deprecated the Gemini CLI](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/), so this drops it as a built-in provider. Gemini is gone from the shipped defaults, `ensure_defaults` no longer re-adds it, and new configs are written without a `[providers.gemini]` block.

Existing users are migrated on load: dux prunes the stock `[providers.gemini]` block from `config.toml`, but **only when it matches the block dux originally shipped** — a customized Gemini provider is left untouched, honoring explicit config preferences. The retirement goes through a small reusable mechanism, so future provider removals are a one-line addition rather than a special case.

Because nothing is silently swapped, a worktree still pinned to Gemini (or any provider missing from config) is **refused at launch** instead of spawning a stray command from `PATH`. dux stays open and posts a short status message telling you to switch the worktree's provider or add a `[providers.gemini]` block back, and a restored block just works again. The README, npm readme, in-app help, and the marketing site are updated to match, and the FAQ links Google's own deprecation notice.