### PR TITLE
Update vite to clear its security advisories and fix local dev images

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -6708,12 +6708,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/website/package.json
+++ b/website/package.json
@@ -4,9 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prep": "node scripts/copy-install.mjs && node scripts/fetch-contributors.mjs && node scripts/generate-webp.mjs",
+    "predev": "npm run prep",
     "dev": "astro dev",
+    "prestart": "npm run prep",
     "start": "astro dev",
-    "build": "node scripts/copy-install.mjs && node scripts/fetch-contributors.mjs && node scripts/generate-webp.mjs && astro build",
+    "build": "npm run prep && astro build",
     "preview": "astro preview",
     "astro": "astro",
     "contributors": "node scripts/fetch-contributors.mjs",


### PR DESCRIPTION
This updates the website's transitive `vite` dependency from `7.3.3` to `7.3.6`, which clears the two high severity advisories flagged against the repository (`GHSA-v6wh-96g9-6wx3` and `GHSA-fx2h-pf6j-xcff`). The bump only touches `website/package-lock.json` because `astro` already allows `vite ^7.3.2`, so no change to `package.json` was needed and `npm audit` now reports zero vulnerabilities. Both advisories are Windows only, but resolving them keeps the dependency tree clean for everyone.

It also fixes broken images when running the site locally with `npm run dev`. The canonical logo and screenshot live in the repository's top level `assets/` folder and are only copied into `website/public/` by a prebuild step that previously ran during `npm run build` alone, so `astro dev` served 404s for `/dux-logo.png` and `/dux-screenshot.svg`. The build steps are now factored into a shared `prep` script that `dev`, `start`, and `build` all reuse, so the local server and the production build always start from the same assets and can no longer drift.

An upgrade to Astro 7 was explored and intentionally left out. The `astro-pagefind` integration that powers the docs search has no Astro 7 compatible release yet, so staying on the current Astro 6 line keeps search working on a supported dependency until that changes.
