### PR TITLE
Add a Buttondown newsletter signup to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dux
 
-[![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/patrickdappollonio/dux/total)](https://github.com/patrickdappollonio/dux/releases/latest) [![NPM Downloads](https://img.shields.io/npm/dm/%40patrickdappollonio%2Fdux)](https://www.npmjs.com/package/@patrickdappollonio/dux) ![GitHub License](https://img.shields.io/github/license/patrickdappollonio/dux)
+[![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/patrickdappollonio/dux/total)](https://github.com/patrickdappollonio/dux/releases/latest) [![NPM Downloads](https://img.shields.io/npm/dm/%40patrickdappollonio%2Fdux)](https://www.npmjs.com/package/@patrickdappollonio/dux) ![GitHub License](https://img.shields.io/github/license/patrickdappollonio/dux) [![Newsletter](https://img.shields.io/badge/newsletter-subscribe-blue)](https://buttondown.com/getduxapp)
 
 <img src="assets/dux-logo.png" width="200" align="right" />
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -5395,7 +5395,7 @@ impl App {
                     ])
                 } else {
                     Line::from(vec![
-                        Span::raw(format!(" {}", &input.text)),
+                        Span::raw(format!(" {}", input.text)),
                         Span::styled(
                             " ",
                             Style::default()
@@ -5657,7 +5657,7 @@ impl App {
                     ])
                 } else {
                     Line::from(vec![
-                        Span::raw(format!(" {}", &input.text)),
+                        Span::raw(format!(" {}", input.text)),
                         Span::styled(
                             " ",
                             Style::default()
@@ -5771,7 +5771,7 @@ impl App {
                     ])
                 } else {
                     Line::from(vec![
-                        Span::raw(format!(" {}", &input.text)),
+                        Span::raw(format!(" {}", input.text)),
                         Span::styled(
                             " ",
                             Style::default()
@@ -6120,7 +6120,7 @@ impl App {
     /// Render a single-line TextInput with cursor in a bordered box.
     /// Uses the terminal's hardware cursor for a blinking caret.
     fn render_single_line_input(&self, input: &TextInput, area: Rect, frame: &mut Frame) {
-        let display = Line::from(Span::raw(format!(" {}", &input.text)));
+        let display = Line::from(Span::raw(format!(" {}", input.text)));
         let block = Block::default()
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -26,7 +26,12 @@ export default defineConfig({
   integrations: [
     mdx(),
     pagefind(),
-    sitemap({ filter: (page) => !page.endsWith("/rss.xml") }),
+    // Newsletter status pages are post-subscribe/post-confirm landing pages
+    // (noindex), so they stay out of the sitemap too.
+    sitemap({
+      filter: (page) =>
+        !page.endsWith("/rss.xml") && !page.includes("/newsletter/"),
+    }),
   ],
   build: {
     inlineStylesheets: "auto",

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -19,6 +19,7 @@ const year = new Date().getFullYear();
       <nav class="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs">
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/docs">Docs</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/blog">Blog</a>
+        <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/#newsletter">Newsletter</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="/rss.xml">RSS</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="https://github.com/patrickdappollonio/dux">GitHub</a>
         <a class="text-[color:var(--color-muted)] hover:text-[color:var(--color-accent)]" href="https://github.com/patrickdappollonio/dux/releases">Releases</a>

--- a/website/src/components/Newsletter.astro
+++ b/website/src/components/Newsletter.astro
@@ -1,0 +1,38 @@
+---
+// Buttondown newsletter signup for the homepage. Posts directly to the
+// Buttondown embed endpoint, no client-side JS required.
+---
+
+<section class="anchor-offset py-16 sm:py-24" id="newsletter">
+  <div class="container-app">
+    <div class="card p-8 sm:p-12">
+      <div class="mx-auto max-w-2xl text-center">
+        <span class="pill">▸ the newsletter</span>
+        <h2 class="heading mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
+          Get dux news in your <span class="text-[color:var(--color-accent)]">inbox</span>
+        </h2>
+        <p class="mt-4 leading-relaxed text-[color:var(--color-muted)]">
+          New releases, new tricks, and the occasional behind-the-scenes.
+          No spam, no daily drip. Unsubscribe whenever.
+        </p>
+        <form
+          action="https://buttondown.com/api/emails/embed-subscribe/getduxapp"
+          method="post"
+          class="embeddable-buttondown-form mx-auto mt-8 flex w-full max-w-md flex-col gap-3 sm:flex-row"
+        >
+          <label for="bd-email" class="sr-only">Enter your email</label>
+          <input
+            type="email"
+            name="email"
+            id="bd-email"
+            required
+            placeholder="you@example.com"
+            autocomplete="email"
+            class="w-full flex-1 rounded-md border border-[color:var(--color-border)] bg-[color:var(--color-panel-2)] px-4 py-2.5 text-sm text-[color:var(--color-text)] placeholder:text-[color:var(--color-dim)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-ink)]"
+          />
+          <button type="submit" class="btn-primary shrink-0">Subscribe</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>

--- a/website/src/components/NewsletterStatus.astro
+++ b/website/src/components/NewsletterStatus.astro
@@ -1,0 +1,39 @@
+---
+// Shared shell for the newsletter status pages (post-subscribe and
+// post-confirm). Keeps both pages visually identical: hero-style grid
+// background, centered card, pill + heading + copy + actions via slots.
+interface Props {
+  pill: string;
+}
+
+const { pill } = Astro.props;
+---
+
+<section class="relative overflow-hidden py-20 sm:py-32">
+  <div class="absolute inset-0 grid-bg pointer-events-none opacity-60"></div>
+
+  <div class="container-app relative">
+    <div class="card mx-auto max-w-2xl p-8 text-center sm:p-12">
+      <img
+        src="/dux-logo.png"
+        alt="dux: a duck conductor with a baton"
+        width="72"
+        height="72"
+        class="mx-auto h-18 w-18 object-contain drop-shadow-[0_0_24px_rgba(0,212,255,0.25)]"
+      />
+      <span class="pill mt-6">{pill}</span>
+      <h1 class="heading mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+        <slot name="title" />
+      </h1>
+      <div class="mt-4 leading-relaxed text-[color:var(--color-muted)]">
+        <slot name="body" />
+      </div>
+      <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <slot name="actions" />
+      </div>
+      <p class="mt-6 text-xs text-[color:var(--color-dim)]">
+        <slot name="footnote" />
+      </p>
+    </div>
+  </div>
+</section>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -10,6 +10,7 @@ import ConfigPeek from "../components/ConfigPeek.astro";
 import InstallSection from "../components/InstallSection.astro";
 import LatestPosts from "../components/LatestPosts.astro";
 import Contributors from "../components/Contributors.astro";
+import Newsletter from "../components/Newsletter.astro";
 import Footer from "../components/Footer.astro";
 
 const title =
@@ -22,6 +23,7 @@ const description =
   <Header />
   <main>
     <Hero />
+    <Newsletter />
     <Asciinema />
     <Manifesto />
     <RealCLI />

--- a/website/src/pages/newsletter/confirmed.astro
+++ b/website/src/pages/newsletter/confirmed.astro
@@ -1,0 +1,40 @@
+---
+// Landing page after someone confirms their newsletter subscription.
+// Buttondown's "redirect after confirming" setting should point here.
+// Utility page: kept out of search engines and the sitemap.
+import Layout from "../../layouts/Layout.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import NewsletterStatus from "../../components/NewsletterStatus.astro";
+
+const title = "You're in the flock | getdux.app";
+const description = "Subscription confirmed. Welcome to the dux newsletter.";
+---
+
+<Layout title={title} description={description} noIndex emitStructuredData={false}>
+  <Header />
+  <main>
+    <NewsletterStatus pill="▸ subscription confirmed">
+      <Fragment slot="title">
+        You're <span class="text-[color:var(--color-accent)]">in</span>. Welcome
+        to the flock.
+      </Fragment>
+      <Fragment slot="body">
+        <p>
+          That's it: no more clicking, no forms, no hoops. Release notes, new
+          tricks, and the occasional behind-the-scenes will now land in your
+          inbox. No spam, no daily drip, and every email carries an
+          unsubscribe link we'll pretend you'll never need.
+        </p>
+      </Fragment>
+      <Fragment slot="actions">
+        <a href="/#install" class="btn-primary">Install dux</a>
+        <a href="/blog" class="btn-ghost">Read the blog</a>
+      </Fragment>
+      <Fragment slot="footnote">
+        In the meantime: dux is pronounced "dooks". Now you know more than most.
+      </Fragment>
+    </NewsletterStatus>
+  </main>
+  <Footer />
+</Layout>

--- a/website/src/pages/newsletter/thanks.astro
+++ b/website/src/pages/newsletter/thanks.astro
@@ -1,0 +1,40 @@
+---
+// Landing page after someone submits the newsletter form. Buttondown's
+// "redirect after subscribing" setting should point here. Utility page:
+// kept out of search engines and the sitemap.
+import Layout from "../../layouts/Layout.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import NewsletterStatus from "../../components/NewsletterStatus.astro";
+
+const title = "Almost in the flock | getdux.app";
+const description =
+  "One confirmation click stands between you and the dux newsletter.";
+---
+
+<Layout title={title} description={description} noIndex emitStructuredData={false}>
+  <Header />
+  <main>
+    <NewsletterStatus pill="▸ one more thing">
+      <Fragment slot="title">
+        Go check your <span class="text-[color:var(--color-accent)]">inbox</span>
+      </Fragment>
+      <Fragment slot="body">
+        <p>
+          A confirmation email is waddling your way right now. Click the link
+          inside it and you're officially in. Skip that click and, well,
+          nothing happens. Ever. Double opt-in isn't bureaucracy, it's how we
+          keep the bots out of the flock.
+        </p>
+      </Fragment>
+      <Fragment slot="actions">
+        <a href="/" class="btn-ghost">Back to the homepage</a>
+      </Fragment>
+      <Fragment slot="footnote">
+        Nothing showing up? Give it a minute, then go rescue it from spam.
+        Email providers love flagging the good stuff.
+      </Fragment>
+    </NewsletterStatus>
+  </main>
+  <Footer />
+</Layout>


### PR DESCRIPTION
This adds a newsletter signup section to the getdux.app homepage, placed right after the hero. The form posts directly to Buttondown's embed-subscribe endpoint for the `getduxapp` newsletter, needs no client-side JavaScript, and is styled entirely with the site's existing theme tokens (`card`, `pill`, `btn-primary`, and the shared focus-ring treatment). A **Newsletter** link was also added to the footer navigation, and the README gains a small shields.io badge pointing to the Buttondown subscribe page.

It also adds two internal landing pages that match the rest of the site's look and tone: `/newsletter/thanks`, shown after someone subscribes and reminding them to click the confirmation email before anything arrives, and `/newsletter/confirmed`, shown once the subscription is confirmed. Both are built on a small shared `NewsletterStatus` component so they cannot drift apart visually, are marked `noindex`, and are excluded from the sitemap since they only make sense as redirect targets.

For the pages to be used, Buttondown's dashboard needs its *redirect after subscribing* and *redirect after confirmation* settings pointed at `https://getdux.app/newsletter/thanks` and `https://getdux.app/newsletter/confirmed` respectively. Until then, subscribers land on Buttondown's hosted pages and everything still works.